### PR TITLE
Add optional custom title per month on Calendar

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -2,14 +2,17 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Task;
+use App\Http\Requests\UpdateMonthTitleRequest;
+use App\Models\CalendarMonthTitle;
 use App\Models\Category;
+use App\Models\Task;
 use App\Modules\Finance\Models\FinanceTransaction;
+use Carbon\Carbon;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 use Inertia\Response;
-use Carbon\Carbon;
 
 class CalendarController extends Controller
 {
@@ -52,7 +55,7 @@ class CalendarController extends Controller
                 'subtasks',
                 'subtasks as completed_subtasks_count' => function ($query) {
                     $query->where('is_completed', true);
-                }
+                },
             ])
             ->get();
 
@@ -68,6 +71,7 @@ class CalendarController extends Controller
             // Convert the task's due_date to user timezone for grouping
             $taskDueDate = $task->due_date; // This is already a Carbon instance from the cast
             $userDate = $user->toUserTimezone($taskDueDate);
+
             return $userDate->format('Y-m-d');
         });
 
@@ -85,6 +89,7 @@ class CalendarController extends Controller
         $transactionsByDate = $transactionOccurrences->groupBy(function ($transaction) use ($user) {
             $transactionDate = $transaction->occurred_at;
             $userDate = $user->toUserTimezone($transactionDate);
+
             return $userDate->format('Y-m-d');
         });
 
@@ -103,7 +108,7 @@ class CalendarController extends Controller
                 'subtasks',
                 'subtasks as completed_subtasks_count' => function ($query) {
                     $query->where('is_completed', true);
-                }
+                },
             ])
             ->overdueForUser($user)
             ->where('is_recurring', false)
@@ -115,6 +120,13 @@ class CalendarController extends Controller
             ->where('user_id', Auth::id())
             ->orderBy('name')
             ->get();
+
+        // Optional user-authored title/theme for the month the current date
+        // falls in (e.g. "Sprint 4" or "Wedding season"). Null when unset.
+        $monthTitle = CalendarMonthTitle::where('user_id', $user->id)
+            ->where('year', (int) $date->format('Y'))
+            ->where('month', (int) $date->format('n'))
+            ->value('title');
 
         // Human-readable label for the active range (in the user's timezone).
         $rangeLabel = match ($range) {
@@ -133,10 +145,35 @@ class CalendarController extends Controller
             'overdueTasks' => $overdueTasks,
             'currentDate' => $date->format('Y-m-d'),
             'monthName' => $date->format('F Y'),
+            'monthTitle' => $monthTitle,
             'range' => $range,
             'rangeLabel' => $rangeLabel,
             'categories' => $categories,
         ]);
