### PR TITLE
Fix unable to add subtasks (302 redirect to dead endpoint)

### DIFF
--- a/app/Http/Controllers/SubtaskController.php
+++ b/app/Http/Controllers/SubtaskController.php
@@ -13,6 +13,28 @@ class SubtaskController extends Controller
     public function __construct(
         private SubtaskService $subtaskService
     ) {}
+
+    /**
+     * Redirect back to the originating page, never to a subtask endpoint.
+     *
+     * The subtask routes are POST/PUT/DELETE only — there is no GET /subtasks —
+     * so a plain back() that resolves to the request's own URL leaves Inertia
+     * following a 302 into a dead endpoint (the subtask saves, but the UI
+     * appears to fail). Guard against self-redirects and any subtasks path,
+     * falling back to the tasks index.
+     */
+    private function redirectBack(): RedirectResponse
+    {
+        $previous = url()->previous();
+        $path = ltrim(parse_url($previous, PHP_URL_PATH) ?? '', '/');
+
+        if ($previous === url()->current() || str_starts_with($path, 'subtasks')) {
+            return redirect()->route('tasks.index');
+        }
+
+        return redirect()->to($previous);
+    }
+
     public function store(Request $request): RedirectResponse
     {
         try {
@@ -25,7 +47,7 @@ class SubtaskController extends Controller
 
             // Flash the created subtask so the client can reconcile its
             // temporary (client-generated) id with the real database id.
-            return back()
+            return $this->redirectBack()
                 ->with('message', 'Subtask created successfully')
                 ->with('subtask', $subtask->only([
                     'id',
@@ -35,8 +57,12 @@ class SubtaskController extends Controller
                     'position',
                     'task_id',
                 ]));
+        } catch (\Illuminate\Validation\ValidationException $e) {
+            throw $e;
         } catch (\Exception $e) {
-            return back()->withErrors(['error' => 'Failed to create subtask: ' . $e->getMessage()]);
+            report($e);
+
+            return $this->redirectBack()->withErrors(['error' => 'Failed to create subtask: ' . $e->getMessage()]);
         }
     }
 
@@ -50,9 +76,13 @@ class SubtaskController extends Controller
 
             $updatedSubtask = $this->subtaskService->updateSubtask($subtask, $validated, Auth::id());
 
-            return back()->with('message', 'Subtask updated successfully');
+            return $this->redirectBack()->with('message', 'Subtask updated successfully');
+        } catch (\Illuminate\Validation\ValidationException $e) {
+            throw $e;
         } catch (\Exception $e) {
-            return back()->withErrors(['error' => 'Failed to update subtask: ' . $e->getMessage()]);
+            report($e);
+
+            return $this->redirectBack()->withErrors(['error' => 'Failed to update subtask: ' . $e->getMessage()]);
         }
     }
 
@@ -60,9 +90,11 @@ class SubtaskController extends Controller
     {
         try {
             $this->subtaskService->deleteSubtask($subtask, Auth::id());
-            return back()->with('message', 'Subtask deleted successfully');
+            return $this->redirectBack()->with('message', 'Subtask deleted successfully');
         } catch (\Exception $e) {
-            return back()->withErrors(['error' => 'Failed to delete subtask: ' . $e->getMessage()]);
+            report($e);
+
+            return $this->redirectBack()->withErrors(['error' => 'Failed to delete subtask: ' . $e->getMessage()]);
         }
     }
 
@@ -71,9 +103,11 @@ class SubtaskController extends Controller
         try {
             $updatedSubtask = $this->subtaskService->toggleSubtaskCompletion($subtask, Auth::id());
             $message = $updatedSubtask->is_completed ? 'Subtask completed!' : 'Subtask marked as pending';
-            return back()->with('message', $message);
+            return $this->redirectBack()->with('message', $message);
         } catch (\Exception $e) {
-            return back()->withErrors(['error' => 'Failed to toggle subtask: ' . $e->getMessage()]);
+            report($e);
+
+            return $this->redirectBack()->withErrors(['error' => 'Failed to toggle subtask: ' . $e->getMessage()]);
         }
     }
 
