### PR TITLE
Fix subtask delete failing for freshly-added subtasks

### DIFF
--- a/app/Http/Controllers/SubtaskController.php
+++ b/app/Http/Controllers/SubtaskController.php
@@ -23,7 +23,18 @@ class SubtaskController extends Controller
 
             $subtask = $this->subtaskService->createSubtask($validated, Auth::id());
 
-            return back()->with('message', 'Subtask created successfully');
+            // Flash the created subtask so the client can reconcile its
+            // temporary (client-generated) id with the real database id.
+            return back()
+                ->with('message', 'Subtask created successfully')
+                ->with('subtask', $subtask->only([
+                    'id',
+                    'title',
+                    'is_completed',
+                    'completed_at',
+                    'position',
+                    'task_id',
+                ]));
         } catch (\Exception $e) {
             return back()->withErrors(['error' => 'Failed to create subtask: ' . $e->getMessage()]);
         }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -34,6 +34,9 @@ class HandleInertiaRequests extends Middleware
             'auth' => [
                 'user' => $request->user(),
             ],
+            'flash' => [
+                'subtask' => fn () => $request->session()->get('subtask'),
+            ],
         ];
     }
 }

--- a/resources/js/Components/SubtaskManager.jsx
+++ b/resources/js/Components/SubtaskManager.jsx
@@ -221,13 +221,29 @@ export default function SubtaskManager({
             {
                 preserveScroll: true,
                 preserveState: true,
-                only: [], // Don't reload any data
-                onSuccess: () => {
+                only: ["flash"], // Only pull back the flashed subtask
+                onSuccess: (page) => {
+                    // Reconcile the temporary client id with the real
+                    // database id returned from the server, otherwise later
+                    // edit/toggle/delete requests would target a non-existent
+                    // subtask.
+                    const created = page?.props?.flash?.subtask;
+                    const reconcile = (list) =>
+                        created?.id
+                            ? list.map((s) =>
+                                  s.id === tempSubtask.id
+                                      ? { ...s, ...created }
+                                      : s
+                              )
+                            : list;
+
+                    setSubtasks((prev) => reconcile(prev));
+
                     // Update parent component's task data if callback provided
                     if (onTaskUpdate) {
                         onTaskUpdate({
                             ...task,
-                            subtasks: subtasks,
+                            subtasks: reconcile(subtasks),
                         });
                     }
                     toast.success("Subtask saved.");


### PR DESCRIPTION
## The bug

When a subtask is added, `SubtaskManager.jsx` inserts it into local state with a **temporary client-generated ID** (`id: Date.now()`), and because the create request used `only: []`, the real database ID was never reconciled back into the list.

As a result, deleting (or editing/toggling) a **just-added** subtask before any page reload sent the fake ID to `subtasks/{temp-id}` → Laravel route-model binding found no matching row → **404** → the delete failed with *"We couldn't remove that just now"* and the subtask stayed on screen.

## The fix (root cause)

- **`SubtaskController@store`** — flashes the created subtask (`id`, `title`, `is_completed`, `completed_at`, `position`, `task_id`) so the client receives the real ID.
- **`HandleInertiaRequests`** — shares it as a lazy `flash.subtask` prop.
- **`SubtaskManager.jsx`** — `handleAddSubtask` now requests `only: ["flash"]` and, in `onSuccess(page)`, reconciles the temp ID with `page.props.flash.subtask.id` in both local state and the `onTaskUpdate` callback (same reconcile helper on both paths so the parent's propagated copy can't clobber the swap back to the temp ID).

A freshly-added subtask now immediately carries its real ID, so subsequent delete/edit/toggle requests hit the correct row.

## Testing

- `php -l` passes on changed PHP files.
- No existing subtask tests to update.
- Could not run the full Pest suite / Vite build in this workspace (no `vendor/` or `node_modules/`; project runs via Docker). Suggested manual check: add a subtask, then delete it without reloading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)