+    }
+
+    /**
+     * Create, update, or clear the current user's custom title for a month.
+     * An empty title removes the record so the month falls back to no title.
+     */
+    public function updateMonthTitle(UpdateMonthTitleRequest $request): RedirectResponse
+    {
+        $data = $request->validated();
+        $title = trim($data['title'] ?? '');
+
+        $attributes = [
+            'user_id' => Auth::id(),
+            'year' => $data['year'],
+            'month' => $data['month'],
+        ];
+
+        if ($title === '') {
+            CalendarMonthTitle::where($attributes)->delete();
+        } else {
+            CalendarMonthTitle::updateOrCreate($attributes, ['title' => $title]);
+        }
+
+        return back();
     }
 
     /**
@@ -146,13 +183,13 @@ class CalendarController extends Controller
     private function weekRangeLabel(Carbon $start, Carbon $end): string
     {
         if ($start->year !== $end->year) {
-            return $start->format('M j, Y') . ' – ' . $end->format('M j, Y');
+            return $start->format('M j, Y').' – '.$end->format('M j, Y');
         }
 
         if ($start->month !== $end->month) {
-            return $start->format('M j') . ' – ' . $end->format('M j, Y');
+            return $start->format('M j').' – '.$end->format('M j, Y');
         }
 
-        return $start->format('M j') . ' – ' . $end->format('j, Y');
+        return $start->format('M j').' – '.$end->format('j, Y');
     }
 }

--- a/app/Http/Requests/UpdateMonthTitleRequest.php
+++ b/app/Http/Requests/UpdateMonthTitleRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateMonthTitleRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        return [
+            'year' => ['required', 'integer', 'min:1970', 'max:2100'],
+            'month' => ['required', 'integer', 'min:1', 'max:12'],
+            'title' => ['nullable', 'string', 'max:60'],
+        ];
+    }
+}

--- a/app/Models/CalendarMonthTitle.php
+++ b/app/Models/CalendarMonthTitle.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CalendarMonthTitle extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'year',
+        'month',
+        'title',
+    ];
+
+    protected $casts = [
+        'year' => 'integer',
+        'month' => 'integer',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2026_07_21_000001_create_calendar_month_titles_table.php
+++ b/database/migrations/2026_07_21_000001_create_calendar_month_titles_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('calendar_month_titles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->unsignedSmallInteger('year');
+            $table->unsignedTinyInteger('month');
+            $table->string('title', 60);
+            $table->timestamps();
+
+            $table->unique(['user_id', 'year', 'month']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('calendar_month_titles');
+    }
+};

--- a/resources/js/Pages/Calendar/Index.jsx
+++ b/resources/js/Pages/Calendar/Index.jsx
@@ -15,6 +15,7 @@ import {
     Grid3X3,
     ChevronDown,
     ChevronUp,
+    Pencil,
 } from "lucide-react";
 import { useState, useEffect } from "react";
 import DayTasksModal from "@/Components/DayTasksModal";
@@ -32,6 +33,101 @@ const readStoredPreference = (key, allowed, fallback) => {
     return allowed.includes(stored) ? stored : fallback;
 };
 
+// Subtle, optional per-month title/theme shown beneath the calendar heading.
+// When empty it renders a quiet "Add a title" affordance so it stays out of the
+// way for people who don't use it; click to edit inline, clear to remove.
+function MonthTitle({ currentDate, monthTitle }) {
+    const [isEditing, setIsEditing] = useState(false);
+    const [value, setValue] = useState(monthTitle ?? "");
+    const [saving, setSaving] = useState(false);
+
+    // Keep the local draft in sync when navigating between months.
+    useEffect(() => {
+        if (!isEditing) setValue(monthTitle ?? "");
+    }, [monthTitle, isEditing]);
+
+    const save = () => {
+        const trimmed = value.trim();
+        // Nothing changed — just leave edit mode without a round-trip.
+        if (trimmed === (monthTitle ?? "")) {
+            setIsEditing(false);
+            setValue(monthTitle ?? "");
+            return;
+        }
+
+        const [year, month] = currentDate.split("-").map(Number);
+        setSaving(true);
+        router.post(
+            route("calendar.month-title.update"),
+            { year, month, title: trimmed },
+            {
+                preserveScroll: true,
+                preserveState: true,
+                onFinish: () => {
+                    setSaving(false);
+                    setIsEditing(false);
+                },
+            }
+        );
+    };
+
+    const cancel = () => {
+        setValue(monthTitle ?? "");
+        setIsEditing(false);
+    };
+
+    if (isEditing) {
+        return (
+            <input
+                type="text"
+                autoFocus
+                value={value}
+                maxLength={60}
+                disabled={saving}
+                onChange={(e) => setValue(e.target.value)}
+                onBlur={save}
+                onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                        e.preventDefault();
+                        save();
+                    } else if (e.key === "Escape") {
+                        e.preventDefault();
+                        cancel();
+                    }
+                }}
+                placeholder="Name this month…"
+                aria-label="Month title"
+                className="mt-0.5 w-full max-w-xs bg-transparent border-b border-gray-300 dark:border-gray-600 px-0 py-0.5 text-sm text-gray-700 dark:text-gray-200 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-wevie-teal"
+            />
+        );
+    }
+
+    if (monthTitle) {
+        return (
+            <button
+                type="button"
+                onClick={() => setIsEditing(true)}
+                title="Edit month title"
+                className="group mt-0.5 flex items-center gap-1.5 text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+            >
+                <span>{monthTitle}</span>
+                <Pencil className="w-3 h-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+            </button>
+        );
+    }
+
+    return (
+        <button
+            type="button"
+            onClick={() => setIsEditing(true)}
+            className="mt-0.5 inline-flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+        >
+            <Pencil className="w-3 h-3" />
+            <span>Add a title</span>
+        </button>
+    );
+}
+
 export default function Index({
     tasks,
     transactions,
@@ -39,6 +135,7 @@ export default function Index({
     overdueTasks,
     currentDate,
     monthName,
+    monthTitle,
     range,
     rangeLabel,
     categories,
@@ -807,9 +904,15 @@ export default function Index({
                             className="flex flex-col sm:flex-row sm:items-center justify-between p-4 sm:p-6 border-b border-gray-200 dark:border-gray-700 gap-4"
                             data-tour="calendar-header"
                         >
-                            <h2 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-gray-100">
-                                {rangeLabel ?? monthName}
-                            </h2>
+                            <div className="min-w-0">
+                                <h2 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-gray-100">
+                                    {rangeLabel ?? monthName}
+                                </h2>
+                                <MonthTitle
+                                    currentDate={currentDate}
+                                    monthTitle={monthTitle}
+                                />
+                            </div>
                             <div className="flex flex-wrap items-center gap-2 sm:justify-end">
                                 {/* View + range controls (wrap together on mobile) */}
                                 <div className="flex flex-wrap items-center gap-2">

--- a/routes/web.php
+++ b/routes/web.php
@@ -76,6 +76,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     // Calendar
     Route::get('calendar', [CalendarController::class, 'index'])->name('calendar.index');
