### PR TITLE
Save subtasks in the background without reloading the page

### DIFF
--- a/app/Http/Controllers/SubtaskController.php
+++ b/app/Http/Controllers/SubtaskController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Subtask;
 use App\Services\SubtaskService;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
@@ -35,7 +36,17 @@ class SubtaskController extends Controller
         return redirect()->to($previous);
     }
 
-    public function store(Request $request): RedirectResponse
+    /**
+     * Whether the request is a plain background XHR (not an Inertia visit)
+     * expecting a JSON response. Checks the raw X-Inertia header so this holds
+     * regardless of whether the Request::inertia() macro is registered.
+     */
+    private function wantsJson(Request $request): bool
+    {
+        return ! $request->hasHeader('X-Inertia') && $request->expectsJson();
+    }
+
+    public function store(Request $request): RedirectResponse|JsonResponse
     {
         try {
             $validated = $request->validate([
@@ -45,22 +56,39 @@ class SubtaskController extends Controller
 
             $subtask = $this->subtaskService->createSubtask($validated, Auth::id());
 
-            // Flash the created subtask so the client can reconcile its
+            $payload = $subtask->only([
+                'id',
+                'title',
+                'is_completed',
+                'completed_at',
+                'position',
+                'task_id',
+            ]);
+
+            // Background (non-Inertia) XHR clients get the created row as JSON
+            // so they can save in place without an Inertia visit / page reload.
+            if ($this->wantsJson($request)) {
+                return response()->json([
+                    'subtask' => $payload,
+                    'message' => 'Subtask created successfully',
+                ]);
+            }
+
+            // Flash the created subtask so Inertia clients can reconcile their
             // temporary (client-generated) id with the real database id.
             return $this->redirectBack()
                 ->with('message', 'Subtask created successfully')
-                ->with('subtask', $subtask->only([
-                    'id',
-                    'title',
-                    'is_completed',
-                    'completed_at',
-                    'position',
-                    'task_id',
-                ]));
+                ->with('subtask', $payload);
         } catch (\Illuminate\Validation\ValidationException $e) {
             throw $e;
         } catch (\Exception $e) {
             report($e);
+
+            if ($this->wantsJson($request)) {
+                return response()->json([
+                    'error' => 'Failed to create subtask: ' . $e->getMessage(),
+                ], 500);
+            }
 
             return $this->redirectBack()->withErrors(['error' => 'Failed to create subtask: ' . $e->getMessage()]);
         }

--- a/resources/js/Components/QuickSubtaskModal.jsx
+++ b/resources/js/Components/QuickSubtaskModal.jsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { router } from "@inertiajs/react";
 import { X, Plus } from "lucide-react";
 import Modal from "@/Components/Modal";
 import PrimaryButton from "@/Components/PrimaryButton";
@@ -9,7 +8,7 @@ import InputLabel from "@/Components/InputLabel";
 import InputError from "@/Components/InputError";
 import { toast } from "react-toastify";
 
-export default function QuickSubtaskModal({ show, onClose, task }) {
+export default function QuickSubtaskModal({ show, onClose, task, onSaved }) {
     const [subtaskTitle, setSubtaskTitle] = useState("");
     const [processing, setProcessing] = useState(false);
     const [errors, setErrors] = useState({});
@@ -25,31 +24,45 @@ export default function QuickSubtaskModal({ show, onClose, task }) {
         setProcessing(true);
         setErrors({});
 
-        router.post(
-            route("subtasks.store"),
-            {
-                task_id: task?.id,
-                title: subtaskTitle.trim(),
-            },
-            {
-                preserveScroll: true,
-                onSuccess: () => {
-                    toast.success("Subtask saved.");
-                    setSubtaskTitle("");
-                    onClose();
+        // Save in the background via a plain XHR (no Inertia visit) so the
+        // Tasks page never reloads.
+        window.axios
+            .post(
+                route("subtasks.store"),
+                {
+                    task_id: task?.id,
+                    title: subtaskTitle.trim(),
                 },
-                onError: (errors) => {
-                    setErrors(errors);
-                    toast.error(
-                        errors?.error ||
-                            "We couldn’t save that just now. Try again when you’re ready."
-                    );
-                },
-                onFinish: () => {
-                    setProcessing(false);
-                },
-            }
-        );
+                { headers: { Accept: "application/json" } }
+            )
+            .then((response) => {
+                toast.success("Subtask saved.");
+                setSubtaskTitle("");
+                if (onSaved) {
+                    onSaved(response?.data?.subtask);
+                }
+                onClose();
+            })
+            .catch((error) => {
+                const responseErrors = error?.response?.data?.errors || {};
+                const flattened = Object.fromEntries(
+                    Object.entries(responseErrors).map(([key, value]) => [
+                        key,
+                        Array.isArray(value) ? value[0] : value,
+                    ])
+                );
+                setErrors({
+                    ...flattened,
+                    error: error?.response?.data?.error,
+                });
+                toast.error(
+                    error?.response?.data?.error ||
+                        "We couldn’t save that just now. Try again when you’re ready."
+                );
+            })
+            .finally(() => {
+                setProcessing(false);
+            });
     };
 
     const handleClose = () => {

--- a/resources/js/Components/SubtaskManager.jsx
+++ b/resources/js/Components/SubtaskManager.jsx
@@ -212,58 +212,56 @@ export default function SubtaskManager({
         setNewSubtaskTitle("");
         setIsAddingSubtask(false);
 
-        router.post(
-            route("subtasks.store"),
-            {
-                task_id: task.id,
-                title: titleToAdd,
-            },
-            {
-                preserveScroll: true,
-                preserveState: true,
-                only: ["flash"], // Only pull back the flashed subtask
-                onSuccess: (page) => {
-                    // Reconcile the temporary client id with the real
-                    // database id returned from the server, otherwise later
-                    // edit/toggle/delete requests would target a non-existent
-                    // subtask.
-                    const created = page?.props?.flash?.subtask;
-                    const reconcile = (list) =>
-                        created?.id
-                            ? list.map((s) =>
-                                  s.id === tempSubtask.id
-                                      ? { ...s, ...created }
-                                      : s
-                              )
-                            : list;
-
-                    // The optimistic add set `[...subtasks, tempSubtask]`, so
-                    // that reconciled list is the true new state. Use it for
-                    // both local state and the parent callback — the bare
-                    // `subtasks` closure is stale (missing the new row).
-                    const nextSubtasks = reconcile([...subtasks, tempSubtask]);
-                    setSubtasks(nextSubtasks);
-
-                    // Update parent component's task data if callback provided
-                    if (onTaskUpdate) {
-                        onTaskUpdate({
-                            ...task,
-                            subtasks: nextSubtasks,
-                        });
-                    }
-                    toast.success("Subtask saved.");
+        // Save in the background via a plain XHR (no Inertia visit) so the page
+        // never reloads and the optimistic row stays put instantly.
+        window.axios
+            .post(
+                route("subtasks.store"),
+                {
+                    task_id: task.id,
+                    title: titleToAdd,
                 },
-                onError: (errors) => {
-                    setSubtasks((prev) =>
-                        prev.filter((s) => s.id !== tempSubtask.id)
-                    );
-                    toast.error(
-                        errors?.error ||
-                            "We couldn’t save that just now. Try again when you’re ready."
-                    );
-                },
-            }
-        );
+                { headers: { Accept: "application/json" } }
+            )
+            .then((response) => {
+                // Reconcile the temporary client id with the real database id
+                // returned from the server, otherwise later edit/toggle/delete
+                // requests would target a non-existent subtask.
+                const created = response?.data?.subtask;
+                const reconcile = (list) =>
+                    created?.id
+                        ? list.map((s) =>
+                              s.id === tempSubtask.id
+                                  ? { ...s, ...created }
+                                  : s
+                          )
+                        : list;
+
+                // The optimistic add set `[...subtasks, tempSubtask]`, so that
+                // reconciled list is the true new state. Use it for both local
+                // state and the parent callback — the bare `subtasks` closure
+                // is stale (missing the new row).
+                const nextSubtasks = reconcile([...subtasks, tempSubtask]);
+                setSubtasks(nextSubtasks);
+
+                // Update parent component's task data if callback provided
+                if (onTaskUpdate) {
+                    onTaskUpdate({
+                        ...task,
+                        subtasks: nextSubtasks,
+                    });
+                }
+                toast.success("Subtask saved.");
+            })
+            .catch((error) => {
+                setSubtasks((prev) =>
+                    prev.filter((s) => s.id !== tempSubtask.id)
+                );
+                toast.error(
+                    error?.response?.data?.error ||
+                        "We couldn’t save that just now. Try again when you’re ready."
+                );
+            });
     };
 
     const handleToggleSubtask = (subtask) => {

--- a/resources/js/Pages/Tasks/Index.jsx
+++ b/resources/js/Pages/Tasks/Index.jsx
@@ -1277,6 +1277,16 @@ export default function Index({ tasks = [], categories, tags = [], filters }) {
                 show={showSubtaskModal}
                 onClose={() => setShowSubtaskModal(false)}
                 task={selectedTask}
+                onSaved={() => {
+                    if (!selectedTask) return;
+                    // Bump the subtask count in place so the card reflects the
+                    // new subtask without reloading the page.
+                    handleTaskUpdate({
+                        ...selectedTask,
+                        subtasks_count:
+                            (selectedTask.subtasks_count || 0) + 1,
+                    });
+                }}
             />
 
             <Toast />


### PR DESCRIPTION
Adding a subtask previously fired an Inertia visit whose controller redirect forced Inertia to re-fetch the page's props, causing a reload/flicker (and `QuickSubtaskModal` did a full reload with no optimistic update). Now `SubtaskController@store` returns the created subtask as JSON for non-Inertia XHR requests, and both `SubtaskManager` and `QuickSubtaskModal` save via a background `axios` call instead of an Inertia visit. The new subtask row appears instantly and the page never reloads; `Tasks/Index` bumps the card's subtask count in place via a new `onSaved` callback. The existing Inertia redirect/flash path is preserved for backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)