### PR TITLE
Add "Recently Accomplished" section to Calendar sidebar

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -97,6 +97,28 @@ class CalendarController extends Controller
         }
         $upcomingTasks = $upcomingTaskOccurrences->where('status', 'pending');
 
+        // Get recently accomplished tasks (completed in the last 24 hours),
+        // ordered by most recently completed.
+        $recentlyAccomplishedTasks = $user->tasks()
+            ->with('category')
+            ->where('status', 'completed')
+            ->whereNotNull('completed_at')
+            ->where('completed_at', '>=', now()->subDay())
+            ->orderByDesc('completed_at')
+            ->get();
+
+        // Ensure a minimum of 5 are shown by backfilling with the most recent
+        // completions when the last 24 hours contain fewer than 5.
+        if ($recentlyAccomplishedTasks->count() < 5) {
+            $recentlyAccomplishedTasks = $user->tasks()
+                ->with('category')
+                ->where('status', 'completed')
+                ->whereNotNull('completed_at')
+                ->orderByDesc('completed_at')
+                ->limit(5)
+                ->get();
+        }
+
         // Get overdue tasks (only regular tasks can be overdue)
         $overdueTasks = Task::with(['category', 'subtasks', 'tags'])
             ->withCount([
@@ -130,6 +152,7 @@ class CalendarController extends Controller
             'tasks' => $tasks,
             'transactions' => $transactionsByDate,
             'upcomingTasks' => $upcomingTasks,
+            'recentlyAccomplishedTasks' => $recentlyAccomplishedTasks,
             'overdueTasks' => $overdueTasks,
             'currentDate' => $date->format('Y-m-d'),
             'monthName' => $date->format('F Y'),

--- a/resources/js/Pages/Calendar/Index.jsx
+++ b/resources/js/Pages/Calendar/Index.jsx
@@ -36,6 +36,7 @@ export default function Index({
     tasks,
     transactions,
     upcomingTasks,
+    recentlyAccomplishedTasks = [],
     overdueTasks,
     currentDate,
     monthName,
@@ -252,6 +253,15 @@ export default function Index({
             day: "numeric",
         });
     };
+
+    const formatCompletedAt = (dateString) =>
+        new Date(dateString).toLocaleString("en-US", {
+            weekday: "short",
+            month: "short",
+            day: "numeric",
+            hour: "numeric",
+            minute: "2-digit",
+        });
 
     const handleDayClick = (day) => {
         setSelectedDate(day.dateStr);
@@ -1337,6 +1347,57 @@ export default function Index({
                             ) : (
                                 <p className="text-gray-500 dark:text-gray-400 text-sm">
                                     No upcoming tasks in the next 7 days.
+                                </p>
+                            )}
+                        </div>
+                    </div>
+
+                    {/* Recently Accomplished Tasks */}
+                    <div className="card p-4 sm:p-6">
+                        <div className="flex items-center mb-4">
+                            <CheckCircle className="w-4 sm:w-5 h-4 sm:h-5 text-primary mr-2" />
+                            <h3 className="text-base sm:text-lg font-semibold text-gray-900 dark:text-gray-100">
+                                Recently Accomplished (
+                                {recentlyAccomplishedTasks.length})
+                            </h3>
+                        </div>
+                        <div className="space-y-3 max-h-64 overflow-y-auto">
+                            {recentlyAccomplishedTasks.length > 0 ? (
+                                recentlyAccomplishedTasks.map((task) => (
+                                    <div
+                                        key={task.id}
+                                        className="p-3 bg-green-50 dark:bg-green-900/20 rounded-lg border border-green-200 dark:border-green-800"
+                                    >
+                                        <div className="flex items-center space-x-2 mb-1">
+                                            <h4 className="font-medium text-gray-900 dark:text-gray-100 text-sm line-through decoration-green-500/60">
+                                                {task.title}
+                                            </h4>
+                                            {task.is_recurring && (
+                                                <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900/20 dark:text-purple-400">
+                                                    Recurring
+                                                </span>
+                                            )}
+                                        </div>
+                                        <p className="text-xs text-green-700 dark:text-green-400 mt-1">
+                                            Completed:{" "}
+                                            {formatCompletedAt(task.completed_at)}
+                                        </p>
+                                        {task.category && (
+                                            <span
+                                                className="inline-block text-xs px-2 py-1 rounded-full text-white mt-2"
+                                                style={{
+                                                    backgroundColor:
+                                                        task.category.color,
+                                                }}
+                                            >
+                                                {task.category.name}
+                                            </span>
+                                        )}
+                                    </div>
+                                ))
+                            ) : (
+                                <p className="text-gray-500 dark:text-gray-400 text-sm">
+                                    No tasks accomplished recently.
                                 </p>
                             )}
                         </div>


### PR DESCRIPTION
## What

Adds a new **"Recently Accomplished"** card to the Calendar page's right sidebar, directly beneath **Upcoming Tasks**. It surfaces tasks the user has completed in the **last 24 hours**, ordered by most recently completed.

To keep the card from feeling empty for active users, it shows a **minimum of 5** items: if fewer than 5 tasks were completed in the last 24 hours, it backfills with the most recent completions regardless of window.

## Changes

**Backend — `app/Http/Controllers/CalendarController.php`**
- New `recentlyAccomplishedTasks` query: `status = completed`, `completed_at >= now()->subDay()`, ordered by `completed_at` desc, eager-loading `category`.
- Minimum-of-5 backfill when the 24h window has fewer than 5.
- Passed as a new Inertia prop.

**Frontend — `resources/js/Pages/Calendar/Index.jsx`**
- Destructured the new prop (defaulted to `[]`).
- Added a `formatCompletedAt` helper (date + time).
- New green/`CheckCircle` "success" card mirroring the Upcoming Tasks structure — strikethrough titles, completed timestamp, recurring badge, category chip, and paired `dark:` variants.

## Notes
- This workspace has no `vendor/` or `node_modules/` installed (Docker-based local dev), so `pint` and a Vite build could not be run here. Edits follow the file's existing 4-space style and reuse the already-imported `CheckCircle` icon. Please run `composer test` / `npm run build` in a full environment before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)