### PR TITLE
Add profile data exports: WevieWallet to Excel, journals to Word

### DIFF
--- a/app/Modules/Finance/Controllers/FinanceExportController.php
+++ b/app/Modules/Finance/Controllers/FinanceExportController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Modules\Finance\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Modules\Finance\Services\FinanceExportService;
+use App\Modules\Finance\Services\FinanceWalletService;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class FinanceExportController extends Controller
+{
+    public function __construct(
+        private FinanceExportService $exportService,
+        private FinanceWalletService $walletService,
+    ) {}
+
+    public function exportExcel(Request $request): StreamedResponse
+    {
+        $validated = $request->validate([
+            'start_date' => ['nullable', 'date'],
+            'end_date' => ['nullable', 'date', 'after_or_equal:start_date'],
+            'wallet_user_id' => ['nullable', 'integer'],
+        ]);
+
+        $user = $request->user();
+        $walletUserId = $this->walletService->resolveWalletUserId(
+            $user,
+            $request->integer('wallet_user_id') ?: null
+        );
+        $this->walletService->ensureCanAccessWallet($user->id, $walletUserId);
+
+        $startDate = ! empty($validated['start_date']) ? Carbon::parse($validated['start_date']) : null;
+        $endDate = ! empty($validated['end_date']) ? Carbon::parse($validated['end_date']) : null;
+
+        $spreadsheet = $this->exportService->build(
+            $walletUserId,
+            $startDate,
+            $endDate,
+            maskAccountNumbers: $walletUserId !== $user->id,
+        );
+
+        $filename = 'weviewallet-'.now()->format('Y-m-d').'.xlsx';
+
+        return response()->streamDownload(function () use ($spreadsheet) {
+            (new Xlsx($spreadsheet))->save('php://output');
+        }, $filename, [
+            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        ]);
+    }
+}

--- a/app/Modules/Finance/Repositories/FinanceTransactionRepository.php
+++ b/app/Modules/Finance/Repositories/FinanceTransactionRepository.php
@@ -26,6 +26,30 @@ class FinanceTransactionRepository
             ->get();
     }
 