@@ -86,9 +120,13 @@ class SubtaskController extends Controller
             ]);
 
             $this->subtaskService->reorderSubtasks($validated['subtaskIds'], Auth::id());
-            return back()->with('message', 'Subtasks reordered successfully');
+            return $this->redirectBack()->with('message', 'Subtasks reordered successfully');
+        } catch (\Illuminate\Validation\ValidationException $e) {
+            throw $e;
         } catch (\Exception $e) {
-            return back()->withErrors(['error' => 'Failed to reorder subtasks: ' . $e->getMessage()]);
+            report($e);
+
+            return $this->redirectBack()->withErrors(['error' => 'Failed to reorder subtasks: ' . $e->getMessage()]);
         }
     }
 }

--- a/resources/js/Components/QuickSubtaskModal.jsx
+++ b/resources/js/Components/QuickSubtaskModal.jsx
@@ -41,7 +41,8 @@ export default function QuickSubtaskModal({ show, onClose, task }) {
                 onError: (errors) => {
                     setErrors(errors);
                     toast.error(
-                        "We couldn’t save that just now. Try again when you’re ready."
+                        errors?.error ||
+                            "We couldn’t save that just now. Try again when you’re ready."
                     );
                 },
                 onFinish: () => {
@@ -100,6 +101,8 @@ export default function QuickSubtaskModal({ show, onClose, task }) {
                         />
                         <InputError message={errors.title} className="mt-2" />
                     </div>
+
+                    <InputError message={errors.error} className="mt-2" />
 
                     <div className="flex items-center justify-end space-x-3 pt-4">
                         <SecondaryButton

--- a/resources/js/Components/SubtaskManager.jsx
+++ b/resources/js/Components/SubtaskManager.jsx
@@ -237,23 +237,29 @@ export default function SubtaskManager({
                               )
                             : list;
 
-                    setSubtasks((prev) => reconcile(prev));
+                    // The optimistic add set `[...subtasks, tempSubtask]`, so
+                    // that reconciled list is the true new state. Use it for
+                    // both local state and the parent callback — the bare
+                    // `subtasks` closure is stale (missing the new row).
+                    const nextSubtasks = reconcile([...subtasks, tempSubtask]);
+                    setSubtasks(nextSubtasks);
 
                     // Update parent component's task data if callback provided
                     if (onTaskUpdate) {
                         onTaskUpdate({
                             ...task,
-                            subtasks: reconcile(subtasks),
+                            subtasks: nextSubtasks,
                         });
                     }
                     toast.success("Subtask saved.");
                 },
-                onError: () => {
+                onError: (errors) => {
                     setSubtasks((prev) =>
                         prev.filter((s) => s.id !== tempSubtask.id)
                     );
                     toast.error(
-                        "We couldn’t save that just now. Try again when you’re ready."
+                        errors?.error ||
+                            "We couldn’t save that just now. Try again when you’re ready."
                     );
                 },
             }


### PR DESCRIPTION
Adding a subtask silently failed even though the row was saved: subtask mutations returned `back()`, which resolved to the POST-only `/subtasks` URL that has no GET route, so Inertia followed the 302 into a dead endpoint and the UI appeared to fail. This adds a `redirectBack()` helper in `SubtaskController` that redirects to the originating page but never to a `subtasks` path or the request's own URL (used across store/update/destroy/toggle/reorder, on success and error paths). It also stops swallowing validation errors and now `report()`s real exceptions, surfaces `errors.error` in `QuickSubtaskModal` and `SubtaskManager`, and fixes a stale-closure that dropped the newly added subtask from the parent task state. Verified with `php -l`; Pint/ESLint/build and browser reproduction were not run in this workspace (no `vendor/`/`node_modules/`; the project builds in Docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)