+    Route::post('calendar/month-title', [CalendarController::class, 'updateMonthTitle'])
+        ->name('calendar.month-title.update');
 
     // Analytics
     Route::get('analytics', [AnalyticsController::class, 'index'])->name('analytics.index');

--- a/tests/Feature/CalendarMonthTitleTest.php
+++ b/tests/Feature/CalendarMonthTitleTest.php
@@ -1,0 +1,122 @@
+<?php
+
+use App\Models\CalendarMonthTitle;
+use App\Models\User;
+
+test('calendar page exposes the custom title for the current month', function () {
+    $user = User::factory()->create();
+
+    CalendarMonthTitle::create([
+        'user_id' => $user->id,
+        'year' => 2026,
+        'month' => 7,
+        'title' => 'Sprint season',
+    ]);
+
+    $this->actingAs($user)
+        ->get('/calendar?date=2026-07-15')
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('Calendar/Index')
+            ->where('monthTitle', 'Sprint season'));
+});
+
+test('month title is null when none is set', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get('/calendar?date=2026-07-15')
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page->where('monthTitle', null));
+});
+
+test('a user can set a title for a month', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->post(route('calendar.month-title.update'), [
+            'year' => 2026,
+            'month' => 7,
+            'title' => '  Focus month  ',
+        ])
+        ->assertRedirect();
+
+    $this->assertDatabaseHas('calendar_month_titles', [
+        'user_id' => $user->id,
+        'year' => 2026,
+        'month' => 7,
+        'title' => 'Focus month',
+    ]);
+});
+
+test('setting a title again updates the existing record', function () {
+    $user = User::factory()->create();
+
+    CalendarMonthTitle::create([
+        'user_id' => $user->id,
+        'year' => 2026,
+        'month' => 7,
+        'title' => 'Old title',
+    ]);
+
+    $this->actingAs($user)
+        ->post(route('calendar.month-title.update'), [
+            'year' => 2026,
+            'month' => 7,
+            'title' => 'New title',
+        ])
+        ->assertRedirect();
+
+    expect(CalendarMonthTitle::where('user_id', $user->id)->count())->toBe(1);
+    $this->assertDatabaseHas('calendar_month_titles', [
+        'user_id' => $user->id,
+        'year' => 2026,
+        'month' => 7,
+        'title' => 'New title',
+    ]);
+});
+
+test('an empty title clears the month title', function () {
+    $user = User::factory()->create();
+
+    CalendarMonthTitle::create([
+        'user_id' => $user->id,
+        'year' => 2026,
+        'month' => 7,
+        'title' => 'Remove me',
+    ]);
+
+    $this->actingAs($user)
+        ->post(route('calendar.month-title.update'), [
+            'year' => 2026,
+            'month' => 7,
+            'title' => '   ',
+        ])
+        ->assertRedirect();
+
+    $this->assertDatabaseMissing('calendar_month_titles', [
+        'user_id' => $user->id,
+        'year' => 2026,
+        'month' => 7,
+    ]);
+});
+
+test('month title update validates the month range', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->post(route('calendar.month-title.update'), [
+            'year' => 2026,
+            'month' => 13,
+            'title' => 'Nope',
+        ])
+        ->assertSessionHasErrors('month');
+});
+
+test('guests cannot update a month title', function () {
+    $this->post(route('calendar.month-title.update'), [
+        'year' => 2026,
+        'month' => 7,
+        'title' => 'Nope',
+    ])->assertRedirect('/login');
+});


### PR DESCRIPTION
## What & why

Lets users give any month a personal title/theme on the Calendar page — e.g. label July as "Sprint season" or "Wedding season". Optional and per-user.

The UI is deliberately subtle so it's discoverable for people who want it without bothering those who don't:

- **No title set:** a small, low-contrast `✎ Add a title` link beneath the month heading.
- **Title set:** shows as a muted subtitle under the heading, with a pencil icon that appears on hover.
- **Editing is inline:** click to edit, **Enter**/blur saves, **Escape** cancels, clearing it removes the title. No modal.

## How it works

- **Frontend** (`Pages/Calendar/Index.jsx`): a self-contained `MonthTitle` component posts to the new route with `preserveScroll`/`preserveState` so saving doesn't jump the page; stays in sync when navigating between months. Title is keyed to the month of the currently-viewed date.
- **Backend:** new `calendar_month_titles` table (unique per `user_id` + `year` + `month`), `CalendarMonthTitle` model, `UpdateMonthTitleRequest` (validates year/month, 60-char title cap), `POST /calendar/month-title` → `CalendarController@updateMonthTitle` (upserts, or deletes when the title is blank). The `index()` action exposes a `monthTitle` prop.

## Testing

- 7 new Pest tests (`tests/Feature/CalendarMonthTitleTest.php`) covering read/create/update/clear/validation/guest-auth — all pass.
- `npm run build` succeeds, Pint clean, ESLint clean (0 errors).
- Requires `php artisan migrate` to run the new migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)