### PR TITLE
Add tag filter to Tasks page

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -29,7 +29,7 @@ class TaskController extends Controller
     public function index(Request $request): Response
     {
 
-        $filters = $request->only(['search', 'status', 'priority', 'category_id', 'due_date_filter']);
+        $filters = $request->only(['search', 'status', 'priority', 'category_id', 'tag_id', 'due_date_filter']);
 
         $baseQuery = Task::with(['category', 'subtasks', 'tags'])
             ->where('status', '!=', 'completed')
@@ -102,7 +102,7 @@ class TaskController extends Controller
             'categorizedTasks' => $categorizedTasks,
             'categories' => $categories,
             'tags' => $tags,
-            'filters' => $request->only(['search', 'status', 'priority', 'category_id', 'due_date_filter']),
+            'filters' => $request->only(['search', 'status', 'priority', 'category_id', 'tag_id', 'due_date_filter']),
         ]);
     }
 

--- a/app/Repositories/Eloquent/TaskRepository.php
+++ b/app/Repositories/Eloquent/TaskRepository.php
@@ -265,6 +265,13 @@ class TaskRepository implements TaskRepositoryInterface
             $query->where('category_id', $filters['category_id']);
         }
 
+        // Filter by tag
+        if (!empty($filters['tag_id'])) {
+            $query->whereHas('tags', function ($q) use ($filters) {
+                $q->where('tags.id', $filters['tag_id']);
+            });
+        }
+
         // Filter by overdue tasks
         if (!empty($filters['overdue'])) {
             $query->overdue();

--- a/resources/js/Pages/Tasks/Index.jsx
+++ b/resources/js/Pages/Tasks/Index.jsx
@@ -342,7 +342,7 @@ function SortableTask({
     );
 }
 
-export default function Index({ categorizedTasks, categories, filters }) {
+export default function Index({ categorizedTasks, categories, tags = [], filters }) {
     const [allTasks, setAllTasks] = useState([]);
     const [search, setSearch] = useState(filters.search || "");
     const [statusFilter, setStatusFilter] = useState(filters.status || "");
@@ -352,6 +352,7 @@ export default function Index({ categorizedTasks, categories, filters }) {
     const [categoryFilter, setCategoryFilter] = useState(
         filters.category_id || ""
     );
+    const [tagFilter, setTagFilter] = useState(filters.tag_id || "");
     const [dueDateFilter, setDueDateFilter] = useState(
         filters.due_date_filter || ""
     );
@@ -554,6 +555,7 @@ export default function Index({ categorizedTasks, categories, filters }) {
                 status: statusFilter,
                 priority: priorityFilter,
                 category_id: categoryFilter,
+                tag_id: tagFilter,
                 due_date_filter: dueDateFilter,
             },
             {
@@ -567,6 +569,7 @@ export default function Index({ categorizedTasks, categories, filters }) {
         let newStatusFilter = statusFilter;
         let newPriorityFilter = priorityFilter;
         let newCategoryFilter = categoryFilter;
+        let newTagFilter = tagFilter;
         let newDueDateFilter = dueDateFilter;
 
         switch (type) {
@@ -579,6 +582,9 @@ export default function Index({ categorizedTasks, categories, filters }) {
             case "category":
                 newCategoryFilter = value;
                 break;
+            case "tag":
+                newTagFilter = value;
+                break;
             case "due_date":
                 newDueDateFilter = value;
                 break;
@@ -587,6 +593,7 @@ export default function Index({ categorizedTasks, categories, filters }) {
         setStatusFilter(newStatusFilter);
         setPriorityFilter(newPriorityFilter);
         setCategoryFilter(newCategoryFilter);
+        setTagFilter(newTagFilter);
         setDueDateFilter(newDueDateFilter);
 
         router.get(
@@ -596,6 +603,7 @@ export default function Index({ categorizedTasks, categories, filters }) {
                 status: newStatusFilter,
                 priority: newPriorityFilter,
                 category_id: newCategoryFilter,
+                tag_id: newTagFilter,
                 due_date_filter: newDueDateFilter,
             },
             {
@@ -769,16 +777,16 @@ export default function Index({ categorizedTasks, categories, filters }) {
                             <button
                                 onClick={() => setShowFilters(!showFilters)}
                                 className={`inline-flex items-center justify-center px-4 py-2.5 border rounded-xl text-sm font-medium transition-colors ${
-                                    showFilters || statusFilter || priorityFilter || categoryFilter || dueDateFilter
+                                    showFilters || statusFilter || priorityFilter || categoryFilter || tagFilter || dueDateFilter
                                         ? "bg-wevie-teal/10 border-wevie-teal/30 text-wevie-text-primary dark:bg-wevie-teal/10 dark:border-wevie-teal/30 dark:text-wevie-dark-text-primary"
                                         : "bg-white dark:bg-dark-card border-light-border/70 dark:border-dark-border/70 text-light-secondary dark:text-dark-secondary hover:bg-light-hover dark:hover:bg-dark-hover"
                                 }`}
                             >
                                 <Filter className="mr-2 h-4 w-4" />
                                 Filters
-                                {(statusFilter || priorityFilter || categoryFilter || dueDateFilter) && (
+                                {(statusFilter || priorityFilter || categoryFilter || tagFilter || dueDateFilter) && (
                                     <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-wevie-teal/20 text-wevie-text-primary dark:bg-wevie-teal/20 dark:text-wevie-dark-text-primary">
-                                        {[statusFilter, priorityFilter, categoryFilter, dueDateFilter].filter(Boolean).length}
+                                        {[statusFilter, priorityFilter, categoryFilter, tagFilter, dueDateFilter].filter(Boolean).length}
                                     </span>
                                 )}
                             </button>
@@ -851,6 +859,27 @@ export default function Index({ categorizedTasks, categories, filters }) {
                                     </select>
                                 </div>
 
+                                {/* Tag Filter */}
+                                <div>
+                                    <label className="block text-sm font-medium text-light-secondary dark:text-dark-secondary mb-2">
+                                        Tag
+                                    </label>
+                                    <select
+                                        value={tagFilter}
+                                        onChange={(e) =>
+                                            handleFilter("tag", e.target.value)
+                                        }
+                                        className="block w-full border border-light-border/70 dark:border-dark-border/70 rounded-xl px-3 py-2 text-sm focus:ring-2 focus:ring-wevie-teal/40 focus:border-wevie-teal dark:bg-dark-card dark:text-dark-primary"
+                                    >
+                                        <option value="">All tags</option>
+                                        {tags.map((tag) => (
+                                            <option key={tag.id} value={tag.id}>
+                                                {tag.name}
+                                            </option>
+                                        ))}
+                                    </select>
+                                </div>
+
                                 {/* Due Date Filter */}
                                 <div>
                                     <label className="block text-sm font-medium text-light-secondary dark:text-dark-secondary mb-2">
@@ -907,6 +936,7 @@ export default function Index({ categorizedTasks, categories, filters }) {
                                 statusFilter ||
                                 priorityFilter ||
                                 categoryFilter ||
+                                tagFilter ||
                                 dueDateFilter
                                     ? "Try a softer filter or a shorter search."
                                     : "Start with one small task when you’re ready."}
@@ -915,6 +945,7 @@ export default function Index({ categorizedTasks, categories, filters }) {
                                 !statusFilter &&
                                 !priorityFilter &&
                                 !categoryFilter &&
+                                !tagFilter &&
                                 !dueDateFilter && (
                                     <button
                                         onClick={() => setShowTaskModal(true)}


### PR DESCRIPTION
## What
Adds a **filter by tag** to the Tasks page, wired end-to-end alongside the existing status, priority, category, and due-date filters.

## Changes
**Backend**
- `TaskRepository::applyFilters()` — filters tasks by `tag_id` via `whereHas('tags', …)` (correct for the many-to-many task↔tags relation).
- `TaskController::index()` — accepts `tag_id` in the working filters and echoes it back in the `filters` prop so the selection survives reloads. The `tags` list was already passed to the page.

**Frontend** (`resources/js/Pages/Tasks/Index.jsx`)
- New **Tag** dropdown in the filters panel ("All tags" + each active tag), styled to match the existing selects.
- `tagFilter` state seeded from `filters.tag_id`; `handleSearch`/`handleFilter` now send `tag_id`, so tag combines with search and other filters.
- Filters button highlight, active-filter count badge, and empty-state messaging all account for the tag filter.

## Notes
- Reuses existing data flow and design tokens — no new dependencies or endpoints.
- PHP syntax checks pass (`php -l`). The frontend build wasn't run — this workspace's `node_modules` is missing `vite`/`vite-plugin-pwa`; the JSX mirrors the existing filter patterns exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)