### PR TITLE
Fix extra bottom space in Tasks page modals

### DIFF
--- a/resources/js/Components/TaskEditModal.jsx
+++ b/resources/js/Components/TaskEditModal.jsx
@@ -102,7 +102,7 @@ export default function TaskEditModal({
     };
 
     return (
-        <Modal show={show} onClose={onClose} maxWidth="2xl">
+        <Modal show={show} onClose={onClose} maxWidth="2xl" alignTop>
             <div className="max-h-[70vh] overflow-y-auto">
                 <form onSubmit={handleSubmit} className="p-6">
                     <h2 className="text-lg font-medium text-light-primary dark:text-dark-primary mb-2">

--- a/resources/js/Components/TaskModal.jsx
+++ b/resources/js/Components/TaskModal.jsx
@@ -125,7 +125,7 @@ export default function TaskModal({
     };
 
     return (
-        <Modal show={show} onClose={handleClose} maxWidth="2xl">
+        <Modal show={show} onClose={handleClose} maxWidth="2xl" alignTop>
             <div className="max-h-[70vh] overflow-y-auto">
                 <form onSubmit={handleSubmit} className="p-6">
                     <h2 className="text-lg font-medium text-light-primary dark:text-dark-primary mb-2">


### PR DESCRIPTION
The create and edit task modals rendered a large empty gap below their action buttons because the shared `Modal` shell's flex container defaults to `align-items: stretch`, stretching short-content panels to the full viewport height. This opts both modals into the `Modal` component's existing `alignTop` prop so their panels size to their content instead. No new CSS or dependencies — just the intended pattern already used by `WelcomeModal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)