+    /**
+     * Every transaction for a user, optionally bounded by an occurred_at range.
+     * Unlike getForUser() this is not limit-capped — it is intended for exports
+     * that must return the complete history.
+     */
+    public function getForUserInRange(int $userId, ?Carbon $startDate, ?Carbon $endDate): Collection
+    {
+        return FinanceTransaction::with([
+            'category',
+            'account',
+            'transferAccount',
+            'creditCardAccount',
+            'loan',
+            'savingsGoal',
+            'tags',
+        ])
+            ->where('user_id', $userId)
+            ->when($startDate, fn ($query) => $query->where('occurred_at', '>=', $startDate->copy()->startOfDay()))
+            ->when($endDate, fn ($query) => $query->where('occurred_at', '<=', $endDate->copy()->endOfDay()))
+            ->orderBy('occurred_at', 'desc')
+            ->orderBy('id', 'desc')
+            ->get();
+    }
+
     public function create(array $data): FinanceTransaction
     {
         return FinanceTransaction::create($data);
@@ -94,7 +118,7 @@ class FinanceTransactionRepository
             ->groupBy('period')
             ->orderBy('period')
             ->get()
-            ->map(fn($row) => (object) [
+            ->map(fn ($row) => (object) [
                 'period' => $row->period,
                 'type' => 'expense',
                 'total' => $row->total,
@@ -129,7 +153,7 @@ class FinanceTransactionRepository
             ->groupBy('period')
             ->orderBy('period')
             ->get()
-            ->map(fn($row) => (object) [
+            ->map(fn ($row) => (object) [
                 'period' => $row->period,
                 'type' => 'expense',
                 'total' => $row->total,

--- a/app/Modules/Finance/Services/FinanceExportService.php
+++ b/app/Modules/Finance/Services/FinanceExportService.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace App\Modules\Finance\Services;
+
+use App\Modules\Finance\Repositories\FinanceAccountRepository;
+use App\Modules\Finance\Repositories\FinanceBudgetRepository;
+use App\Modules\Finance\Repositories\FinanceLoanRepository;
+use App\Modules\Finance\Repositories\FinanceSavingsGoalRepository;
+use App\Modules\Finance\Repositories\FinanceTransactionRepository;
+use Carbon\Carbon;
+use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+class FinanceExportService
+{
+    public function __construct(
+        private FinanceAccountRepository $accountRepository,
+        private FinanceTransactionRepository $transactionRepository,
+        private FinanceBudgetRepository $budgetRepository,
+        private FinanceSavingsGoalRepository $savingsGoalRepository,
+        private FinanceLoanRepository $loanRepository,
+    ) {}
+
+    /**
+     * Build a multi-tab workbook for a wallet. The date range only bounds the
+     * Transactions sheet (by occurred_at); the other sheets are current-state
+     * snapshots. Account numbers are masked unless the requester owns the wallet.
+     */
+    public function build(int $walletUserId, ?Carbon $startDate, ?Carbon $endDate, bool $maskAccountNumbers): Spreadsheet
+    {
+        $spreadsheet = new Spreadsheet;
+        $spreadsheet->removeSheetByIndex(0);
+
+        $this->buildAccountsSheet($spreadsheet, $walletUserId, $maskAccountNumbers);
+        $this->buildTransactionsSheet($spreadsheet, $walletUserId, $startDate, $endDate);
+        $this->buildBudgetsSheet($spreadsheet, $walletUserId);
+        $this->buildSavingsGoalsSheet($spreadsheet, $walletUserId);
+        $this->buildLoansSheet($spreadsheet, $walletUserId);
+
+        $spreadsheet->setActiveSheetIndex(0);
+
+        return $spreadsheet;
+    }
+
+    private function buildAccountsSheet(Spreadsheet $spreadsheet, int $walletUserId, bool $maskAccountNumbers): void
+    {
+        $sheet = $this->addSheet($spreadsheet, 'Accounts');
+        $headers = [
+            'Name', 'Label', 'Type', 'Currency', 'Account Number', 'Starting Balance',
+            'Current Balance', 'Credit Limit', 'Available Credit', 'Used Credit',
+            'Active', 'Default', 'Notes',
+        ];
+        $this->writeHeader($sheet, $headers);
+
+        $row = 2;
+        foreach ($this->accountRepository->getForUser($walletUserId) as $account) {
+            $sheet->fromArray([
+                $account->name,
+                $account->label,
+                $account->type,
+                $account->currency,
+                $this->formatAccountNumber($account->account_number, $maskAccountNumbers),
+                $this->number($account->starting_balance),
+                $this->number($account->current_balance),
+                $this->number($account->credit_limit),
+                $this->number($account->available_credit),
+                $this->number($account->used_credit),
+                $this->bool($account->is_active),
+                $this->bool($account->is_default),
+                $account->notes,
+            ], null, "A{$row}");
+            $row++;
+        }
+
+        $this->autoSize($sheet, $headers);
+    }
+
+    private function buildTransactionsSheet(Spreadsheet $spreadsheet, int $walletUserId, ?Carbon $startDate, ?Carbon $endDate): void
+    {
+        $sheet = $this->addSheet($spreadsheet, 'Transactions');
+        $headers = [
+            'Date', 'Type', 'Amount', 'Currency', 'Category', 'Account', 'Transfer Account',
+            'Description', 'Notes', 'Payment Method', 'Recurring', 'Frequency', 'Tags',
+        ];
+        $this->writeHeader($sheet, $headers);
+
+        $row = 2;
+        foreach ($this->transactionRepository->getForUserInRange($walletUserId, $startDate, $endDate) as $transaction) {
+            $sheet->fromArray([
+                $transaction->occurred_at?->format('Y-m-d H:i'),
+                $transaction->type,
+                $this->number($transaction->amount),
+                $transaction->currency,
+                $transaction->category?->name,
+                $transaction->account?->name,
+                $transaction->transferAccount?->name,
+                $transaction->description,
+                $transaction->notes,
+                $transaction->payment_method,
+                $this->bool($transaction->is_recurring),
+                $transaction->recurring_frequency,
+                $transaction->tags->pluck('name')->implode(', '),
+            ], null, "A{$row}");
+            $row++;
+        }
+
+        $this->autoSize($sheet, $headers);
+    }
+
+    private function buildBudgetsSheet(Spreadsheet $spreadsheet, int $walletUserId): void
+    {
+        $sheet = $this->addSheet($spreadsheet, 'Budgets');
+        $headers = [
+            'Name', 'Budget Type', 'Category', 'Account', 'Amount', 'Current Spent',
+            'Currency', 'Period', 'Recurring', 'Starts On', 'Ends On', 'Active',
+        ];
+        $this->writeHeader($sheet, $headers);
+
+        $row = 2;
+        foreach ($this->budgetRepository->getForUser($walletUserId) as $budget) {
+            $sheet->fromArray([
+                $budget->name,
+                $budget->budget_type,
+                $budget->category?->name,
+                $budget->account?->name,
+                $this->number($budget->amount),
+                $this->number($budget->current_spent),
+                $budget->currency,
+                $budget->period,
+                $this->bool($budget->is_recurring),
+                $budget->starts_on?->format('Y-m-d'),
+                $budget->ends_on?->format('Y-m-d'),
+                $this->bool($budget->is_active),
+            ], null, "A{$row}");
+            $row++;
+        }
+
+        $this->autoSize($sheet, $headers);
+    }
+
+    private function buildSavingsGoalsSheet(Spreadsheet $spreadsheet, int $walletUserId): void
+    {
+        $sheet = $this->addSheet($spreadsheet, 'Savings Goals');
+        $headers = [
+            'Name', 'Account', 'Target Amount', 'Current Amount', 'Currency',
+            'Target Date', 'Active', 'Notes',
+        ];
+        $this->writeHeader($sheet, $headers);
+
+        $row = 2;
+        foreach ($this->savingsGoalRepository->getForUser($walletUserId) as $goal) {
+            $sheet->fromArray([
+                $goal->name,
+                $goal->account?->name,
+                $this->number($goal->target_amount),
+                $this->number($goal->current_amount),
+                $goal->currency,
+                $goal->target_date?->format('Y-m-d'),
+                $this->bool($goal->is_active),
+                $goal->notes,
+            ], null, "A{$row}");
+            $row++;
+        }
+
+        $this->autoSize($sheet, $headers);
+    }
+
+    private function buildLoansSheet(Spreadsheet $spreadsheet, int $walletUserId): void
+    {
+        $sheet = $this->addSheet($spreadsheet, 'Loans');
+        $headers = [
+            'Name', 'Total Amount', 'Remaining Amount', 'Currency', 'Target Date', 'Active', 'Notes',
+        ];
+        $this->writeHeader($sheet, $headers);
+
+        $row = 2;
+        foreach ($this->loanRepository->getForUser($walletUserId) as $loan) {
+            $sheet->fromArray([
+                $loan->name,
+                $this->number($loan->total_amount),
+                $this->number($loan->remaining_amount),
+                $loan->currency,
+                $loan->target_date?->format('Y-m-d'),
+                $this->bool($loan->is_active),
+                $loan->notes,
+            ], null, "A{$row}");
+            $row++;
+        }
+
+        $this->autoSize($sheet, $headers);
+    }
+
+    private function addSheet(Spreadsheet $spreadsheet, string $title): Worksheet
+    {
+        $sheet = $spreadsheet->createSheet();
+        $sheet->setTitle($title);
+
+        return $sheet;
+    }
+
+    /**
+     * @param  array<int, string>  $headers
+     */
+    private function writeHeader(Worksheet $sheet, array $headers): void
+    {
+        $sheet->fromArray($headers, null, 'A1');
+        $lastColumn = Coordinate::stringFromColumnIndex(count($headers));
+        $sheet->getStyle("A1:{$lastColumn}1")->getFont()->setBold(true);
+        $sheet->getStyle("A1:{$lastColumn}1")->getAlignment()->setVertical(Alignment::VERTICAL_CENTER);
+        $sheet->freezePane('A2');
+    }
+
+    /**
+     * @param  array<int, string>  $headers
+     */
+    private function autoSize(Worksheet $sheet, array $headers): void
+    {
+        $lastColumn = Coordinate::stringFromColumnIndex(count($headers));
+        foreach (range('A', $lastColumn) as $column) {
+            $sheet->getColumnDimension($column)->setAutoSize(true);
+        }
+    }
+
+    private function formatAccountNumber(?string $accountNumber, bool $mask): ?string
+    {
+        if ($accountNumber === null || $accountNumber === '') {
+            return null;
+        }
+
+        if (! $mask) {
+            return $accountNumber;
+        }
+
+        $last4 = substr($accountNumber, -4);
+
+        return '•••• '.$last4;
+    }
+
+    private function number(mixed $value): ?float
+    {
+        return $value === null ? null : (float) $value;
+    }
+
+    private function bool(?bool $value): string
+    {
+        return $value ? 'Yes' : 'No';
+    }
+}

--- a/app/Modules/Journal/Controllers/JournalEntryController.php
+++ b/app/Modules/Journal/Controllers/JournalEntryController.php
@@ -9,17 +9,22 @@ use App\Modules\Journal\Repositories\Contracts\JournalEntryRepositoryInterface;
 use App\Modules\Journal\Repositories\Contracts\JournalTagRepositoryInterface;
 use App\Modules\Journal\Requests\StoreJournalEntryRequest;
 use App\Modules\Journal\Requests\UpdateJournalEntryRequest;
+use App\Modules\Journal\Services\JournalExportService;
 use App\Modules\Journal\Services\JournalService;
+use Carbon\Carbon;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 use Inertia\Response;
+use PhpOffice\PhpWord\Writer\Word2007;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class JournalEntryController extends Controller
 {
     public function __construct(
         private JournalService $journalService,
+        private JournalExportService $exportService,
         private JournalEntryRepositoryInterface $entryRepository,
         private JournalTagRepositoryInterface $tagRepository,
     ) {}
@@ -38,6 +43,28 @@ class JournalEntryController extends Controller
             'tags' => $this->serializeTags($userId),
             'moods' => JournalMood::options(),
             'filters' => $filters,
+        ]);
+    }
+
+    public function export(Request $request): StreamedResponse
+    {
+        $validated = $request->validate([
+            'start_date' => ['nullable', 'date'],
+            'end_date' => ['nullable', 'date', 'after_or_equal:start_date'],
+        ]);
+
+        $startDate = ! empty($validated['start_date']) ? Carbon::parse($validated['start_date']) : null;
+        $endDate = ! empty($validated['end_date']) ? Carbon::parse($validated['end_date']) : null;
+
+        $entries = $this->entryRepository->getForUserInRange(Auth::id(), $startDate, $endDate);
+
+        $phpWord = $this->exportService->buildDocx($entries);
+        $filename = 'journals-'.now()->format('Y-m-d').'.docx';
+
+        return response()->streamDownload(function () use ($phpWord) {
+            (new Word2007($phpWord))->save('php://output');
+        }, $filename, [
+            'Content-Type' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
         ]);
     }
 

--- a/app/Modules/Journal/Repositories/Contracts/JournalEntryRepositoryInterface.php
+++ b/app/Modules/Journal/Repositories/Contracts/JournalEntryRepositoryInterface.php
@@ -3,7 +3,9 @@
 namespace App\Modules\Journal\Repositories\Contracts;
 
 use App\Modules\Journal\Models\JournalEntry;
+use Carbon\Carbon;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Collection;
 
 interface JournalEntryRepositoryInterface
 {
@@ -13,6 +15,14 @@ interface JournalEntryRepositoryInterface
     public function paginateForUser(int $userId, array $filters, int $perPage = 15): LengthAwarePaginator;
 
     public function findForUser(int $id, int $userId): ?JournalEntry;
+
+    /**
+     * Every entry for a user in chronological order, optionally bounded by an
+     * entry_date range. Intended for exports (not limit-capped or paginated).
+     *
+     * @return Collection<int, JournalEntry>
+     */
+    public function getForUserInRange(int $userId, ?Carbon $startDate, ?Carbon $endDate): Collection;
 
     /**
      * @param  array<string, mixed>  $data

--- a/app/Modules/Journal/Repositories/Eloquent/JournalEntryRepository.php
+++ b/app/Modules/Journal/Repositories/Eloquent/JournalEntryRepository.php
@@ -4,7 +4,9 @@ namespace App\Modules\Journal\Repositories\Eloquent;
 
 use App\Modules\Journal\Models\JournalEntry;
 use App\Modules\Journal\Repositories\Contracts\JournalEntryRepositoryInterface;
+use Carbon\Carbon;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Collection;
 
 class JournalEntryRepository implements JournalEntryRepositoryInterface
 {
@@ -45,6 +47,18 @@ class JournalEntryRepository implements JournalEntryRepositoryInterface
             ->where('user_id', $userId)
             ->with('tags')
             ->find($id);
+    }
+
+    public function getForUserInRange(int $userId, ?Carbon $startDate, ?Carbon $endDate): Collection
+    {
+        return JournalEntry::query()
+            ->where('user_id', $userId)
+            ->with('tags')
+            ->when($startDate, fn ($query) => $query->whereDate('entry_date', '>=', $startDate->toDateString()))
+            ->when($endDate, fn ($query) => $query->whereDate('entry_date', '<=', $endDate->toDateString()))
+            ->orderBy('entry_date')
+            ->orderBy('id')
+            ->get();
     }
 
     public function create(array $data): JournalEntry

--- a/app/Modules/Journal/Services/JournalExportService.php
+++ b/app/Modules/Journal/Services/JournalExportService.php
@@ -1,0 +1,460 @@
+<?php
+
+namespace App\Modules\Journal\Services;
+
+use App\Modules\Journal\Models\JournalEntry;
+use Illuminate\Support\Collection;
+use PhpOffice\PhpWord\Element\Section;
+use PhpOffice\PhpWord\Element\Table;
+use PhpOffice\PhpWord\Element\TextRun;
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\Style\Font;
+use PhpOffice\PhpWord\Style\ListItem;
+
+/**
+ * Converts journal entries — whose `content` column is TipTap ProseMirror JSON
+ * (NOT HTML/markdown) — into a Word document. The node/mark set handled here
+ * mirrors resources/js/Components/Journal/journalExtensions.js. Anything richer
+ * than Word can cleanly represent (footnotes, task lists, remote images)
+ * degrades gracefully rather than being dropped.
+ */
+class JournalExportService
+{
+    /** @var array<int, string> Footnote bodies collected while walking the current entry. */
+    private array $footnotes = [];
+
+    /**
+     * @param  Collection<int, JournalEntry>|iterable<JournalEntry>  $entries
+     */
+    public function buildDocx(iterable $entries): PhpWord
+    {
+        $phpWord = new PhpWord;
+        $phpWord->addTitleStyle(1, ['bold' => true, 'size' => 18], ['spaceAfter' => 120]);
+        $phpWord->addTitleStyle(2, ['bold' => true, 'size' => 15], ['spaceBefore' => 120]);
+        $phpWord->addTitleStyle(3, ['bold' => true, 'size' => 13], ['spaceBefore' => 80]);
+
+        $section = $phpWord->addSection();
+        $first = true;
+
+        foreach ($entries as $entry) {
+            if (! $first) {
+                $section->addPageBreak();
+            }
+            $first = false;
+
+            $this->renderEntry($section, $entry);
+        }
+
+        if ($first) {
+            // No entries at all — still return a valid, non-empty document.
+            $section->addText('No journal entries found for the selected range.', ['italic' => true, 'color' => '888888']);
+        }
+
+        return $phpWord;
+    }
+
+    private function renderEntry(Section $section, JournalEntry $entry): void
+    {
+        $this->footnotes = [];
+
+        $section->addTitle($entry->title !== '' && $entry->title !== null ? $entry->title : 'Untitled', 1);
+
+        $meta = $entry->entry_date?->format('F j, Y') ?? '';
+        if ($entry->mood) {
+            $meta = trim($meta.'   '.$entry->mood->emoji().' '.$entry->mood->label());
+        }
+        if ($meta !== '') {
+            $section->addText($meta, ['italic' => true, 'color' => '666666']);
+        }
+
+        if ($entry->tags->isNotEmpty()) {
+            $section->addText('Tags: '.$entry->tags->pluck('name')->implode(', '), ['size' => 9, 'color' => '888888']);
+        }
+
+        $section->addTextBreak();
+
+        $content = is_array($entry->content) ? $entry->content : [];
+        $this->renderBlocks($section, $content['content'] ?? []);
+
+        $this->renderFootnotes($section);
+    }
+
+    /**
+     * @param  array<int, mixed>  $nodes
+     */
+    private function renderBlocks(Section $section, array $nodes): void
+    {
+        foreach ($nodes as $node) {
+            if (! is_array($node)) {
+                continue;
+            }
+            $this->renderBlock($section, $node);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $node
+     */
+    private function renderBlock(Section $section, array $node): void
+    {
+        switch ($node['type'] ?? '') {
+            case 'heading':
+                $level = (int) ($node['attrs']['level'] ?? 2);
+                $level = max(1, min(3, $level));
+                $text = $this->plainText($node);
+                $section->addTitle($text === '' ? ' ' : $text, $level);
+                break;
+
+            case 'paragraph':
+                $run = $section->addTextRun();
+                $this->renderInline($run, $node['content'] ?? []);
+                break;
+
+            case 'blockquote':
+                foreach ($node['content'] ?? [] as $child) {
+                    if (! is_array($child)) {
+                        continue;
+                    }
+                    $run = $section->addTextRun(['indentation' => ['left' => 480]]);
+                    $this->renderInline($run, $child['content'] ?? [], ['italic' => true, 'color' => '555555']);
+                }
+                break;
+
+            case 'bulletList':
+                $this->renderList($section, $node, ordered: false);
+                break;
+
+            case 'orderedList':
+                $this->renderList($section, $node, ordered: true);
+                break;
+
+            case 'taskList':
+                $this->renderTaskList($section, $node);
+                break;
+
+            case 'codeBlock':
+                $section->addText($this->plainText($node), ['name' => 'Courier New', 'size' => 10]);
+                break;
+
+            case 'horizontalRule':
+                $section->addText('────────────────────────────', ['color' => 'CCCCCC']);
+                break;
+
+            case 'image':
+                $src = $node['attrs']['src'] ?? '';
+                $section->addText('🖼 Image: '.$src, ['italic' => true, 'color' => '888888']);
+                break;
+
+            case 'table':
+                $this->renderTable($section, $node);
+                break;
+
+            case 'footnotes':
+                foreach ($node['content'] ?? [] as $footnote) {
+                    if (is_array($footnote)) {
+                        $this->footnotes[] = $this->plainText($footnote);
+                    }
+                }
+                break;
+
+            default:
+                // Unknown block: recurse into children so nothing is silently lost.
+                if (! empty($node['content']) && is_array($node['content'])) {
+                    $this->renderBlocks($section, $node['content']);
+                } elseif (($text = $this->plainText($node)) !== '') {
+                    $section->addText($text);
+                }
+                break;
+        }
+    }
+
+    /**
+     * @param  array<int, mixed>  $nodes
+     * @param  array<string, mixed>  $baseFont
+     */
+    private function renderInline(TextRun $run, array $nodes, array $baseFont = []): void
+    {
+        foreach ($nodes as $node) {
+            if (! is_array($node)) {
+                continue;
+            }
+
+            $type = $node['type'] ?? '';
+
+            if ($type === 'hardBreak') {
+                $run->addTextBreak();
+
+                continue;
+            }
+
+            if ($type === 'footnoteReference') {
+                $this->footnotes[] = '';
+                $run->addText('['.count($this->footnotes).']', ['superScript' => true, 'size' => 8]);
+
+                continue;
+            }
+
+            if ($type === 'text' && isset($node['text'])) {
+                [$font, $href] = $this->buildFontStyle($node['marks'] ?? [], $baseFont);
+
+                if ($href !== null) {
+                    $run->addLink($href, $node['text'], $font);
+                } else {
+                    $run->addText($node['text'], $font);
+                }
+
+                continue;
+            }
+
+            // Nested inline container: recurse.
+            if (! empty($node['content']) && is_array($node['content'])) {
+                $this->renderInline($run, $node['content'], $baseFont);
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $node
+     */
+    private function renderList(Section $section, array $node, bool $ordered, int $depth = 0): void
+    {
+        $listType = $ordered ? ListItem::TYPE_NUMBER : ListItem::TYPE_BULLET_FILLED;
+
+        foreach ($node['content'] ?? [] as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            foreach ($item['content'] ?? [] as $child) {
+                if (! is_array($child)) {
+                    continue;
+                }
+
+                $childType = $child['type'] ?? '';
+                if ($childType === 'bulletList' || $childType === 'orderedList') {
+                    $this->renderList($section, $child, $childType === 'orderedList', $depth + 1);
+
+                    continue;
+                }
+
+                $section->addListItem($this->plainText($child), $depth, [], ['listType' => $listType]);
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $node
+     */
+    private function renderTaskList(Section $section, array $node, int $depth = 0): void
+    {
+        foreach ($node['content'] ?? [] as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $checked = (bool) ($item['attrs']['checked'] ?? false);
+            $prefix = str_repeat('    ', $depth).($checked ? '☒ ' : '☐ ');
+
+            foreach ($item['content'] ?? [] as $child) {
+                if (! is_array($child)) {
+                    continue;
+                }
+
+                $childType = $child['type'] ?? '';
+                if ($childType === 'taskList') {
+                    $this->renderTaskList($section, $child, $depth + 1);
+
+                    continue;
+                }
+
+                $section->addText($prefix.$this->plainText($child));
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $node
+     */
+    private function renderTable(Section $section, array $node): void
+    {
+        /** @var Table $table */
+        $table = $section->addTable([
+            'borderSize' => 6,
+            'borderColor' => 'BBBBBB',
+            'cellMargin' => 60,
+        ]);
+
+        foreach ($node['content'] ?? [] as $row) {
+            if (! is_array($row) || ($row['type'] ?? '') !== 'tableRow') {
+                continue;
+            }
+
+            $table->addRow();
+
+            foreach ($row['content'] ?? [] as $cell) {
+                if (! is_array($cell)) {
+                    continue;
+                }
+
+                $isHeader = ($cell['type'] ?? '') === 'tableHeader';
+                $cellElement = $table->addCell(2500, $isHeader ? ['bgColor' => 'F2F2F2'] : []);
+                $text = $this->plainText($cell);
+                $cellElement->addText($text, $isHeader ? ['bold' => true] : []);
+            }
+        }
+    }
+
+    private function renderFootnotes(Section $section): void
+    {
+        $bodies = array_values(array_filter($this->footnotes, fn ($body) => $body !== ''));
+
+        if ($bodies === []) {
+            return;
+        }
+
+        $section->addTextBreak();
+        $section->addTitle('Footnotes', 3);
+
+        foreach ($bodies as $index => $body) {
+            $section->addText(($index + 1).'. '.$body, ['size' => 9, 'color' => '555555']);
+        }
+    }
+
+    /**
+     * Build a PHPWord font-style array from a TipTap mark list. Returns the
+     * style plus an optional link href (link is rendered via addLink, not addText).
+     *
+     * @param  array<int, mixed>  $marks
+     * @param  array<string, mixed>  $baseFont
+     * @return array{0: array<string, mixed>, 1: ?string}
+     */
+    private function buildFontStyle(array $marks, array $baseFont = []): array
+    {
+        $font = $baseFont;
+        $href = null;
+
+        foreach ($marks as $mark) {
+            if (! is_array($mark)) {
+                continue;
+            }
+
+            $attrs = $mark['attrs'] ?? [];
+
+            switch ($mark['type'] ?? '') {
+                case 'bold':
+                    $font['bold'] = true;
+                    break;
+                case 'italic':
+                    $font['italic'] = true;
+                    break;
+                case 'underline':
+                    $font['underline'] = Font::UNDERLINE_SINGLE;
+                    break;
+                case 'strike':
+                    $font['strikethrough'] = true;
+                    break;
+                case 'code':
+                    $font['name'] = 'Courier New';
+                    break;
+                case 'link':
+                    $href = is_string($attrs['href'] ?? null) ? $attrs['href'] : null;
+                    break;
+                case 'highlight':
+                    if ($color = $this->sanitizeHex($attrs['color'] ?? null)) {
+                        $font['bgColor'] = $color;
+                    }
+                    break;
+                case 'textStyle':
+                    if ($color = $this->sanitizeHex($attrs['color'] ?? null)) {
+                        $font['color'] = $color;
+                    }
+                    if (! empty($attrs['fontFamily']) && is_string($attrs['fontFamily'])) {
+                        $font['name'] = $attrs['fontFamily'];
+                    }
+                    if ($size = $this->parseFontSize($attrs['fontSize'] ?? null)) {
+                        $font['size'] = $size;
+                    }
+                    break;
+            }
+        }
+
+        return [$font, $href];
+    }
+
+    private function sanitizeHex(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $hex = ltrim(trim($value), '#');
+
+        if (preg_match('/^[0-9a-fA-F]{6}$/', $hex)) {
+            return strtoupper($hex);
+        }
+
+        if (preg_match('/^[0-9a-fA-F]{3}$/', $hex)) {
+            // Expand shorthand (#abc → aabbcc).
+            return strtoupper($hex[0].$hex[0].$hex[1].$hex[1].$hex[2].$hex[2]);
+        }
+
+        return null;
+    }
+
+    private function parseFontSize(mixed $value): ?int
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        if (! preg_match('/([0-9]+(?:\.[0-9]+)?)/', (string) $value, $matches)) {
+            return null;
+        }
+
+        $number = (float) $matches[1];
+
+        // Values are stored as CSS pixels; Word sizes are points (≈ px * 0.75).
+        if (str_contains((string) $value, 'px')) {
+            $number *= 0.75;
+        }
+
+        $points = (int) round($number);
+
+        return $points > 0 ? $points : null;
+    }
+
+    /**
+     * Recursively collect plain text from a TipTap node (mirrors
+     * JournalService::collectText).
+     *
+     * @param  mixed  $node
+     */
+    private function plainText($node): string
+    {
+        $parts = [];
+        $this->collectText($node, $parts);
+
+        return trim(preg_replace('/\s+/', ' ', implode(' ', $parts)) ?? '');
+    }
+
+    /**
+     * @param  mixed  $node
+     * @param  array<int, string>  $parts
+     */
+    private function collectText($node, array &$parts): void
+    {
+        if (! is_array($node)) {
+            return;
+        }
+
+        if (isset($node['text']) && is_string($node['text'])) {
+            $parts[] = $node['text'];
+        }
+
+        if (isset($node['content']) && is_array($node['content'])) {
+            foreach ($node['content'] as $child) {
+                $this->collectText($child, $parts);
+            }
+        }
+    }
+}

--- a/app/Modules/Journal/routes.php
+++ b/app/Modules/Journal/routes.php
@@ -4,5 +4,7 @@ use App\Modules\Journal\Controllers\JournalEntryController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware(['web', 'auth'])->group(function () {
+    // Must precede the resource route so `journal/export` is not captured by `journal/{journal}`.
+    Route::get('journal/export', [JournalEntryController::class, 'export'])->name('journal.export');
     Route::resource('journal', JournalEntryController::class);
 });

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,8 @@
         "laravel/framework": "^12.0",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.10.1",
+        "phpoffice/phpspreadsheet": "^5.9",
+        "phpoffice/phpword": "^1.4",
         "symfony/console": "~7.3.0",
         "tightenco/ziggy": "^2.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4b43223094baf50539a7ec015fcd74ee",
+    "content-hash": "ef7d060e3ba7b1a4435a3644f8e77a0c",
     "packages": [
         {
             "name": "brick/math",
@@ -134,6 +134,82 @@
                 }
             ],
             "time": "2024-02-09T16:56:22+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<2.2.2"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-07T11:47:49+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -2395,6 +2471,191 @@
             "time": "2026-03-08T20:05:35+00:00"
         },
         {
+            "name": "maennchen/zipstream-php",
+            "version": "3.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maennchen/ZipStream-PHP.git",
+                "reference": "77bebeb4c6c340bb3c11c843b2cffd8bbfde4d5e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/77bebeb4c6c340bb3c11c843b2cffd8bbfde4d5e",
+                "reference": "77bebeb4c6c340bb3c11c843b2cffd8bbfde4d5e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "ext-zlib": "*",
+                "php-64bit": "^8.3"
+            },
+            "require-dev": {
+                "brianium/paratest": "^7.7",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "^3.86",
+                "guzzlehttp/guzzle": "^7.5",
+                "mikey179/vfsstream": "^1.6",
+                "php-coveralls/php-coveralls": "^2.5",
+                "phpunit/phpunit": "^12.0",
+                "vimeo/psalm": "^6.0"
+            },
+            "suggest": {
+                "guzzlehttp/psr7": "^2.4",
+                "psr/http-message": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ZipStream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paul Duncan",
+                    "email": "pabs@pablotron.org"
+                },
+                {
+                    "name": "Jonatan Männchen",
+                    "email": "jonatan@maennchen.ch"
+                },
+                {
+                    "name": "Jesse Donat",
+                    "email": "donatj@gmail.com"
+                },
+                {
+                    "name": "András Kolesár",
+                    "email": "kolesar@kolesar.hu"
+                }
+            ],
+            "description": "ZipStream is a library for dynamically streaming dynamic zip files from PHP without writing to the disk at all on the server.",
+            "keywords": [
+                "stream",
+                "zip"
+            ],
+            "support": {
+                "issues": "https://github.com/maennchen/ZipStream-PHP/issues",
+                "source": "https://github.com/maennchen/ZipStream-PHP/tree/3.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/maennchen",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-11T18:38:28+00:00"
+        },
+        {
+            "name": "markbaker/complex",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MarkBaker/PHPComplex.git",
+                "reference": "95c56caa1cf5c766ad6d65b6344b807c1e8405b9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MarkBaker/PHPComplex/zipball/95c56caa1cf5c766ad6d65b6344b807c1e8405b9",
+                "reference": "95c56caa1cf5c766ad6d65b6344b807c1e8405b9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "dev-master",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+                "squizlabs/php_codesniffer": "^3.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Complex\\": "classes/src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Baker",
+                    "email": "mark@lange.demon.co.uk"
+                }
+            ],
+            "description": "PHP Class for working with complex numbers",
+            "homepage": "https://github.com/MarkBaker/PHPComplex",
+            "keywords": [
+                "complex",
+                "mathematics"
+            ],
+            "support": {
+                "issues": "https://github.com/MarkBaker/PHPComplex/issues",
+                "source": "https://github.com/MarkBaker/PHPComplex/tree/3.0.2"
+            },
+            "time": "2022-12-06T16:21:08+00:00"
+        },
+        {
+            "name": "markbaker/matrix",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MarkBaker/PHPMatrix.git",
+                "reference": "728434227fe21be27ff6d86621a1b13107a2562c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MarkBaker/PHPMatrix/zipball/728434227fe21be27ff6d86621a1b13107a2562c",
+                "reference": "728434227fe21be27ff6d86621a1b13107a2562c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "dev-master",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpdocumentor/phpdocumentor": "2.*",
+                "phploc/phploc": "^4.0",
+                "phpmd/phpmd": "2.*",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+                "sebastian/phpcpd": "^4.0",
+                "squizlabs/php_codesniffer": "^3.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Matrix\\": "classes/src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Baker",
+                    "email": "mark@demon-angel.eu"
+                }
+            ],
+            "description": "PHP Class for working with matrices",
+            "homepage": "https://github.com/MarkBaker/PHPMatrix",
+            "keywords": [
+                "mathematics",
+                "matrix",
+                "vector"
+            ],
+            "support": {
+                "issues": "https://github.com/MarkBaker/PHPMatrix/issues",
+                "source": "https://github.com/MarkBaker/PHPMatrix/tree/3.0.1"
+            },
+            "time": "2022-12-02T22:17:43+00:00"
+        },
+        {
             "name": "monolog/monolog",
             "version": "3.10.0",
             "source": {
@@ -3021,6 +3282,275 @@
                 "source": "https://github.com/paragonie/random_compat"
             },
             "time": "2020-10-15T08:29:30+00:00"
+        },
+        {
+            "name": "phpoffice/math",
+            "version": "0.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPOffice/Math.git",
+                "reference": "fc31c8f57a7a81f962cbf389fd89f4d9d06fc99a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPOffice/Math/zipball/fc31c8f57a7a81f962cbf389fd89f4d9d06fc99a",
+                "reference": "fc31c8f57a7a81f962cbf389fd89f4d9d06fc99a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xml": "*",
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.88 || ^1.0.0",
+                "phpunit/phpunit": "^7.0 || ^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpOffice\\Math\\": "src/Math/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Progi1984",
+                    "homepage": "https://lefevre.dev"
+                }
+            ],
+            "description": "Math - Manipulate Math Formula",
+            "homepage": "https://phpoffice.github.io/Math/",
+            "keywords": [
+                "MathML",
+                "officemathml",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPOffice/Math/issues",
+                "source": "https://github.com/PHPOffice/Math/tree/0.3.0"
+            },
+            "time": "2025-05-29T08:31:49+00:00"
+        },
+        {
+            "name": "phpoffice/phpspreadsheet",
+            "version": "5.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
+                "reference": "05e99ebf61238a70227b4d9cc02d0030d34f6339"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/05e99ebf61238a70227b4d9cc02d0030d34f6339",
+                "reference": "05e99ebf61238a70227b4d9cc02d0030d34f6339",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1||^2||^3",
+                "ext-ctype": "*",
+                "ext-dom": "*",
+                "ext-fileinfo": "*",
+                "ext-filter": "*",
+                "ext-gd": "*",
+                "ext-iconv": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-xml": "*",
+                "ext-xmlreader": "*",
+                "ext-xmlwriter": "*",
+                "ext-zip": "*",
+                "ext-zlib": "*",
+                "maennchen/zipstream-php": "^2.1 || ^3.0",
+                "markbaker/complex": "^3.0",
+                "markbaker/matrix": "^3.0",
+                "php": "^8.2",
+                "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "dev-main",
+                "dompdf/dompdf": "^2.0 || ^3.0",
+                "ext-intl": "*",
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "mitoteam/jpgraph": "^10.5",
+                "mpdf/mpdf": "^8.1.1",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpstan/phpstan": "^1.1 || ^2.0",
+                "phpstan/phpstan-deprecation-rules": "^1.0 || ^2.0",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2.0",
+                "phpunit/phpunit": "^10.5 || ^11.0",
+                "squizlabs/php_codesniffer": "^3.7",
+                "tecnickcom/tcpdf": "^6.5"
+            },
+            "suggest": {
+                "dompdf/dompdf": "Option for rendering PDF with PDF Writer",
+                "ext-intl": "PHP Internationalization Functions, required for NumberFormat Wizard and StringHelper::setLocale()",
+                "mitoteam/jpgraph": "Option for rendering charts, or including charts with PDF or HTML Writers",
+                "mpdf/mpdf": "Option for rendering PDF with PDF Writer",
+                "tecnickcom/tcpdf": "Option for rendering PDF with PDF Writer"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpOffice\\PhpSpreadsheet\\": "src/PhpSpreadsheet"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maarten Balliauw",
+                    "homepage": "https://blog.maartenballiauw.be"
+                },
+                {
+                    "name": "Mark Baker",
+                    "homepage": "https://markbakeruk.net"
+                },
+                {
+                    "name": "Franck Lefevre",
+                    "homepage": "https://rootslabs.net"
+                },
+                {
+                    "name": "Erik Tilt"
+                },
+                {
+                    "name": "Adrien Crivelli"
+                },
+                {
+                    "name": "Owen Leibman"
+                }
+            ],
+            "description": "PHPSpreadsheet - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine",
+            "homepage": "https://github.com/PHPOffice/PhpSpreadsheet",
+            "keywords": [
+                "OpenXML",
+                "excel",
+                "gnumeric",
+                "ods",
+                "php",
+                "spreadsheet",
+                "xls",
+                "xlsx"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.9.0"
+            },
+            "time": "2026-07-12T19:17:39+00:00"
+        },
+        {
+            "name": "phpoffice/phpword",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPOffice/PHPWord.git",
+                "reference": "6d75328229bc93790b37e93741adf70646cea958"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPOffice/PHPWord/zipball/6d75328229bc93790b37e93741adf70646cea958",
+                "reference": "6d75328229bc93790b37e93741adf70646cea958",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-gd": "*",
+                "ext-json": "*",
+                "ext-xml": "*",
+                "ext-zip": "*",
+                "php": "^7.1|^8.0",
+                "phpoffice/math": "^0.3"
+            },
+            "require-dev": {
+                "dompdf/dompdf": "^2.0 || ^3.0",
+                "ext-libxml": "*",
+                "friendsofphp/php-cs-fixer": "^3.3",
+                "mpdf/mpdf": "^7.0 || ^8.0",
+                "phpmd/phpmd": "^2.13",
+                "phpstan/phpstan": "^0.12.88 || ^1.0.0",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2.0",
+                "phpunit/phpunit": ">=7.0",
+                "symfony/process": "^4.4 || ^5.0",
+                "tecnickcom/tcpdf": "^6.5"
+            },
+            "suggest": {
+                "dompdf/dompdf": "Allows writing PDF",
+                "ext-xmlwriter": "Allows writing OOXML and ODF",
+                "ext-xsl": "Allows applying XSL style sheet to headers, to main document part, and to footers of an OOXML template"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpOffice\\PhpWord\\": "src/PhpWord"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Baker"
+                },
+                {
+                    "name": "Gabriel Bull",
+                    "email": "me@gabrielbull.com",
+                    "homepage": "http://gabrielbull.com/"
+                },
+                {
+                    "name": "Franck Lefevre",
+                    "homepage": "https://rootslabs.net/blog/"
+                },
+                {
+                    "name": "Ivan Lanin",
+                    "homepage": "http://ivan.lanin.org"
+                },
+                {
+                    "name": "Roman Syroeshko",
+                    "homepage": "http://ru.linkedin.com/pub/roman-syroeshko/34/a53/994/"
+                },
+                {
+                    "name": "Antoine de Troostembergh"
+                }
+            ],
+            "description": "PHPWord - A pure PHP library for reading and writing word processing documents (OOXML, ODF, RTF, HTML, PDF)",
+            "homepage": "https://phpoffice.github.io/PHPWord/",
+            "keywords": [
+                "ISO IEC 29500",
+                "OOXML",
+                "Office Open XML",
+                "OpenDocument",
+                "OpenXML",
+                "PhpOffice",
+                "PhpWord",
+                "Rich Text Format",
+                "WordprocessingML",
+                "doc",
+                "docx",
+                "html",
+                "odf",
+                "odt",
+                "office",
+                "pdf",
+                "php",
+                "reader",
+                "rtf",
+                "template",
+                "template processor",
+                "word",
+                "writer"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPOffice/PHPWord/issues",
+                "source": "https://github.com/PHPOffice/PHPWord/tree/1.4.0"
+            },
+            "time": "2025-06-05T10:32:36+00:00"
         },
         {
             "name": "phpoption/phpoption",

--- a/resources/js/Pages/Profile/Edit.jsx
+++ b/resources/js/Pages/Profile/Edit.jsx
@@ -2,6 +2,7 @@ import TodoLayout from "@/Layouts/TodoLayout";
 import { Head, Link, useForm, usePage } from "@inertiajs/react";
 import { Calendar, Edit3, LogOut, Mail, Shield, User } from "lucide-react";
 import DeleteUserForm from "./Partials/DeleteUserForm";
+import ExportDataForm from "./Partials/ExportDataForm";
 import UpdatePasswordForm from "./Partials/UpdatePasswordForm";
 import UpdateProfileInformationForm from "./Partials/UpdateProfileInformationForm";
 import DangerButton from "@/Components/DangerButton";
@@ -178,6 +179,10 @@ export default function Edit({ mustVerifyEmail, status }) {
 
                 <div className="card p-4 sm:p-8">
                     <UpdatePasswordForm className="max-w-xl" />
+                </div>
+
+                <div className="card p-4 sm:p-8">
+                    <ExportDataForm className="max-w-xl" />
                 </div>
 
                 <div className="card p-4 sm:p-8">

--- a/resources/js/Pages/Profile/Partials/ExportDataForm.jsx
+++ b/resources/js/Pages/Profile/Partials/ExportDataForm.jsx
@@ -1,0 +1,151 @@
+import InputLabel from "@/Components/InputLabel";
+import PrimaryButton from "@/Components/PrimaryButton";
+import TextInput from "@/Components/TextInput";
+import { Download, FileSpreadsheet, FileText } from "lucide-react";
+import { useState } from "react";
+
+export default function ExportDataForm({ className = "" }) {
+    const [wallet, setWallet] = useState({ start_date: "", end_date: "" });
+    const [journal, setJournal] = useState({ start_date: "", end_date: "" });
+
+    // Ziggy omits params that are undefined/null, so blank dates → export everything.
+    const buildParams = ({ start_date, end_date }) => ({
+        start_date: start_date || undefined,
+        end_date: end_date || undefined,
+    });
+
+    const download = (routeName, range) => {
+        window.location.assign(route(routeName, buildParams(range)));
+    };
+
+    return (
+        <section className={`space-y-6 ${className}`}>
+            <header>
+                <h2 className="text-lg font-medium text-gray-900 dark:text-gray-100">
+                    Export Your Data
+                </h2>
+
+                <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                    Download a copy of your data to keep or use elsewhere. Leave
+                    the dates blank to export everything.
+                </p>
+            </header>
+
+            {/* WevieWallet → Excel */}
+            <div className="rounded-xl border border-light-border/70 p-4 dark:border-dark-border/70">
+                <div className="flex items-center gap-2">
+                    <FileSpreadsheet className="h-5 w-5 text-wevie-teal" />
+                    <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                        WevieWallet (Excel)
+                    </h3>
+                </div>
+                <p className="mt-1 text-xs text-gray-600 dark:text-gray-400">
+                    Accounts, transactions, budgets, savings goals and loans, as
+                    a multi-tab spreadsheet. The date range filters transactions.
+                </p>
+
+                <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    <div>
+                        <InputLabel htmlFor="wallet_start" value="Start date" />
+                        <TextInput
+                            id="wallet_start"
+                            type="date"
+                            className="mt-1 block w-full"
+                            value={wallet.start_date}
+                            max={wallet.end_date || undefined}
+                            onChange={(e) =>
+                                setWallet((prev) => ({
+                                    ...prev,
+                                    start_date: e.target.value,
+                                }))
+                            }
+                        />
+                    </div>
+                    <div>
+                        <InputLabel htmlFor="wallet_end" value="End date" />
+                        <TextInput
+                            id="wallet_end"
+                            type="date"
+                            className="mt-1 block w-full"
+                            value={wallet.end_date}
+                            min={wallet.start_date || undefined}
+                            onChange={(e) =>
+                                setWallet((prev) => ({
+                                    ...prev,
+                                    end_date: e.target.value,
+                                }))
+                            }
+                        />
+                    </div>
+                </div>
+
+                <PrimaryButton
+                    type="button"
+                    className="mt-4"
+                    onClick={() => download("weviewallet.export.excel", wallet)}
+                >
+                    <Download className="mr-2 h-4 w-4" />
+                    Download Excel
+                </PrimaryButton>
+            </div>
+
+            {/* Journals → Word */}
+            <div className="rounded-xl border border-light-border/70 p-4 dark:border-dark-border/70">
+                <div className="flex items-center gap-2">
+                    <FileText className="h-5 w-5 text-wevie-teal" />
+                    <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                        Journals (Word)
+                    </h3>
+                </div>
+                <p className="mt-1 text-xs text-gray-600 dark:text-gray-400">
+                    All your journal entries in one Word document, ordered by
+                    date. The date range filters by entry date.
+                </p>
+
+                <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    <div>
+                        <InputLabel htmlFor="journal_start" value="Start date" />
+                        <TextInput
+                            id="journal_start"
+                            type="date"
+                            className="mt-1 block w-full"
+                            value={journal.start_date}
+                            max={journal.end_date || undefined}
+                            onChange={(e) =>
+                                setJournal((prev) => ({
+                                    ...prev,
+                                    start_date: e.target.value,
+                                }))
+                            }
+                        />
+                    </div>
+                    <div>
+                        <InputLabel htmlFor="journal_end" value="End date" />
+                        <TextInput
+                            id="journal_end"
+                            type="date"
+                            className="mt-1 block w-full"
+                            value={journal.end_date}
+                            min={journal.start_date || undefined}
+                            onChange={(e) =>
+                                setJournal((prev) => ({
+                                    ...prev,
+                                    end_date: e.target.value,
+                                }))
+                            }
+                        />
+                    </div>
+                </div>
+
+                <PrimaryButton
+                    type="button"
+                    className="mt-4"
+                    onClick={() => download("journal.export", journal)}
+                >
+                    <Download className="mr-2 h-4 w-4" />
+                    Download Word
+                </PrimaryButton>
+            </div>
+        </section>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,23 +1,24 @@
 <?php
 
-use App\Http\Controllers\ProfileController;
-use App\Http\Controllers\TaskController;
-use App\Http\Controllers\CategoryController;
-use App\Http\Controllers\TagController;
 use App\Http\Controllers\AdminController;
-use App\Http\Controllers\SubtaskController;
-use App\Http\Controllers\ReminderController;
-use App\Http\Controllers\DashboardController;
-use App\Http\Controllers\CalendarController;
 use App\Http\Controllers\AnalyticsController;
-use App\Http\Controllers\GoogleCalendarController;
-use App\Http\Controllers\WorkspaceController;
 use App\Http\Controllers\BoardController;
+use App\Http\Controllers\CalendarController;
+use App\Http\Controllers\CategoryController;
+use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\GoogleCalendarController;
+use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\ReminderController;
+use App\Http\Controllers\SubtaskController;
 use App\Http\Controllers\SwimlaneController;
-use App\Modules\Finance\Controllers\FinanceBudgetController;
+use App\Http\Controllers\TagController;
+use App\Http\Controllers\TaskController;
+use App\Http\Controllers\WorkspaceController;
 use App\Modules\Finance\Controllers\FinanceAccountController;
+use App\Modules\Finance\Controllers\FinanceBudgetController;
 use App\Modules\Finance\Controllers\FinanceCategoryController;
 use App\Modules\Finance\Controllers\FinanceDashboardController;
+use App\Modules\Finance\Controllers\FinanceExportController;
 use App\Modules\Finance\Controllers\FinanceLoanController;
 use App\Modules\Finance\Controllers\FinanceReportController;
 use App\Modules\Finance\Controllers\FinanceSavingsGoalController;
@@ -98,6 +99,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ->name('weviewallet.savings-goals.index');
     Route::get('weviewallet/loans', [FinanceLoanController::class, 'indexPage'])
         ->name('weviewallet.loans.index');
+    Route::get('weviewallet/export/excel', [FinanceExportController::class, 'exportExcel'])
+        ->name('weviewallet.export.excel');
     Route::prefix('weviewallet/api')->name('weviewallet.api.')->group(function () {
         Route::get('collaborators/search', [FinanceWalletCollaboratorController::class, 'search'])
             ->name('collaborators.search');
@@ -209,4 +212,4 @@ Route::middleware('auth')->group(function () {
     Route::get('/google/callback', [GoogleCalendarController::class, 'callback'])->name('google.callback');
 });
 
-require __DIR__ . '/auth.php';
+require __DIR__.'/auth.php';

--- a/tests/Feature/Modules/Finance/FinanceExportTest.php
+++ b/tests/Feature/Modules/Finance/FinanceExportTest.php
@@ -1,0 +1,181 @@
+<?php
+
+use App\Models\User;
+use App\Modules\Finance\Models\FinanceAccount;
+use App\Modules\Finance\Models\FinanceTransaction;
+use Illuminate\Support\Facades\DB;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+
+/**
+ * Capture the streamed export body and load it back as a spreadsheet so we can
+ * make assertions about the actual worksheet contents.
+ */
+function loadExportedWorkbook(string $content): array
+{
+    $path = tempnam(sys_get_temp_dir(), 'export').'.xlsx';
+    file_put_contents($path, $content);
+
+    $spreadsheet = IOFactory::load($path);
+    $sheets = [];
+    foreach ($spreadsheet->getAllSheets() as $sheet) {
+        $sheets[$sheet->getTitle()] = $sheet->toArray();
+    }
+
+    unlink($path);
+
+    return $sheets;
+}
+
+function makeAccount(User $user, array $overrides = []): FinanceAccount
+{
+    return FinanceAccount::create(array_merge([
+        'user_id' => $user->id,
+        'name' => 'Regular Bank',
+        'type' => 'bank',
+        'currency' => 'PHP',
+        'account_number' => '1234567890',
+        'starting_balance' => 100,
+        'current_balance' => 100,
+        'is_active' => true,
+        'is_default' => false,
+    ], $overrides));
+}
+
+it('exports wallet data as an xlsx with the expected sheets', function () {
+    $user = User::factory()->create();
+    $account = makeAccount($user);
+
+    FinanceTransaction::create([
+        'user_id' => $user->id,
+        'finance_account_id' => $account->id,
+        'type' => 'expense',
+        'amount' => 42.50,
+        'currency' => 'PHP',
+        'description' => 'Coffee run',
+        'occurred_at' => '2026-07-10 09:00:00',
+    ]);
+
+    $response = $this->actingAs($user)->get(route('weviewallet.export.excel'));
+
+    $response->assertOk();
+    $response->assertHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+
+    $content = $response->streamedContent();
+    expect(substr($content, 0, 2))->toBe('PK'); // xlsx is a zip archive
+
+    $sheets = loadExportedWorkbook($content);
+    expect(array_keys($sheets))->toBe(['Accounts', 'Transactions', 'Budgets', 'Savings Goals', 'Loans']);
+
+    $flat = collect($sheets['Transactions'])->flatten()->filter()->implode('|');
+    expect($flat)->toContain('Coffee run');
+});
+
+it('respects the date range for the transactions sheet', function () {
+    $user = User::factory()->create();
+    $account = makeAccount($user);
+
+    FinanceTransaction::create([
+        'user_id' => $user->id,
+        'finance_account_id' => $account->id,
+        'type' => 'expense',
+        'amount' => 10,
+        'currency' => 'PHP',
+        'description' => 'InsideRange',
+        'occurred_at' => '2026-07-15 09:00:00',
+    ]);
+    FinanceTransaction::create([
+        'user_id' => $user->id,
+        'finance_account_id' => $account->id,
+        'type' => 'expense',
+        'amount' => 20,
+        'currency' => 'PHP',
+        'description' => 'OutsideRange',
+        'occurred_at' => '2026-06-01 09:00:00',
+    ]);
+
+    $response = $this->actingAs($user)->get(route('weviewallet.export.excel', [
+        'start_date' => '2026-07-01',
+        'end_date' => '2026-07-31',
+    ]));
+
+    $response->assertOk();
+
+    $sheets = loadExportedWorkbook($response->streamedContent());
+    $flat = collect($sheets['Transactions'])->flatten()->filter()->implode('|');
+
+    expect($flat)->toContain('InsideRange');
+    expect($flat)->not->toContain('OutsideRange');
+});
+
+it('only includes the requesting user\'s data', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    makeAccount($other, ['name' => 'Someone Elses Bank']);
+
+    $response = $this->actingAs($user)->get(route('weviewallet.export.excel'));
+    $response->assertOk();
+
+    $sheets = loadExportedWorkbook($response->streamedContent());
+    $flat = collect($sheets['Accounts'])->flatten()->filter()->implode('|');
+
+    expect($flat)->not->toContain('Someone Elses Bank');
+});
+
+it('shows the full account number when you export your own wallet', function () {
+    $user = User::factory()->create();
+    makeAccount($user, ['account_number' => '9998887777']);
+
+    $response = $this->actingAs($user)->get(route('weviewallet.export.excel'));
+    $sheets = loadExportedWorkbook($response->streamedContent());
+
+    $flat = collect($sheets['Accounts'])->flatten()->filter()->implode('|');
+    expect($flat)->toContain('9998887777');
+});
+
+it('masks the account number when a collaborator exports a shared wallet', function () {
+    $owner = User::factory()->create();
+    $collaborator = User::factory()->create();
+    makeAccount($owner, ['account_number' => '9998887777']);
+
+    DB::table('finance_wallet_collaborators')->insert([
+        'owner_user_id' => $owner->id,
+        'collaborator_user_id' => $collaborator->id,
+        'role' => 'collaborator',
+        'joined_at' => now(),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $response = $this->actingAs($collaborator)->get(route('weviewallet.export.excel', [
+        'wallet_user_id' => $owner->id,
+    ]));
+    $response->assertOk();
+
+    $sheets = loadExportedWorkbook($response->streamedContent());
+    $flat = collect($sheets['Accounts'])->flatten()->filter()->implode('|');
+
+    expect($flat)->not->toContain('9998887777');
+    expect($flat)->toContain('•••• 7777');
+});
+
+it('falls back to your own wallet when given an inaccessible wallet_user_id', function () {
+    $user = User::factory()->create();
+    $stranger = User::factory()->create();
+    makeAccount($user, ['name' => 'My Own Bank']);
+    makeAccount($stranger, ['name' => 'Strangers Bank']);
+
+    $response = $this->actingAs($user)->get(route('weviewallet.export.excel', [
+        'wallet_user_id' => $stranger->id,
+    ]));
+    $response->assertOk();
+
+    $sheets = loadExportedWorkbook($response->streamedContent());
+    $flat = collect($sheets['Accounts'])->flatten()->filter()->implode('|');
+
+    expect($flat)->toContain('My Own Bank');
+    expect($flat)->not->toContain('Strangers Bank');
+});
+
+it('requires authentication', function () {
+    $this->get(route('weviewallet.export.excel'))->assertRedirect(route('login'));
+});

--- a/tests/Feature/Modules/Journal/JournalExportTest.php
+++ b/tests/Feature/Modules/Journal/JournalExportTest.php
@@ -1,0 +1,144 @@
+<?php
+
+use App\Models\User;
+use App\Modules\Journal\Models\JournalEntry;
+
+function docWithText(string $text): array
+{
+    return [
+        'type' => 'doc',
+        'content' => [
+            ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $text]]],
+        ],
+    ];
+}
+
+function makeJournalEntry(User $user, array $overrides = []): JournalEntry
+{
+    return JournalEntry::create(array_merge([
+        'user_id' => $user->id,
+        'entry_date' => '2026-07-15',
+        'title' => 'Default title',
+        'content' => docWithText('Default body text'),
+        'excerpt' => 'Default body text',
+        'mood' => 'good',
+    ], $overrides));
+}
+
+/**
+ * A .docx is a zip; the readable text lives in word/document.xml. Return that
+ * XML so tests can assert which entries made it into the document.
+ */
+function exportedDocumentXml(string $content): string
+{
+    $path = tempnam(sys_get_temp_dir(), 'journal').'.docx';
+    file_put_contents($path, $content);
+
+    $zip = new ZipArchive;
+    $zip->open($path);
+    $xml = $zip->getFromName('word/document.xml');
+    $zip->close();
+    unlink($path);
+
+    return $xml ?: '';
+}
+
+it('exports journals as a docx document', function () {
+    $user = User::factory()->create();
+    makeJournalEntry($user, ['title' => 'A Sunny Day', 'content' => docWithText('It was a lovely afternoon.')]);
+
+    $response = $this->actingAs($user)->get(route('journal.export'));
+
+    $response->assertOk();
+    $response->assertHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+
+    $content = $response->streamedContent();
+    expect(substr($content, 0, 2))->toBe('PK'); // docx is a zip archive
+
+    $xml = exportedDocumentXml($content);
+    expect($xml)->toContain('A Sunny Day');
+    expect($xml)->toContain('It was a lovely afternoon.');
+});
+
+it('only exports the requesting user\'s entries', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+
+    makeJournalEntry($user, ['title' => 'My Private Entry']);
+    makeJournalEntry($other, ['title' => 'Someone Elses Entry']);
+
+    $response = $this->actingAs($user)->get(route('journal.export'));
+    $response->assertOk();
+
+    $xml = exportedDocumentXml($response->streamedContent());
+    expect($xml)->toContain('My Private Entry');
+    expect($xml)->not->toContain('Someone Elses Entry');
+});
+
+it('filters journal entries by the entry_date range', function () {
+    $user = User::factory()->create();
+    makeJournalEntry($user, ['title' => 'InRangeEntry', 'entry_date' => '2026-07-15']);
+    makeJournalEntry($user, ['title' => 'OutOfRangeEntry', 'entry_date' => '2026-05-01']);
+
+    $response = $this->actingAs($user)->get(route('journal.export', [
+        'start_date' => '2026-07-01',
+        'end_date' => '2026-07-31',
+    ]));
+    $response->assertOk();
+
+    $xml = exportedDocumentXml($response->streamedContent());
+    expect($xml)->toContain('InRangeEntry');
+    expect($xml)->not->toContain('OutOfRangeEntry');
+});
+
+it('returns a valid document even when there are no entries', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->get(route('journal.export'));
+
+    $response->assertOk();
+    expect(substr($response->streamedContent(), 0, 2))->toBe('PK');
+});
+
+it('handles rich content nodes without error', function () {
+    $user = User::factory()->create();
+    makeJournalEntry($user, [
+        'title' => 'Rich Entry',
+        'content' => [
+            'type' => 'doc',
+            'content' => [
+                ['type' => 'heading', 'attrs' => ['level' => 2], 'content' => [['type' => 'text', 'text' => 'A Heading']]],
+                ['type' => 'paragraph', 'content' => [
+                    ['type' => 'text', 'text' => 'bold word', 'marks' => [['type' => 'bold']]],
+                    ['type' => 'text', 'text' => ' and a link', 'marks' => [['type' => 'link', 'attrs' => ['href' => 'https://example.com']]]],
+                ]],
+                ['type' => 'bulletList', 'content' => [
+                    ['type' => 'listItem', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'first item']]]]],
+                ]],
+                ['type' => 'taskList', 'content' => [
+                    ['type' => 'taskItem', 'attrs' => ['checked' => true], 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'done task']]]]],
+                ]],
+                ['type' => 'table', 'content' => [
+                    ['type' => 'tableRow', 'content' => [
+                        ['type' => 'tableHeader', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'Col A']]]]],
+                        ['type' => 'tableCell', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'Cell A']]]]],
+                    ]],
+                ]],
+            ],
+        ],
+    ]);
+
+    $response = $this->actingAs($user)->get(route('journal.export'));
+    $response->assertOk();
+
+    $xml = exportedDocumentXml($response->streamedContent());
+    expect($xml)->toContain('A Heading');
+    expect($xml)->toContain('bold word');
+    expect($xml)->toContain('first item');
+    expect($xml)->toContain('done task');
+    expect($xml)->toContain('Col A');
+});
+
+it('requires authentication', function () {
+    $this->get(route('journal.export'))->assertRedirect(route('login'));
+});


### PR DESCRIPTION
Adds an **Export Your Data** section to Profile → Edit with two date-range-scoped exports: WevieWallet to a real multi-tab `.xlsx` (Accounts, Transactions, Budgets, Savings Goals, Loans) via a new `FinanceExportController`/`FinanceExportService` scoped through `FinanceWalletService`, and journals to a `.docx` via a new `JournalExportService` that walks the TipTap ProseMirror JSON into PHPWord (headings, marks, lists, tables, task lists; footnotes/images degrade gracefully). Account numbers export in full for your own wallet and are masked to last-4 when a collaborator exports a shared wallet. Adds `phpoffice/phpspreadsheet` and `phpoffice/phpword`, two range-scoped repository read methods, and 13 feature tests that parse the generated files to assert sheet/entry contents, date filtering, user-scoping, and collaborator masking. Downloads are plain GET links (Inertia is bypassed since it can't handle binary responses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)