### PR TITLE
Add customizable widget dashboard and AI daily summary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,3 +75,12 @@ AWS_USE_PATH_STYLE_ENDPOINT=false
 VITE_APP_NAME="${APP_NAME}"
 VITE_WEATHER_API_KEY=""
 VITE_NEWS_ORG_API=""
+
+# AI daily summary (provider-agnostic). AI_PROVIDER selects the active driver.
+AI_PROVIDER=anthropic
+ANTHROPIC_API_KEY=
+ANTHROPIC_MODEL=claude-sonnet-5
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-4o-mini
+GEMINI_API_KEY=
+GEMINI_MODEL=gemini-1.5-flash

--- a/app/Console/Commands/GenerateDailySummaries.php
+++ b/app/Console/Commands/GenerateDailySummaries.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\GenerateDailySummaryJob;
+use App\Models\User;
+use App\Repositories\Contracts\DailySummaryRepositoryInterface;
+use App\Services\DailySummaryService;
+use Illuminate\Console\Command;
+
+class GenerateDailySummaries extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:generate-daily-summaries';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Dispatch AI daily summary generation for users whose local time matches their preference';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(
+        DailySummaryService $summaryService,
+        DailySummaryRepositoryInterface $repository
+    ): int {
+        $dispatched = 0;
+
+        User::where('daily_summary_enabled', true)
+            ->chunkById(200, function ($users) use ($summaryService, $repository, &$dispatched) {
+                foreach ($users as $user) {
+                    if (! $summaryService->userCanUseSummary($user)) {
+                        continue;
+                    }
+
+                    $userNow = $user->nowInUserTimezone();
+                    $currentHourLabel = $userNow->format('H:00');
+                    $preferredHourLabel = $this->normalizeToHour($user->daily_summary_time);
+
+                    if ($currentHourLabel !== $preferredHourLabel) {
+                        continue;
+                    }
+
+                    // Skip if today's summary was already generated.
+                    if ($repository->findForUserOnDate($user->id, $userNow)) {
+                        continue;
+                    }
+
+                    GenerateDailySummaryJob::dispatch($user->id);
+                    $dispatched++;
+                }
+            });
+
+        $this->info("Dispatched {$dispatched} daily summary job(s).");
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Reduce a stored "HH:MM" (or "HH:MM:SS") preference to a top-of-hour label.
+     */
+    private function normalizeToHour(?string $time): string
+    {
+        if (! $time) {
+            return '08:00';
+        }
+
+        $hour = explode(':', $time)[0] ?? '08';
+
+        return str_pad($hour, 2, '0', STR_PAD_LEFT).':00';
+    }
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -6,57 +6,43 @@ use App\Models\Task;
 use App\Modules\Finance\Models\FinanceAccount;
 use App\Modules\Finance\Models\FinanceTransaction;
 use App\Services\CategoryService;
+use App\Services\DailySummaryService;
+use App\Services\DashboardService;
 use App\Services\TaskService;
-use Illuminate\Http\Request;
+use App\Support\DashboardWidgets;
 use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 use Inertia\Response;
-use Carbon\Carbon;
 
 class DashboardController extends Controller
 {
     public function __construct(
         private TaskService $taskService,
-        private CategoryService $categoryService
+        private CategoryService $categoryService,
+        private DashboardService $dashboardService,
+        private DailySummaryService $dailySummaryService,
     ) {}
+
     public function index(): Response
     {
         $userId = Auth::id();
         $user = Auth::user();
-        $userToday = $user->todayInUserTimezone();
 
-        // Get dashboard data using services
-        $todayTasks = $this->taskService->getTodayTasksForUser($userId, 5);
-        $overdueTasks = $this->taskService->getOverdueTasksForUser($userId, 5);
-        $upcomingTasks = $this->taskService->getUpcomingTasksForUser($userId, 5);
-        $currentTasks = $this->taskService->getInProgressTasksForUser($userId, 3);
+        // Resolve the widget layout: saved layout (if any) merged with the
+        // registry so newly-added widgets appear for existing users.
+        $widgetLayout = DashboardWidgets::normalizeLayout($user->dashboard_widgets);
 
-        // Get task statistics
+        $enabledKeys = collect($widgetLayout)
+            ->filter(fn (array $row): bool => (bool) ($row['enabled'] ?? false))
+            ->pluck('key')
+            ->all();
+
+        $widgetData = $this->dashboardService->getWidgetData($user, $enabledKeys);
+
+        // Categories for quick task creation + onboarding checklist.
+        $categories = $this->categoryService->getActiveCategoriesForUser($userId);
         $stats = $this->taskService->getTaskStatsForUser($userId);
 
-        // Get categories for quick task creation
-        $categories = $this->categoryService->getActiveCategoriesForUser($userId);
-
-        // Get weekly tasks for schedule modal
-        $weekStart = $userToday->copy();
-        $weekEnd = $userToday->copy()->addDays(7);
-        $weeklyTasks = $this->taskService->getTasksInDateRange($userId, $weekStart, $weekEnd);
-
-        $upcomingPayments = FinanceTransaction::with(['category', 'loan'])
-            ->where('user_id', $userId)
-            ->where('type', 'expense')
-            ->where('is_recurring', true)
-            ->whereBetween('occurred_at', [
-                $userToday->copy()->startOfDay(),
-                $userToday->copy()->addDays(30)->endOfDay(),
-            ])
-            ->orderBy('occurred_at')
-            ->limit(5)
-            ->get();
-
-        // Getting Started checklist state, computed from real user data. The
-        // frontend combines these booleans with `tutorial_progress` to decide
-        // which onboarding steps are done and whether to show the widget.
         $gettingStarted = [
             'hasTask' => ($stats['total_tasks'] ?? 0) > 0,
             'hasCategory' => $categories->isNotEmpty(),
@@ -65,16 +51,46 @@ class DashboardController extends Controller
             'hasSampleData' => Task::where('user_id', $userId)->where('is_sample', true)->exists(),
         ];
 
+        // AI daily summary (pro-gated). Only computed when the user is entitled.
+        $canUseDailySummary = $this->dailySummaryService->userCanUseSummary($user);
+        $dailySummary = null;
+
+        if ($canUseDailySummary) {
+            $summary = $this->dailySummaryService->getCachedForToday($user);
+            $dailySummary = $summary ? [
+                'content' => $summary->content,
+                'provider' => $summary->provider,
+                'model' => $summary->model,
+                'generated_at' => optional($summary->generated_at)->toIso8601String(),
+            ] : null;
+        }
+
         return Inertia::render('Dashboard', [
-            'currentTasks' => $currentTasks->values()->all(),
-            'todayTasks' => $todayTasks->values()->all(),
-            'overdueTasks' => $overdueTasks->values()->all(),
-            'upcomingTasks' => $upcomingTasks->values()->all(),
-            'weeklyTasks' => $weeklyTasks->values()->all(),
-            'upcomingPayments' => $upcomingPayments->values()->all(),
-            'stats' => $stats,
             'categories' => $categories->values()->all(),
             'gettingStarted' => $gettingStarted,
+            'availableWidgets' => DashboardWidgets::availableWidgets(),
+            'widgetLayout' => $widgetLayout,
+            'widgetData' => $widgetData,
+            'dailySummary' => $dailySummary,
+            'canUseDailySummary' => $canUseDailySummary,
+            'dailySummaryEnabled' => (bool) ($user->daily_summary_enabled ?? true),
+            'dailySummaryTime' => $this->formatSummaryTime($user->daily_summary_time),
         ]);
+    }
+
+    /**
+     * Normalize the stored summary time to an "HH:MM" string for the frontend.
+     */
+    private function formatSummaryTime(?string $time): string
+    {
+        if (! $time) {
+            return '08:00';
+        }
+
+        $parts = explode(':', $time);
+        $hour = str_pad($parts[0] ?? '08', 2, '0', STR_PAD_LEFT);
+        $minute = str_pad($parts[1] ?? '00', 2, '0', STR_PAD_LEFT);
+
+        return "{$hour}:{$minute}";
     }
 }

--- a/app/Http/Controllers/DashboardLayoutController.php
+++ b/app/Http/Controllers/DashboardLayoutController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\UpdateDashboardLayoutRequest;
+use App\Services\DailySummaryService;
+use App\Services\UserService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class DashboardLayoutController extends Controller
+{
+    public function __construct(
+        private UserService $userService,
+        private DailySummaryService $dailySummaryService,
+    ) {}
+
+    /**
+     * Persist the authenticated user's dashboard widget layout.
+     */
+    public function update(UpdateDashboardLayoutRequest $request): RedirectResponse
+    {
+        $this->userService->updateUserPreferences($request->user(), [
+            'dashboard_widgets' => $request->validated('widgets'),
+        ]);
+
+        return back();
+    }
+
+    /**
+     * Synchronously regenerate the user's AI daily summary on demand.
+     */
+    public function refreshSummary(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+
+        if (! $this->dailySummaryService->userCanUseSummary($user)) {
+            return back()->with('error', 'The daily summary is not available on your plan.');
+        }
+
+        $this->dailySummaryService->generateForUser($user);
+
+        return back();
+    }
+}

--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -26,6 +26,8 @@ class ProfileUpdateRequest extends FormRequest
                 Rule::unique(User::class)->ignore($this->user()->id),
             ],
             'timezone' => ['required', 'string', 'timezone'],
+            'daily_summary_enabled' => ['sometimes', 'boolean'],
+            'daily_summary_time' => ['sometimes', 'date_format:H:i'],
         ];
     }
 }

--- a/app/Http/Requests/UpdateDashboardLayoutRequest.php
+++ b/app/Http/Requests/UpdateDashboardLayoutRequest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Support\DashboardWidgets;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+
+class UpdateDashboardLayoutRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'widgets' => ['required', 'array', 'min:1'],
+            'widgets.*.key' => ['required', 'string', Rule::in(DashboardWidgets::keys())],
+            'widgets.*.size' => ['required', 'string', Rule::in(['sm', 'md', 'lg'])],
+            'widgets.*.enabled' => ['required', 'boolean'],
+        ];
+    }
+
+    /**
+     * Additional cross-field validation: the chosen size must be within the
+     * widget's own allowed sizes (which vary per widget).
+     */
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator) {
+            foreach ((array) $this->input('widgets', []) as $index => $widget) {
+                $key = $widget['key'] ?? null;
+                $size = $widget['size'] ?? null;
+
+                if (! is_string($key)) {
+                    continue;
+                }
+
+                $allowed = DashboardWidgets::allowedSizesFor($key);
+
+                if ($allowed !== [] && ! in_array($size, $allowed, true)) {
+                    $validator->errors()->add(
+                        "widgets.{$index}.size",
+                        "The selected size is not allowed for the {$key} widget."
+                    );
+                }
+            }
+        });
+    }
+
+    /**
+     * Normalize the enabled flag so string/int booleans validate cleanly.
+     */
+    protected function prepareForValidation(): void
+    {
+        $widgets = $this->input('widgets');
+
+        if (! is_array($widgets)) {
+            return;
+        }
+
+        $this->merge([
+            'widgets' => array_map(function ($widget) {
+                if (is_array($widget) && array_key_exists('enabled', $widget)) {
+                    $widget['enabled'] = filter_var(
+                        $widget['enabled'],
+                        FILTER_VALIDATE_BOOLEAN,
+                        FILTER_NULL_ON_FAILURE
+                    ) ?? $widget['enabled'];
+                }
+
+                return $widget;
+            }, $widgets),
+        ]);
+    }
+}

--- a/app/Jobs/GenerateDailySummaryJob.php
+++ b/app/Jobs/GenerateDailySummaryJob.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\User;
+use App\Services\DailySummaryService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class GenerateDailySummaryJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public int $userId
+    ) {}
+
+    public function handle(DailySummaryService $service): void
+    {
+        $user = User::find($this->userId);
+
+        if (! $user) {
+            return;
+        }
+
+        if (! $service->userCanUseSummary($user)) {
+            return;
+        }
+
+        $service->generateForUser($user);
+    }
+}

--- a/app/Models/DailySummary.php
+++ b/app/Models/DailySummary.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class DailySummary extends Model
+{
+    /** @use HasFactory<\Database\Factories\DailySummaryFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'summary_date',
+        'content',
+        'provider',
+        'model',
+        'generated_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'summary_date' => 'date',
+            'generated_at' => 'datetime',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -32,6 +32,9 @@ class User extends Authenticatable
         'role',
         'timezone',
         'news_category',
+        'dashboard_widgets',
+        'daily_summary_enabled',
+        'daily_summary_time',
         'tutorial_progress',
         'last_active_at',
     ];
@@ -57,6 +60,8 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
             'tutorial_progress' => 'encrypted:array',
+            'dashboard_widgets' => 'array',
+            'daily_summary_enabled' => 'boolean',
             'last_active_at' => 'datetime',
         ];
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -33,6 +33,20 @@ class AppServiceProvider extends ServiceProvider
             \App\Repositories\Eloquent\TagRepository::class
         );
 
+        $this->app->bind(
+            \App\Repositories\Contracts\DailySummaryRepositoryInterface::class,
+            \App\Repositories\Eloquent\DailySummaryRepository::class
+        );
+
+        // AI text-generation manager + default driver bound to the contract.
+        $this->app->singleton(\App\Services\Ai\AiManager::class, function ($app) {
+            return new \App\Services\Ai\AiManager($app);
+        });
+
+        $this->app->bind(\App\Services\Ai\Contracts\TextGenerator::class, function ($app) {
+            return $app->make(\App\Services\Ai\AiManager::class)->driver();
+        });
+
         // Register Services (no interfaces needed for services)
         $this->app->singleton(\App\Services\ReminderService::class);
         $this->app->singleton(\App\Services\SubtaskService::class);

--- a/app/Repositories/Contracts/DailySummaryRepositoryInterface.php
+++ b/app/Repositories/Contracts/DailySummaryRepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Repositories\Contracts;
+
+use App\Models\DailySummary;
+use Carbon\CarbonInterface;
+
+interface DailySummaryRepositoryInterface
+{
+    /**
+     * Find a stored summary for a user on a given date.
+     */
+    public function findForUserOnDate(int $userId, CarbonInterface $date): ?DailySummary;
+
+    /**
+     * Create or update the summary for a user on a given date.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function upsertForUserOnDate(int $userId, CarbonInterface $date, array $attributes): DailySummary;
+}

--- a/app/Repositories/Eloquent/DailySummaryRepository.php
+++ b/app/Repositories/Eloquent/DailySummaryRepository.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Repositories\Eloquent;
+
+use App\Models\DailySummary;
+use App\Repositories\Contracts\DailySummaryRepositoryInterface;
+use Carbon\CarbonInterface;
+
+class DailySummaryRepository implements DailySummaryRepositoryInterface
+{
+    public function findForUserOnDate(int $userId, CarbonInterface $date): ?DailySummary
+    {
+        return DailySummary::where('user_id', $userId)
+            ->whereDate('summary_date', $date->toDateString())
+            ->first();
+    }
+
+    public function upsertForUserOnDate(int $userId, CarbonInterface $date, array $attributes): DailySummary
+    {
+        // Match on the calendar day via whereDate so the time component of the
+        // stored `date` column never causes a false miss (portable across
+        // MySQL/SQLite/Postgres). Falls through to a create when none exists.
+        $summary = $this->findForUserOnDate($userId, $date);
+
+        if ($summary) {
+            $summary->update($attributes);
+
+            return $summary;
+        }
+
+        return DailySummary::create(array_merge($attributes, [
+            'user_id' => $userId,
+            'summary_date' => $date->toDateString(),
+        ]));
+    }
+}

--- a/app/Repositories/Eloquent/UserRepository.php
+++ b/app/Repositories/Eloquent/UserRepository.php
@@ -179,7 +179,13 @@ class UserRepository implements UserRepositoryInterface
      */
     public function updatePreferences(User $user, array $preferences): User
     {
-        $allowedPreferences = ['timezone', 'news_category'];
+        $allowedPreferences = [
+            'timezone',
+            'news_category',
+            'dashboard_widgets',
+            'daily_summary_enabled',
+            'daily_summary_time',
+        ];
         $filteredPreferences = array_intersect_key($preferences, array_flip($allowedPreferences));
 
         $user->update($filteredPreferences);

--- a/app/Services/Ai/AiManager.php
+++ b/app/Services/Ai/AiManager.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Services\Ai;
+
+use App\Services\Ai\Drivers\AnthropicDriver;
+use App\Services\Ai\Drivers\GeminiDriver;
+use App\Services\Ai\Drivers\OpenAiDriver;
+use Illuminate\Support\Manager;
+
+class AiManager extends Manager
+{
+    /**
+     * The default text-generation driver name.
+     */
+    public function getDefaultDriver(): string
+    {
+        return (string) $this->config->get('ai.default', 'anthropic');
+    }
+
+    public function createAnthropicDriver(): AnthropicDriver
+    {
+        return new AnthropicDriver(
+            $this->config->get('ai.providers.anthropic.key'),
+            (string) $this->config->get('ai.providers.anthropic.model', 'claude-sonnet-5'),
+        );
+    }
+
+    public function createOpenaiDriver(): OpenAiDriver
+    {
+        return new OpenAiDriver(
+            $this->config->get('ai.providers.openai.key'),
+            (string) $this->config->get('ai.providers.openai.model', 'gpt-4o-mini'),
+        );
+    }
+
+    public function createGeminiDriver(): GeminiDriver
+    {
+        return new GeminiDriver(
+            $this->config->get('ai.providers.gemini.key'),
+            (string) $this->config->get('ai.providers.gemini.model', 'gemini-1.5-flash'),
+        );
+    }
+}

--- a/app/Services/Ai/Contracts/TextGenerator.php
+++ b/app/Services/Ai/Contracts/TextGenerator.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Services\Ai\Contracts;
+
+interface TextGenerator
+{
+    /**
+     * Generate text from a system prompt and a user prompt.
+     *
+     * @param  array<string, mixed>  $options
+     *
+     * @throws \Throwable when the provider fails or returns a non-2xx response.
+     */
+    public function generate(string $system, string $prompt, array $options = []): string;
+}

--- a/app/Services/Ai/Drivers/AnthropicDriver.php
+++ b/app/Services/Ai/Drivers/AnthropicDriver.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Services\Ai\Drivers;
+
+use App\Services\Ai\Contracts\TextGenerator;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+class AnthropicDriver implements TextGenerator
+{
+    public function __construct(
+        private ?string $apiKey,
+        private string $model = 'claude-sonnet-5'
+    ) {}
+
+    public function generate(string $system, string $prompt, array $options = []): string
+    {
+        if (empty($this->apiKey)) {
+            throw new RuntimeException('Anthropic API key is not configured.');
+        }
+
+        $response = Http::withHeaders([
+            'x-api-key' => $this->apiKey,
+            'anthropic-version' => '2023-06-01',
+            'content-type' => 'application/json',
+        ])
+            ->timeout(30)
+            ->post('https://api.anthropic.com/v1/messages', [
+                'model' => $options['model'] ?? $this->model,
+                'max_tokens' => $options['max_tokens'] ?? 1024,
+                'system' => $system,
+                'messages' => [
+                    ['role' => 'user', 'content' => $prompt],
+                ],
+            ]);
+
+        $response->throw();
+
+        return (string) $response->json('content.0.text', '');
+    }
+}

--- a/app/Services/Ai/Drivers/GeminiDriver.php
+++ b/app/Services/Ai/Drivers/GeminiDriver.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Services\Ai\Drivers;
+
+use App\Services\Ai\Contracts\TextGenerator;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+class GeminiDriver implements TextGenerator
+{
+    public function __construct(
+        private ?string $apiKey,
+        private string $model = 'gemini-1.5-flash'
+    ) {}
+
+    public function generate(string $system, string $prompt, array $options = []): string
+    {
+        if (empty($this->apiKey)) {
+            throw new RuntimeException('Gemini API key is not configured.');
+        }
+
+        $model = $options['model'] ?? $this->model;
+        $url = "https://generativelanguage.googleapis.com/v1beta/models/{$model}:generateContent?key={$this->apiKey}";
+
+        $response = Http::timeout(30)
+            ->post($url, [
+                'systemInstruction' => [
+                    'parts' => [['text' => $system]],
+                ],
+                'contents' => [
+                    [
+                        'role' => 'user',
+                        'parts' => [['text' => $prompt]],
+                    ],
+                ],
+            ]);
+
+        $response->throw();
+
+        return (string) $response->json('candidates.0.content.parts.0.text', '');
+    }
+}

--- a/app/Services/Ai/Drivers/OpenAiDriver.php
+++ b/app/Services/Ai/Drivers/OpenAiDriver.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Services\Ai\Drivers;
+
+use App\Services\Ai\Contracts\TextGenerator;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+class OpenAiDriver implements TextGenerator
+{
+    public function __construct(
+        private ?string $apiKey,
+        private string $model = 'gpt-4o-mini'
+    ) {}
+
+    public function generate(string $system, string $prompt, array $options = []): string
+    {
+        if (empty($this->apiKey)) {
+            throw new RuntimeException('OpenAI API key is not configured.');
+        }
+
+        $response = Http::withToken($this->apiKey)
+            ->timeout(30)
+            ->post('https://api.openai.com/v1/chat/completions', [
+                'model' => $options['model'] ?? $this->model,
+                'max_tokens' => $options['max_tokens'] ?? 1024,
+                'messages' => [
+                    ['role' => 'system', 'content' => $system],
+                    ['role' => 'user', 'content' => $prompt],
+                ],
+            ]);
+
+        $response->throw();
+
+        return (string) $response->json('choices.0.message.content', '');
+    }
+}

--- a/app/Services/DailySummaryService.php
+++ b/app/Services/DailySummaryService.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\DailySummary;
+use App\Models\User;
+use App\Repositories\Contracts\DailySummaryRepositoryInterface;
+use App\Services\Ai\Contracts\TextGenerator;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class DailySummaryService
+{
+    public function __construct(
+        private DashboardService $dashboardService,
+        private DailySummaryRepositoryInterface $repository,
+        private TextGenerator $textGenerator,
+    ) {}
+
+    /**
+     * Whether the user is entitled to the AI daily summary (a "pro" feature).
+     *
+     * Centralized so gating the feature to a paid plan later is a one-line
+     * change. Today it returns true for everyone via the open-beta flag.
+     */
+    public function userCanUseSummary(User $user): bool
+    {
+        // Open beta: treat everyone as entitled while we test publicly.
+        if (config('ai.daily_summary_open_beta', true)) {
+            return true;
+        }
+
+        // TODO: gate to pro plan. When a real paid tier/subscription exists,
+        // replace this with the entitlement check (mirroring the tier pattern
+        // in App\Modules\Finance\Services\FinanceAccessService::getTier()), e.g.
+        // return $user->hasProPlan();
+        return false;
+    }
+
+    /**
+     * Generate (and persist) the daily summary for a user. Falls back to a
+     * deterministic template if the AI provider fails, so the dashboard never
+     * breaks on provider errors.
+     */
+    public function generateForUser(User $user, ?Carbon $date = null): DailySummary
+    {
+        $date = $date ? $date->copy() : $user->nowInUserTimezone();
+
+        $context = $this->dashboardService->buildDaySummaryContext($user);
+        $provider = (string) config('ai.default', 'anthropic');
+        $model = (string) config("ai.providers.{$provider}.model", $provider);
+
+        $system = 'You are a concise daily planner assistant. Write a friendly 2-4 sentence summary of the user\'s day.';
+        $prompt = $this->buildPrompt($user, $context);
+
+        try {
+            $content = trim($this->textGenerator->generate($system, $prompt));
+
+            if ($content === '') {
+                throw new \RuntimeException('AI provider returned an empty summary.');
+            }
+        } catch (Throwable $e) {
+            Log::warning('Daily summary generation failed; using template fallback.', [
+                'user_id' => $user->id,
+                'provider' => $provider,
+                'error' => $e->getMessage(),
+            ]);
+
+            $content = $this->templateSummary($context);
+            $provider = 'fallback';
+            $model = 'template';
+        }
+
+        return $this->repository->upsertForUserOnDate($user->id, $date, [
+            'content' => $content,
+            'provider' => $provider,
+            'model' => $model,
+            'generated_at' => now(),
+        ]);
+    }
+
+    /**
+     * The cached summary for the user's current local day, if one exists.
+     */
+    public function getCachedForToday(User $user): ?DailySummary
+    {
+        return $this->repository->findForUserOnDate($user->id, $user->nowInUserTimezone());
+    }
+
+    /**
+     * Build the user prompt from the gathered day context.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    private function buildPrompt(User $user, array $context): string
+    {
+        $counts = $this->counts($context);
+
+        $lines = [];
+        $lines[] = "User: {$user->name}";
+        $lines[] = "Tasks due today: {$counts['today']}";
+        $lines[] = "Overdue tasks: {$counts['overdue']}";
+        $lines[] = "Upcoming tasks (next 7 days): {$counts['upcoming']}";
+        $lines[] = "Upcoming payments (next 30 days): {$counts['payments']}";
+        $lines[] = "Calendar items (next 7 days): {$counts['calendar']}";
+
+        $todayTitles = collect($context['today_tasks'] ?? [])
+            ->take(5)
+            ->map(fn ($task) => '- '.(string) ($task->title ?? 'Untitled'))
+            ->all();
+
+        if (! empty($todayTitles)) {
+            $lines[] = "Today's task titles:";
+            $lines = array_merge($lines, $todayTitles);
+        }
+
+        $lines[] = '';
+        $lines[] = 'Summarize the day for the user in 2-4 encouraging sentences.';
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * Deterministic fallback summary used when the AI provider is unavailable.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    private function templateSummary(array $context): string
+    {
+        $counts = $this->counts($context);
+
+        return sprintf(
+            'You have %d task%s due today, %d overdue, and %d upcoming this week. There %s %d payment%s scheduled in the next 30 days. Have a productive day!',
+            $counts['today'],
+            $counts['today'] === 1 ? '' : 's',
+            $counts['overdue'],
+            $counts['upcoming'],
+            $counts['payments'] === 1 ? 'is' : 'are',
+            $counts['payments'],
+            $counts['payments'] === 1 ? '' : 's',
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array{today: int, overdue: int, upcoming: int, payments: int, calendar: int}
+     */
+    private function counts(array $context): array
+    {
+        return [
+            'today' => $this->count($context['today_tasks'] ?? []),
+            'overdue' => $this->count($context['overdue_tasks'] ?? []),
+            'upcoming' => $this->count($context['upcoming_tasks'] ?? []),
+            'payments' => $this->count($context['payments'] ?? []),
+            'calendar' => $this->count($context['calendar'] ?? []),
+        ];
+    }
+
+    private function count(mixed $value): int
+    {
+        return is_countable($value) ? count($value) : 0;
+    }
+}

--- a/app/Services/DashboardService.php
+++ b/app/Services/DashboardService.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use App\Modules\Finance\Models\FinanceTransaction;
+use App\Modules\Finance\Services\FinanceService;
+
+/**
+ * Composes existing services into the per-widget payloads consumed by the
+ * dashboard. This class holds no business logic of its own; it only orchestrates
+ * TaskService, ReportingService and the Finance module.
+ */
+class DashboardService
+{
+    public function __construct(
+        private TaskService $taskService,
+        private ReportingService $reportingService,
+        private FinanceService $financeService,
+    ) {}
+
+    /**
+     * Build a map of widget key => payload, computing data only for the enabled
+     * keys. Client-only widgets (pomodoro, weather) intentionally return nothing.
+     *
+     * @param  array<int, string>  $enabledKeys
+     * @return array<string, mixed>
+     */
+    public function getWidgetData(User $user, array $enabledKeys): array
+    {
+        $userId = $user->id;
+        $enabled = array_flip($enabledKeys);
+        $data = [];
+
+        if (isset($enabled['task_stats'])) {
+            $data['task_stats'] = $this->taskService->getTaskStatsForUser($userId);
+        }
+
+        if (isset($enabled['today_tasks'])) {
+            $data['today_tasks'] = $this->taskService->getTodayTasksForUser($userId, 5)->values()->all();
+        }
+
+        if (isset($enabled['overdue_tasks'])) {
+            $data['overdue_tasks'] = $this->taskService->getOverdueTasksForUser($userId, 5)->values()->all();
+        }
+
+        if (isset($enabled['upcoming_tasks'])) {
+            $data['upcoming_tasks'] = $this->taskService->getUpcomingTasksForUser($userId, 5)->values()->all();
+        }
+
+        if (isset($enabled['in_progress'])) {
+            $data['in_progress'] = $this->taskService->getInProgressTasksForUser($userId, 5)->values()->all();
+        }
+
+        if (isset($enabled['upcoming_payments'])) {
+            $data['upcoming_payments'] = $this->getUpcomingPayments($user)->values()->all();
+        }
+
+        if (isset($enabled['budgets'])) {
+            $finance = $this->financeService->getDashboardData($userId);
+            $data['budgets'] = [
+                'summary' => $finance['summary'],
+                'budgets' => $finance['budgets'],
+            ];
+        }
+
+        if (isset($enabled['calendar'])) {
+            $data['calendar'] = $this->getCalendarItems($user);
+        }
+
+        if (isset($enabled['productivity'])) {
+            $end = $user->nowInUserTimezone();
+            $start = $end->copy()->subDays(6)->startOfDay();
+            $data['productivity'] = [
+                'trends' => $this->reportingService->getCompletionTrends($user, $start->copy(), $end->copy()),
+                'metrics' => $this->reportingService->getProductivityMetrics($user, $start->copy(), $end->copy()),
+            ];
+        }
+
+        // pomodoro and weather are client-only widgets: no server payload.
+
+        return $data;
+    }
+
+    /**
+     * Recurring expense transactions falling in the next 30 days.
+     */
+    public function getUpcomingPayments(User $user)
+    {
+        $userToday = $user->todayInUserTimezone();
+
+        return FinanceTransaction::with(['category', 'loan'])
+            ->where('user_id', $user->id)
+            ->where('type', 'expense')
+            ->where('is_recurring', true)
+            ->whereBetween('occurred_at', [
+                $userToday->copy()->startOfDay(),
+                $userToday->copy()->addDays(30)->endOfDay(),
+            ])
+            ->orderBy('occurred_at')
+            ->limit(5)
+            ->get();
+    }
+
+    /**
+     * Combined task + transaction occurrences for the next 7 days, as a flat
+     * list of {date, title, type} ordered by date.
+     *
+     * @return array<int, array{date: string, title: string, type: string}>
+     */
+    public function getCalendarItems(User $user): array
+    {
+        $userNow = $user->toUserTimezone(now());
+        $rangeStart = $userNow->copy()->utc();
+        $rangeEnd = $userNow->copy()->addDays(7)->utc();
+
+        $items = collect();
+
+        $tasks = $user->tasks()->get();
+        foreach ($tasks as $task) {
+            foreach ($task->getOccurrencesInRange($rangeStart->copy(), $rangeEnd->copy()) as $occurrence) {
+                if (! $occurrence->due_date) {
+                    continue;
+                }
+
+                $items->push([
+                    'date' => $user->toUserTimezone($occurrence->due_date)->format('Y-m-d'),
+                    'title' => (string) $occurrence->title,
+                    'type' => 'task',
+                ]);
+            }
+        }
+
+        $transactions = FinanceTransaction::with('category')
+            ->where('user_id', $user->id)
+            ->get();
+        foreach ($transactions as $transaction) {
+            foreach ($transaction->getOccurrencesInRange($rangeStart->copy(), $rangeEnd->copy()) as $occurrence) {
+                if (! $occurrence->occurred_at) {
+                    continue;
+                }
+
+                $items->push([
+                    'date' => $user->toUserTimezone($occurrence->occurred_at)->format('Y-m-d'),
+                    'title' => (string) ($occurrence->description ?? 'Transaction'),
+                    'type' => 'transaction',
+                ]);
+            }
+        }
+
+        return $items
+            ->sortBy('date')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Compact plaintext description of the user's day, used to prompt the AI
+     * summary generator.
+     */
+    public function buildDaySummaryContext(User $user): array
+    {
+        $userId = $user->id;
+
+        $today = $this->taskService->getTodayTasksForUser($userId);
+        $overdue = $this->taskService->getOverdueTasksForUser($userId);
+        $upcoming = $this->taskService->getUpcomingTasksForUser($userId);
+        $payments = $this->getUpcomingPayments($user);
+        $finance = $this->financeService->getDashboardData($userId);
+        $calendar = $this->getCalendarItems($user);
+
+        return [
+            'today_tasks' => $today,
+            'overdue_tasks' => $overdue,
+            'upcoming_tasks' => $upcoming,
+            'payments' => $payments,
+            'budgets' => $finance['budgets'] ?? [],
+            'calendar' => $calendar,
+        ];
+    }
+}

--- a/app/Support/DashboardWidgets.php
+++ b/app/Support/DashboardWidgets.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * Canonical registry of dashboard widgets.
+ *
+ * This is the single source of truth for which widgets exist, their default
+ * size, the sizes they support, and whether they are enabled by default. Both
+ * the save-layout validation and the dashboard props are derived from here so
+ * that adding a widget only requires editing this list.
+ */
+class DashboardWidgets
+{
+    /**
+     * The canonical widget definitions, in default display order.
+     *
+     * @return array<int, array{key: string, title: string, defaultSize: string, allowedSizes: array<int, string>, defaultEnabled: bool}>
+     */
+    public static function all(): array
+    {
+        $full = ['sm', 'md', 'lg'];
+        $compact = ['sm', 'md'];
+
+        return [
+            ['key' => 'task_stats', 'title' => 'Task Stats', 'defaultSize' => 'lg', 'allowedSizes' => $full, 'defaultEnabled' => true],
+            ['key' => 'today_tasks', 'title' => 'Today', 'defaultSize' => 'md', 'allowedSizes' => $full, 'defaultEnabled' => true],
+            ['key' => 'overdue_tasks', 'title' => 'Overdue', 'defaultSize' => 'md', 'allowedSizes' => $full, 'defaultEnabled' => true],
+            ['key' => 'upcoming_tasks', 'title' => 'Upcoming', 'defaultSize' => 'md', 'allowedSizes' => $full, 'defaultEnabled' => true],
+            ['key' => 'in_progress', 'title' => 'In Progress', 'defaultSize' => 'md', 'allowedSizes' => $full, 'defaultEnabled' => true],
+            ['key' => 'upcoming_payments', 'title' => 'Upcoming Payments', 'defaultSize' => 'md', 'allowedSizes' => $full, 'defaultEnabled' => true],
+            ['key' => 'budgets', 'title' => 'Budgets', 'defaultSize' => 'md', 'allowedSizes' => $full, 'defaultEnabled' => true],
+            ['key' => 'calendar', 'title' => 'Calendar', 'defaultSize' => 'md', 'allowedSizes' => $full, 'defaultEnabled' => true],
+            ['key' => 'productivity', 'title' => 'Productivity', 'defaultSize' => 'lg', 'allowedSizes' => $full, 'defaultEnabled' => true],
+            ['key' => 'pomodoro', 'title' => 'Pomodoro', 'defaultSize' => 'sm', 'allowedSizes' => $compact, 'defaultEnabled' => false],
+            ['key' => 'weather', 'title' => 'Weather', 'defaultSize' => 'sm', 'allowedSizes' => $compact, 'defaultEnabled' => false],
+        ];
+    }
+
+    /**
+     * All valid widget keys.
+     *
+     * @return array<int, string>
+     */
+    public static function keys(): array
+    {
+        return array_column(self::all(), 'key');
+    }
+
+    /**
+     * The default layout: ordered rows of {key, size, enabled}.
+     *
+     * @return array<int, array{key: string, size: string, enabled: bool}>
+     */
+    public static function defaultLayout(): array
+    {
+        return array_map(fn (array $widget): array => [
+            'key' => $widget['key'],
+            'size' => $widget['defaultSize'],
+            'enabled' => $widget['defaultEnabled'],
+        ], self::all());
+    }
+
+    /**
+     * Look up a single widget definition by key.
+     *
+     * @return array{key: string, title: string, defaultSize: string, allowedSizes: array<int, string>, defaultEnabled: bool}|null
+     */
+    public static function find(string $key): ?array
+    {
+        foreach (self::all() as $widget) {
+            if ($widget['key'] === $key) {
+                return $widget;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * The sizes allowed for a given widget key (empty if unknown).
+     *
+     * @return array<int, string>
+     */
+    public static function allowedSizesFor(string $key): array
+    {
+        return self::find($key)['allowedSizes'] ?? [];
+    }
+
+    /**
+     * The registry metadata exposed to the frontend as `availableWidgets`.
+     *
+     * @return array<int, array{key: string, title: string, defaultSize: string, allowedSizes: array<int, string>}>
+     */
+    public static function availableWidgets(): array
+    {
+        return array_map(fn (array $widget): array => [
+            'key' => $widget['key'],
+            'title' => $widget['title'],
+            'defaultSize' => $widget['defaultSize'],
+            'allowedSizes' => $widget['allowedSizes'],
+        ], self::all());
+    }
+
+    /**
+     * Merge a saved layout with the registry so that newly added widgets are
+     * appended (with their defaults) and any stale/unknown keys are dropped.
+     * Preserves the saved order and per-widget size/enabled choices.
+     *
+     * @param  array<int, array{key?: string, size?: string, enabled?: bool}>|null  $savedLayout
+     * @return array<int, array{key: string, size: string, enabled: bool}>
+     */
+    public static function normalizeLayout(?array $savedLayout): array
+    {
+        if (empty($savedLayout)) {
+            return self::defaultLayout();
+        }
+
+        $validKeys = self::keys();
+        $seen = [];
+        $normalized = [];
+
+        foreach ($savedLayout as $row) {
+            $key = $row['key'] ?? null;
+
+            if (! is_string($key) || ! in_array($key, $validKeys, true) || isset($seen[$key])) {
+                continue;
+            }
+
+            $definition = self::find($key);
+            $size = $row['size'] ?? $definition['defaultSize'];
+
+            if (! in_array($size, $definition['allowedSizes'], true)) {
+                $size = $definition['defaultSize'];
+            }
+
+            $normalized[] = [
+                'key' => $key,
+                'size' => $size,
+                'enabled' => (bool) ($row['enabled'] ?? $definition['defaultEnabled']),
+            ];
+            $seen[$key] = true;
+        }
+
+        // Append any registry widgets missing from the saved layout so new
+        // widgets surface for existing users without wiping their choices.
+        foreach (self::defaultLayout() as $defaultRow) {
+            if (! isset($seen[$defaultRow['key']])) {
+                $normalized[] = $defaultRow;
+            }
+        }
+
+        return $normalized;
+    }
+}

--- a/config/ai.php
+++ b/config/ai.php
@@ -1,0 +1,60 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default AI Provider
+    |--------------------------------------------------------------------------
+    |
+    | The text-generation provider used for features such as the AI daily
+    | summary. Supported: "anthropic", "openai", "gemini". Each provider is
+    | called over HTTP (via the Http facade) so no vendor SDK is required.
+    |
+    */
+
+    'default' => env('AI_PROVIDER', 'anthropic'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Daily Summary Open Beta
+    |--------------------------------------------------------------------------
+    |
+    | The AI daily summary is a "pro" feature, but during the open beta every
+    | user is entitled to it. Flip this to false (and implement the real tier
+    | check in DailySummaryService::userCanUseSummary) once a paid plan exists.
+    |
+    */
+
+    'daily_summary_open_beta' => env('AI_DAILY_SUMMARY_OPEN_BETA', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Providers
+    |--------------------------------------------------------------------------
+    |
+    | Per-provider credentials and default model. Keys are read from the
+    | environment so they never live in source control.
+    |
+    */
+
+    'providers' => [
+
+        'anthropic' => [
+            'key' => env('ANTHROPIC_API_KEY'),
+            'model' => env('ANTHROPIC_MODEL', 'claude-sonnet-5'),
+        ],
+
+        'openai' => [
+            'key' => env('OPENAI_API_KEY'),
+            'model' => env('OPENAI_MODEL', 'gpt-4o-mini'),
+        ],
+
+        'gemini' => [
+            'key' => env('GEMINI_API_KEY'),
+            'model' => env('GEMINI_MODEL', 'gemini-1.5-flash'),
+        ],
+
+    ],
+
+];

--- a/database/factories/DailySummaryFactory.php
+++ b/database/factories/DailySummaryFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\DailySummary>
+ */
+class DailySummaryFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'summary_date' => now()->toDateString(),
+            'content' => fake()->sentence(),
+            'provider' => 'anthropic',
+            'model' => 'claude-sonnet-5',
+            'generated_at' => now(),
+        ];
+    }
+}

--- a/database/migrations/2026_07_23_090000_add_dashboard_widgets_to_users_table.php
+++ b/database/migrations/2026_07_23_090000_add_dashboard_widgets_to_users_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->json('dashboard_widgets')->nullable()->after('news_category');
+            $table->boolean('daily_summary_enabled')->default(true)->after('dashboard_widgets');
+            $table->string('daily_summary_time')->default('08:00')->after('daily_summary_enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['dashboard_widgets', 'daily_summary_enabled', 'daily_summary_time']);
+        });
+    }
+};

--- a/database/migrations/2026_07_23_090100_create_daily_summaries_table.php
+++ b/database/migrations/2026_07_23_090100_create_daily_summaries_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('daily_summaries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->date('summary_date');
+            $table->text('content');
+            $table->string('provider');
+            $table->string('model');
+            $table->timestamp('generated_at');
+            $table->timestamps();
+
+            $table->index('user_id');
+            $table->unique(['user_id', 'summary_date']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('daily_summaries');
+    }
+};

--- a/resources/js/Components/DailySummary/DailySummaryCard.jsx
+++ b/resources/js/Components/DailySummary/DailySummaryCard.jsx
@@ -1,0 +1,192 @@
+import { useState } from "react";
+import { Link, router } from "@inertiajs/react";
+import { formatDistanceToNow, isValid, parseISO } from "date-fns";
+import { Sparkles, RefreshCw, Lock, BellOff, Wand2 } from "lucide-react";
+
+function relativeTime(value) {
+    if (!value) return null;
+    const parsed = typeof value === "string" ? parseISO(value) : new Date(value);
+    if (!isValid(parsed)) return null;
+    return formatDistanceToNow(parsed, { addSuffix: true });
+}
+
+/**
+ * AI daily-summary banner shown at the top of the dashboard.
+ *
+ * State precedence (highest first):
+ *   1. locked      — `canUseDailySummary === false` (plan entitlement) → upsell
+ *   2. disabled    — `dailySummaryEnabled === false` (user's own toggle)
+ *   3. empty       — no summary generated yet → Generate prompt
+ *   4. has-summary — render the content + provenance
+ *
+ * `canUseDailySummary` is treated as `true` when undefined so the banner keeps
+ * working before the backend entitlement prop lands.
+ */
+export default function DailySummaryCard({ summary = null, enabled = true, canUse = true }) {
+    const [loading, setLoading] = useState(false);
+
+    const generate = () => {
+        if (loading || canUse === false) return;
+        router.post(
+            route("dashboard.summary.refresh"),
+            {},
+            {
+                preserveScroll: true,
+                preserveState: true,
+                onStart: () => setLoading(true),
+                onFinish: () => setLoading(false),
+            }
+        );
+    };
+
+    const shellClass =
+        "card relative overflow-hidden bg-gradient-to-br from-primary-50 via-light-card to-secondary-50 p-5 dark:from-primary-900/20 dark:via-dark-card dark:to-secondary-900/20 sm:p-6";
+
+    // 1. Locked — plan entitlement (Pro feature).
+    if (canUse === false) {
+        return (
+            <section className={shellClass} aria-label="Daily AI summary (Pro)">
+                <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex items-start gap-3">
+                        <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-wevie-teal to-wevie-mint text-white">
+                            <Lock className="h-5 w-5" aria-hidden="true" />
+                        </span>
+                        <div>
+                            <div className="flex items-center gap-2">
+                                <h2 className="text-base font-semibold text-adaptive-primary sm:text-lg">
+                                    Daily AI Summary
+                                </h2>
+                                <span className="inline-flex items-center gap-1 rounded-full bg-gradient-to-r from-wevie-teal to-wevie-mint px-2 py-0.5 text-xs font-semibold text-white">
+                                    <Sparkles className="h-3 w-3" aria-hidden="true" />
+                                    Pro
+                                </span>
+                            </div>
+                            <p className="mt-1 max-w-lg text-sm text-adaptive-muted">
+                                Start each day with an AI recap of what’s due, what’s overdue, and
+                                where to focus. Upgrade to Pro to unlock daily summaries.
+                            </p>
+                        </div>
+                    </div>
+                    <button
+                        type="button"
+                        disabled
+                        aria-disabled="true"
+                        className="inline-flex flex-shrink-0 cursor-not-allowed items-center gap-2 rounded-xl bg-gradient-to-r from-wevie-teal to-wevie-mint px-4 py-2 text-sm font-medium text-white opacity-90"
+                        title="Upgrade to Pro to unlock daily summaries"
+                    >
+                        <Sparkles className="h-4 w-4" aria-hidden="true" />
+                        Upgrade to Pro
+                    </button>
+                </div>
+            </section>
+        );
+    }
+
+    // 2. Disabled — user turned the feature off.
+    if (enabled === false) {
+        return (
+            <section className={shellClass} aria-label="Daily AI summary (off)">
+                <div className="flex items-center gap-3">
+                    <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-light-hover text-adaptive-muted dark:bg-dark-hover">
+                        <BellOff className="h-5 w-5" aria-hidden="true" />
+                    </span>
+                    <div>
+                        <h2 className="text-base font-semibold text-adaptive-primary sm:text-lg">
+                            Daily summary is off
+                        </h2>
+                        <p className="mt-0.5 text-sm text-adaptive-muted">
+                            Turn it back on in{" "}
+                            <Link
+                                href={route("profile.edit")}
+                                className="font-medium text-wevie-teal underline-offset-2 hover:underline"
+                            >
+                                settings
+                            </Link>{" "}
+                            to get an AI recap each morning.
+                        </p>
+                    </div>
+                </div>
+            </section>
+        );
+    }
+
+    // 3. Empty — enabled + entitled, but nothing generated yet.
+    if (!summary || !summary.content) {
+        return (
+            <section className={shellClass} aria-label="Daily AI summary">
+                <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex items-start gap-3">
+                        <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-wevie-teal to-wevie-mint text-white">
+                            <Sparkles className="h-5 w-5" aria-hidden="true" />
+                        </span>
+                        <div>
+                            <h2 className="text-base font-semibold text-adaptive-primary sm:text-lg">
+                                Your daily summary is ready to write
+                            </h2>
+                            <p className="mt-1 max-w-lg text-sm text-adaptive-muted">
+                                Generate an AI recap of today’s tasks, deadlines, and priorities.
+                            </p>
+                        </div>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={generate}
+                        disabled={loading}
+                        className="btn-primary flex-shrink-0 disabled:cursor-not-allowed disabled:opacity-70"
+                    >
+                        {loading ? (
+                            <RefreshCw className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                        ) : (
+                            <Wand2 className="mr-2 h-4 w-4" aria-hidden="true" />
+                        )}
+                        {loading ? "Generating…" : "Generate summary"}
+                    </button>
+                </div>
+            </section>
+        );
+    }
+
+    // 4. Has summary.
+    const updated = relativeTime(summary.generated_at);
+    const provenance = [summary.provider, summary.model].filter(Boolean).join(" · ");
+
+    return (
+        <section className={shellClass} aria-label="Daily AI summary">
+            <div className="flex items-start justify-between gap-4">
+                <div className="flex items-center gap-2">
+                    <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-wevie-teal to-wevie-mint text-white">
+                        <Sparkles className="h-5 w-5" aria-hidden="true" />
+                    </span>
+                    <h2 className="text-base font-semibold text-adaptive-primary sm:text-lg">
+                        Your daily summary
+                    </h2>
+                </div>
+                <button
+                    type="button"
+                    onClick={generate}
+                    disabled={loading}
+                    aria-label="Refresh daily summary"
+                    className="inline-flex flex-shrink-0 items-center gap-1.5 rounded-xl border border-light-border/70 bg-light-card/70 px-3 py-1.5 text-sm font-medium text-adaptive-secondary transition-colors hover:bg-light-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-wevie-teal/40 disabled:cursor-not-allowed disabled:opacity-70 dark:border-dark-border/70 dark:bg-dark-card/70 dark:hover:bg-dark-hover"
+                >
+                    <RefreshCw
+                        className={`h-4 w-4 ${loading ? "animate-spin" : ""}`}
+                        aria-hidden="true"
+                    />
+                    <span className="hidden sm:inline">{loading ? "Refreshing…" : "Refresh"}</span>
+                </button>
+            </div>
+
+            <p className="mt-3 whitespace-pre-line text-sm leading-relaxed text-adaptive-secondary">
+                {summary.content}
+            </p>
+
+            {(updated || provenance) && (
+                <div className="mt-4 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-adaptive-muted">
+                    {updated && <span>Updated {updated}</span>}
+                    {updated && provenance && <span aria-hidden="true">·</span>}
+                    {provenance && <span className="uppercase tracking-wide">{provenance}</span>}
+                </div>
+            )}
+        </section>
+    );
+}

--- a/resources/js/Components/Dashboard/CustomizeDashboardModal.jsx
+++ b/resources/js/Components/Dashboard/CustomizeDashboardModal.jsx
@@ -1,0 +1,292 @@
+import { useEffect, useMemo, useState } from "react";
+import { router } from "@inertiajs/react";
+import { toast } from "react-toastify";
+import { Switch } from "@headlessui/react";
+import { GripVertical, X } from "lucide-react";
+import {
+    DndContext,
+    closestCenter,
+    KeyboardSensor,
+    PointerSensor,
+    useSensor,
+    useSensors,
+} from "@dnd-kit/core";
+import {
+    arrayMove,
+    SortableContext,
+    sortableKeyboardCoordinates,
+    verticalListSortingStrategy,
+    useSortable,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import Modal from "@/Components/Modal";
+
+const SIZE_LABELS = { sm: "S", md: "M", lg: "L" };
+
+/**
+ * Merge the server's available widgets with the ordered layout into a single
+ * editable list. Anything in `availableWidgets` but missing from the layout is
+ * appended (disabled) so users can still enable it.
+ */
+function buildRows(availableWidgets, widgetLayout) {
+    const available = availableWidgets ?? [];
+    const layout = widgetLayout ?? [];
+    const byKey = new Map(available.map((w) => [w.key, w]));
+    const seen = new Set();
+    const rows = [];
+
+    layout.forEach((item) => {
+        const meta = byKey.get(item.key);
+        if (!meta) return;
+        seen.add(item.key);
+        rows.push({
+            key: item.key,
+            title: meta.title,
+            allowedSizes: meta.allowedSizes?.length > 0 ? meta.allowedSizes : ["sm", "md", "lg"],
+            size: item.size ?? meta.defaultSize ?? "md",
+            enabled: item.enabled ?? true,
+        });
+    });
+
+    available.forEach((meta) => {
+        if (seen.has(meta.key)) return;
+        rows.push({
+            key: meta.key,
+            title: meta.title,
+            allowedSizes: meta.allowedSizes?.length > 0 ? meta.allowedSizes : ["sm", "md", "lg"],
+            size: meta.defaultSize ?? "md",
+            enabled: false,
+        });
+    });
+
+    return rows;
+}
+
+function SortableRow({ row, onToggle, onSize }) {
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+        id: row.key,
+    });
+
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.6 : 1,
+    };
+
+    return (
+        <li
+            ref={setNodeRef}
+            style={style}
+            className={`flex items-center gap-3 rounded-xl border border-light-border/70 bg-light-card px-3 py-2.5 dark:border-dark-border/70 dark:bg-dark-card ${
+                isDragging ? "shadow-soft" : ""
+            }`}
+        >
+            <button
+                type="button"
+                {...attributes}
+                {...listeners}
+                aria-label={`Reorder ${row.title}`}
+                className="flex-shrink-0 cursor-grab touch-none rounded-md p-1 text-light-muted transition-colors hover:bg-light-hover hover:text-light-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-wevie-teal/40 active:cursor-grabbing dark:text-dark-muted dark:hover:bg-dark-hover"
+            >
+                <GripVertical className="h-4 w-4" aria-hidden="true" />
+            </button>
+
+            <span className="min-w-0 flex-1 truncate text-sm font-medium text-adaptive-primary">
+                {row.title}
+            </span>
+
+            <div
+                className="flex flex-shrink-0 items-center gap-0.5 rounded-lg bg-light-hover p-0.5 dark:bg-dark-hover"
+                role="group"
+                aria-label={`${row.title} size`}
+            >
+                {["sm", "md", "lg"].map((size) => {
+                    const allowed = row.allowedSizes.includes(size);
+                    if (!allowed) return null;
+                    const active = row.size === size;
+                    return (
+                        <button
+                            key={size}
+                            type="button"
+                            onClick={() => onSize(row.key, size)}
+                            disabled={!row.enabled}
+                            aria-pressed={active}
+                            className={`h-7 w-7 rounded-md text-xs font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-wevie-teal/40 disabled:opacity-40 ${
+                                active
+                                    ? "bg-white text-wevie-teal shadow-soft dark:bg-dark-secondary"
+                                    : "text-adaptive-muted hover:text-adaptive-primary"
+                            }`}
+                        >
+                            {SIZE_LABELS[size]}
+                        </button>
+                    );
+                })}
+            </div>
+
+            <Switch
+                checked={row.enabled}
+                onChange={() => onToggle(row.key)}
+                className={`${
+                    row.enabled
+                        ? "bg-gradient-to-r from-wevie-teal to-wevie-mint"
+                        : "bg-light-border dark:bg-dark-border"
+                } relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-wevie-teal/40`}
+            >
+                <span className="sr-only">
+                    {row.enabled ? "Hide" : "Show"} {row.title}
+                </span>
+                <span
+                    className={`${
+                        row.enabled ? "translate-x-6" : "translate-x-1"
+                    } inline-block h-4 w-4 transform rounded-full bg-white transition-transform`}
+                />
+            </Switch>
+        </li>
+    );
+}
+
+/**
+ * Customize modal: toggle widgets on/off, pick each widget's size (limited to
+ * its allowedSizes), and drag to reorder. Save persists the full layout;
+ * Cancel discards local edits by resetting from props.
+ */
+export default function CustomizeDashboardModal({
+    show,
+    onClose,
+    availableWidgets = [],
+    widgetLayout = [],
+    onSaved,
+}) {
+    const initialRows = useMemo(
+        () => buildRows(availableWidgets, widgetLayout),
+        [availableWidgets, widgetLayout]
+    );
+    const [rows, setRows] = useState(initialRows);
+    const [saving, setSaving] = useState(false);
+
+    // Re-seed local edits whenever the modal (re)opens or the source changes.
+    useEffect(() => {
+        if (show) {
+            setRows(buildRows(availableWidgets, widgetLayout));
+        }
+    }, [show, availableWidgets, widgetLayout]);
+
+    const sensors = useSensors(
+        useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+        useSensor(KeyboardSensor, {
+            coordinateGetter: sortableKeyboardCoordinates,
+        })
+    );
+
+    const toggle = (key) =>
+        setRows((prev) =>
+            prev.map((row) => (row.key === key ? { ...row, enabled: !row.enabled } : row))
+        );
+
+    const setSize = (key, size) =>
+        setRows((prev) => prev.map((row) => (row.key === key ? { ...row, size } : row)));
+
+    const handleDragEnd = (event) => {
+        const { active, over } = event;
+        if (!over || active.id === over.id) return;
+        setRows((prev) => {
+            const oldIndex = prev.findIndex((r) => r.key === active.id);
+            const newIndex = prev.findIndex((r) => r.key === over.id);
+            if (oldIndex === -1 || newIndex === -1) return prev;
+            return arrayMove(prev, oldIndex, newIndex);
+        });
+    };
+
+    const save = () => {
+        const widgets = rows.map((row) => ({
+            key: row.key,
+            size: row.size,
+            enabled: row.enabled,
+        }));
+        setSaving(true);
+        router.post(
+            route("dashboard.layout.update"),
+            { widgets },
+            {
+                preserveScroll: true,
+                preserveState: true,
+                onSuccess: () => {
+                    if (onSaved) onSaved(widgets);
+                    toast.success("Dashboard layout saved.");
+                    onClose();
+                },
+                onError: () => {
+                    toast.error("We couldn’t save your layout just now. Please try again.");
+                },
+                onFinish: () => setSaving(false),
+            }
+        );
+    };
+
+    return (
+        <Modal show={show} onClose={onClose} maxWidth="2xl" alignTop>
+            <div className="flex items-center justify-between border-b border-light-border/70 px-5 py-4 dark:border-dark-border/70">
+                <div>
+                    <h2 className="text-lg font-semibold text-adaptive-primary">
+                        Customize dashboard
+                    </h2>
+                    <p className="mt-0.5 text-sm text-adaptive-muted">
+                        Toggle widgets, set their size, and drag to reorder.
+                    </p>
+                </div>
+                <button
+                    type="button"
+                    onClick={onClose}
+                    aria-label="Close"
+                    className="rounded-md p-1 text-light-muted transition-colors hover:bg-light-hover hover:text-light-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-wevie-teal/40 dark:text-dark-muted dark:hover:bg-dark-hover"
+                >
+                    <X className="h-5 w-5" />
+                </button>
+            </div>
+
+            <div className="max-h-[60vh] overflow-y-auto px-5 py-4">
+                {rows.length === 0 ? (
+                    <p className="py-8 text-center text-sm text-adaptive-muted">
+                        No widgets available to customize.
+                    </p>
+                ) : (
+                    <DndContext
+                        sensors={sensors}
+                        collisionDetection={closestCenter}
+                        onDragEnd={handleDragEnd}
+                    >
+                        <SortableContext
+                            items={rows.map((r) => r.key)}
+                            strategy={verticalListSortingStrategy}
+                        >
+                            <ul className="space-y-2">
+                                {rows.map((row) => (
+                                    <SortableRow
+                                        key={row.key}
+                                        row={row}
+                                        onToggle={toggle}
+                                        onSize={setSize}
+                                    />
+                                ))}
+                            </ul>
+                        </SortableContext>
+                    </DndContext>
+                )}
+            </div>
+
+            <div className="flex items-center justify-end gap-3 border-t border-light-border/70 px-5 py-4 dark:border-dark-border/70">
+                <button type="button" onClick={onClose} className="btn-secondary" disabled={saving}>
+                    Cancel
+                </button>
+                <button
+                    type="button"
+                    onClick={save}
+                    className="btn-primary disabled:cursor-not-allowed disabled:opacity-70"
+                    disabled={saving}
+                >
+                    {saving ? "Saving…" : "Save changes"}
+                </button>
+            </div>
+        </Modal>
+    );
+}

--- a/resources/js/Components/Dashboard/WidgetFrame.jsx
+++ b/resources/js/Components/Dashboard/WidgetFrame.jsx
@@ -1,0 +1,53 @@
+import { GripVertical } from "lucide-react";
+
+/**
+ * Shared shell for every dashboard widget. Built on the `.card` token with the
+ * header/actions pattern borrowed from Finance's ChartWrapper: a title, an
+ * optional icon, an optional right-aligned action slot, an accessible drag
+ * handle, and the widget body as children.
+ *
+ * `dragHandleProps` carries dnd-kit's `attributes` + `listeners`; when absent
+ * (e.g. previewing outside the sortable grid) the handle is simply not shown.
+ */
+export default function WidgetFrame({
+    title,
+    icon: Icon,
+    iconClassName = "bg-wevie-teal/10 text-wevie-teal",
+    action,
+    dragHandleProps,
+    children,
+    className = "",
+    contentClassName = "",
+}) {
+    return (
+        <section className={`card flex h-full flex-col ${className}`} aria-label={title}>
+            <header className="flex items-center justify-between gap-2 border-b border-light-border/70 px-4 py-3 dark:border-dark-border/70 sm:px-5">
+                <div className="flex min-w-0 items-center gap-2">
+                    {dragHandleProps && (
+                        <button
+                            type="button"
+                            {...dragHandleProps}
+                            aria-label={`Drag to reorder ${title}`}
+                            className="hidden flex-shrink-0 cursor-grab touch-none rounded-md p-1 text-light-muted transition-colors hover:bg-light-hover hover:text-light-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-wevie-teal/40 active:cursor-grabbing dark:text-dark-muted dark:hover:bg-dark-hover dark:hover:text-dark-secondary sm:block"
+                        >
+                            <GripVertical className="h-4 w-4" aria-hidden="true" />
+                        </button>
+                    )}
+                    {Icon && (
+                        <span
+                            className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full ${iconClassName}`}
+                            aria-hidden="true"
+                        >
+                            <Icon className="h-4 w-4" />
+                        </span>
+                    )}
+                    <h3 className="truncate text-sm font-semibold text-adaptive-primary sm:text-base">
+                        {title}
+                    </h3>
+                </div>
+                {action && <div className="flex flex-shrink-0 items-center gap-1">{action}</div>}
+            </header>
+            <div className={`flex-1 p-4 sm:p-5 ${contentClassName}`}>{children}</div>
+        </section>
+    );
+}

--- a/resources/js/Components/Dashboard/WidgetGrid.jsx
+++ b/resources/js/Components/Dashboard/WidgetGrid.jsx
@@ -1,0 +1,135 @@
+import { useState } from "react";
+import { LayoutGrid, GripVertical } from "lucide-react";
+import {
+    DndContext,
+    DragOverlay,
+    closestCenter,
+    KeyboardSensor,
+    PointerSensor,
+    useSensor,
+    useSensors,
+} from "@dnd-kit/core";
+import {
+    arrayMove,
+    SortableContext,
+    rectSortingStrategy,
+    sortableKeyboardCoordinates,
+    useSortable,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import EmptyState from "@/Components/Finance/UI/EmptyState";
+import { getWidget, getColSpanClass } from "@/widgets/registry";
+
+function SortableWidget({ item, data }) {
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+        id: item.key,
+    });
+
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.4 : 1,
+    };
+
+    const entry = getWidget(item.key);
+    if (!entry) return null;
+
+    const { Component, selfContained, title } = entry;
+    const dragHandleProps = { ...attributes, ...listeners };
+    const colSpan = getColSpanClass(item.size);
+
+    return (
+        <div ref={setNodeRef} style={style} className={`${colSpan} ${isDragging ? "z-10" : ""}`}>
+            {selfContained ? (
+                // Widgets that render their own card (Weather) get an overlaid
+                // handle instead of one inside a shared WidgetFrame header.
+                <div className="relative h-full">
+                    <button
+                        type="button"
+                        {...dragHandleProps}
+                        aria-label={`Drag to reorder ${title}`}
+                        className="absolute left-3 top-3 z-10 hidden cursor-grab touch-none rounded-md bg-white/20 p-1 text-white backdrop-blur-sm transition-colors hover:bg-white/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 active:cursor-grabbing sm:block"
+                    >
+                        <GripVertical className="h-4 w-4" aria-hidden="true" />
+                    </button>
+                    <Component data={data} />
+                </div>
+            ) : (
+                <Component data={data} dragHandleProps={dragHandleProps} />
+            )}
+        </div>
+    );
+}
+
+/**
+ * The customizable widget grid. Renders only enabled widgets in layout order.
+ * Dragging reorders local state optimistically and calls `onReorder` with the
+ * full reordered layout so the parent can persist it.
+ */
+export default function WidgetGrid({ layout = [], widgetData = {}, onReorder }) {
+    const [activeKey, setActiveKey] = useState(null);
+
+    const sensors = useSensors(
+        useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+        useSensor(KeyboardSensor, {
+            coordinateGetter: sortableKeyboardCoordinates,
+        })
+    );
+
+    const visible = layout.filter((item) => item.enabled && getWidget(item.key));
+
+    const handleDragStart = (event) => setActiveKey(event.active.id);
+
+    const handleDragEnd = (event) => {
+        setActiveKey(null);
+        const { active, over } = event;
+        if (!over || active.id === over.id) return;
+
+        const oldIndex = layout.findIndex((i) => i.key === active.id);
+        const newIndex = layout.findIndex((i) => i.key === over.id);
+        if (oldIndex === -1 || newIndex === -1) return;
+
+        onReorder?.(arrayMove(layout, oldIndex, newIndex));
+    };
+
+    if (visible.length === 0) {
+        return (
+            <EmptyState
+                icon={LayoutGrid}
+                title="No widgets on your dashboard"
+                description="Use Customize to switch some widgets on and arrange them your way."
+            />
+        );
+    }
+
+    const activeEntry = activeKey ? getWidget(activeKey) : null;
+
+    return (
+        <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+            onDragCancel={() => setActiveKey(null)}
+        >
+            <SortableContext items={visible.map((item) => item.key)} strategy={rectSortingStrategy}>
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6 lg:grid-cols-4">
+                    {visible.map((item) => (
+                        <SortableWidget key={item.key} item={item} data={widgetData[item.key]} />
+                    ))}
+                </div>
+            </SortableContext>
+
+            <DragOverlay>
+                {activeEntry ? (
+                    <div className="card flex items-center gap-2 px-4 py-3 shadow-soft">
+                        <GripVertical className="h-4 w-4 text-adaptive-muted" aria-hidden="true" />
+                        <span className="text-sm font-semibold text-adaptive-primary">
+                            {activeEntry.title}
+                        </span>
+                    </div>
+                ) : null}
+            </DragOverlay>
+        </DndContext>
+    );
+}

--- a/resources/js/Components/widgets/BudgetWidget.jsx
+++ b/resources/js/Components/widgets/BudgetWidget.jsx
@@ -1,0 +1,100 @@
+import { PiggyBank, Wallet } from "lucide-react";
+import WidgetFrame from "@/Components/Dashboard/WidgetFrame";
+import StatCard from "@/Components/Finance/UI/StatCard";
+import EmptyState from "@/Components/Finance/UI/EmptyState";
+import { formatCurrency } from "@/Utils/currency";
+
+function clampPercent(value) {
+    if (!Number.isFinite(value)) return 0;
+    return Math.min(100, Math.max(0, Math.round(value)));
+}
+
+/**
+ * Budget snapshot. `budgets` is an array of Finance budget rows (`amount` is the
+ * limit, `current_spent` the spend — matching the WevieWallet Budgets page).
+ * Totals are derived from the rows themselves; the finance `summary` prop carries
+ * cashflow figures (income/expenses/net), not budget totals, so we don't read it.
+ */
+export default function BudgetWidget({ data, dragHandleProps }) {
+    const budgets = data?.budgets ?? [];
+
+    const totalBudgeted = budgets.reduce((sum, b) => sum + Number(b.amount ?? 0), 0);
+    const totalSpent = budgets.reduce((sum, b) => sum + Number(b.current_spent ?? 0), 0);
+    const remaining = Math.max(0, totalBudgeted - totalSpent);
+
+    return (
+        <WidgetFrame
+            title="Budgets"
+            icon={PiggyBank}
+            iconClassName="bg-secondary-100 text-secondary-500 dark:bg-secondary-900/30"
+            dragHandleProps={dragHandleProps}
+        >
+            <div className="space-y-4">
+                <div className="grid grid-cols-2 gap-3">
+                    <StatCard
+                        label="Budgeted"
+                        value={formatCurrency(totalBudgeted)}
+                        icon={Wallet}
+                        iconClassName="bg-wevie-teal/10 text-wevie-teal"
+                    />
+                    <StatCard
+                        label="Remaining"
+                        value={formatCurrency(remaining)}
+                        icon={PiggyBank}
+                        iconClassName="bg-emerald-100/60 text-emerald-500 dark:bg-emerald-900/30"
+                    />
+                </div>
+
+                {budgets.length === 0 ? (
+                    <EmptyState
+                        icon={PiggyBank}
+                        title="No budgets yet"
+                        description="Set a budget to track spending against it here."
+                    />
+                ) : (
+                    <ul className="space-y-3">
+                        {budgets.map((budget) => {
+                            const limit = Number(budget.amount ?? 0);
+                            const spent = Number(budget.current_spent ?? 0);
+                            const pct = limit > 0 ? (spent / limit) * 100 : 0;
+                            const over = spent > limit && limit > 0;
+                            const name = budget.name || budget.category?.name || "Budget";
+
+                            return (
+                                <li key={budget.id ?? name} className="space-y-1">
+                                    <div className="flex items-center justify-between gap-2 text-xs">
+                                        <span className="truncate font-medium text-adaptive-primary">
+                                            {name}
+                                        </span>
+                                        <span className="flex-shrink-0 text-adaptive-muted">
+                                            {formatCurrency(spent)} / {formatCurrency(limit)}
+                                        </span>
+                                    </div>
+                                    <div
+                                        className="h-2 w-full overflow-hidden rounded-full bg-light-hover dark:bg-dark-hover"
+                                        role="progressbar"
+                                        aria-valuenow={clampPercent(pct)}
+                                        aria-valuemin={0}
+                                        aria-valuemax={100}
+                                        aria-label={`${name} budget used`}
+                                    >
+                                        <div
+                                            className={`h-full rounded-full ${
+                                                over
+                                                    ? "bg-rose-500"
+                                                    : "bg-gradient-to-r from-wevie-teal to-wevie-mint"
+                                            }`}
+                                            style={{
+                                                width: `${clampPercent(pct)}%`,
+                                            }}
+                                        />
+                                    </div>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                )}
+            </div>
+        </WidgetFrame>
+    );
+}

--- a/resources/js/Components/widgets/CalendarWidget.jsx
+++ b/resources/js/Components/widgets/CalendarWidget.jsx
@@ -1,0 +1,98 @@
+import { CalendarRange, CheckSquare, Banknote } from "lucide-react";
+import { format, isValid, parseISO, isSameDay } from "date-fns";
+import WidgetFrame from "@/Components/Dashboard/WidgetFrame";
+import EmptyState from "@/Components/Finance/UI/EmptyState";
+
+function toDate(value) {
+    if (!value) return null;
+    const parsed = typeof value === "string" ? parseISO(value) : new Date(value);
+    return isValid(parsed) ? parsed : null;
+}
+
+const TYPE_BADGE = {
+    task: "bg-wevie-teal/10 text-wevie-teal",
+    transaction:
+        "bg-secondary-100 text-secondary-600 dark:bg-secondary-900/30 dark:text-secondary-300",
+};
+
+const TYPE_ICON = {
+    task: CheckSquare,
+    transaction: Banknote,
+};
+
+/**
+ * Next-7-days calendar. `calendar` is a flat array of
+ * `{ date, title, type: 'task' | 'transaction' }` — we sort by date and group
+ * events under their day heading.
+ */
+export default function CalendarWidget({ data, dragHandleProps }) {
+    const events = (data ?? [])
+        .map((event) => ({ ...event, _date: toDate(event.date) }))
+        .filter((event) => event._date)
+        .sort((a, b) => a._date - b._date);
+
+    const groups = [];
+    events.forEach((event) => {
+        const last = groups[groups.length - 1];
+        if (last && isSameDay(last.date, event._date)) {
+            last.items.push(event);
+        } else {
+            groups.push({ date: event._date, items: [event] });
+        }
+    });
+
+    return (
+        <WidgetFrame
+            title="Next 7 days"
+            icon={CalendarRange}
+            iconClassName="bg-indigo-100/60 text-indigo-500 dark:bg-indigo-900/30"
+            dragHandleProps={dragHandleProps}
+        >
+            {groups.length === 0 ? (
+                <EmptyState
+                    icon={CalendarRange}
+                    title="A quiet week"
+                    description="No tasks or transactions scheduled in the next 7 days."
+                />
+            ) : (
+                <div className="space-y-4">
+                    {groups.map((group) => (
+                        <div key={group.date.toISOString()}>
+                            <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-adaptive-muted">
+                                {format(group.date, "EEE, MMM d")}
+                            </p>
+                            <ul className="space-y-2">
+                                {group.items.map((event, index) => {
+                                    const Icon = TYPE_ICON[event.type] ?? CheckSquare;
+                                    return (
+                                        <li
+                                            key={`${event.title}-${index}`}
+                                            className="flex items-center justify-between gap-3 rounded-xl bg-light-hover px-3 py-2 dark:bg-dark-hover"
+                                        >
+                                            <div className="flex min-w-0 items-center gap-2">
+                                                <Icon
+                                                    className="h-4 w-4 flex-shrink-0 text-adaptive-muted"
+                                                    aria-hidden="true"
+                                                />
+                                                <span className="truncate text-sm font-medium text-adaptive-primary">
+                                                    {event.title}
+                                                </span>
+                                            </div>
+                                            <span
+                                                className={`flex-shrink-0 rounded-full px-2 py-0.5 text-xs font-medium capitalize ${
+                                                    TYPE_BADGE[event.type] ?? TYPE_BADGE.task
+                                                }`}
+                                            >
+                                                {event.type}
+                                            </span>
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </WidgetFrame>
+    );
+}

--- a/resources/js/Components/widgets/InProgressWidget.jsx
+++ b/resources/js/Components/widgets/InProgressWidget.jsx
@@ -1,0 +1,22 @@
+import { Loader, Sparkles } from "lucide-react";
+import WidgetFrame from "@/Components/Dashboard/WidgetFrame";
+import TaskList from "@/Components/widgets/partials/TaskList";
+
+export default function InProgressWidget({ data, dragHandleProps }) {
+    return (
+        <WidgetFrame
+            title="In progress"
+            icon={Loader}
+            iconClassName="bg-indigo-100/60 text-indigo-500 dark:bg-indigo-900/30"
+            dragHandleProps={dragHandleProps}
+        >
+            <TaskList
+                tasks={data ?? []}
+                emptyIcon={Sparkles}
+                emptyTitle="Nothing in motion"
+                emptyDescription="Start a task and it’ll show up here while you work."
+                dueLabel="Due"
+            />
+        </WidgetFrame>
+    );
+}

--- a/resources/js/Components/widgets/OverdueTasksWidget.jsx
+++ b/resources/js/Components/widgets/OverdueTasksWidget.jsx
@@ -1,0 +1,23 @@
+import { AlertTriangle, CheckCircle } from "lucide-react";
+import WidgetFrame from "@/Components/Dashboard/WidgetFrame";
+import TaskList from "@/Components/widgets/partials/TaskList";
+
+export default function OverdueTasksWidget({ data, dragHandleProps }) {
+    return (
+        <WidgetFrame
+            title="Tasks to revisit"
+            icon={AlertTriangle}
+            iconClassName="bg-amber-100/60 text-amber-500 dark:bg-amber-900/30"
+            dragHandleProps={dragHandleProps}
+        >
+            <TaskList
+                tasks={data ?? []}
+                emptyIcon={CheckCircle}
+                emptyTitle="Nothing waiting here"
+                emptyDescription="You’re all caught up — no overdue tasks."
+                dueLabel="Was due"
+                accentDue
+            />
+        </WidgetFrame>
+    );
+}

--- a/resources/js/Components/widgets/PomodoroWidget.jsx
+++ b/resources/js/Components/widgets/PomodoroWidget.jsx
@@ -1,0 +1,102 @@
+import { Timer, Play, Pause, RotateCcw } from "lucide-react";
+import WidgetFrame from "@/Components/Dashboard/WidgetFrame";
+import { usePomodoro } from "@/Components/Pomodoro/PomodoroContext";
+
+const SESSION_LABELS = {
+    work: "Focus session",
+    short_break: "Short break",
+    long_break: "Long break",
+};
+
+/**
+ * Client-only Pomodoro widget. It reads the shared PomodoroContext rather than
+ * any server payload, so the `data` prop is intentionally ignored.
+ */
+export default function PomodoroWidget({ dragHandleProps }) {
+    const {
+        timeLeft,
+        currentSession,
+        sessionsCompleted,
+        isRunning,
+        isIdle,
+        formatTime,
+        getProgress,
+        startTimer,
+        pauseTimer,
+        resetTimer,
+    } = usePomodoro();
+
+    const progress = Math.min(100, Math.max(0, getProgress()));
+
+    return (
+        <WidgetFrame
+            title="Pomodoro"
+            icon={Timer}
+            iconClassName="bg-rose-100/60 text-rose-500 dark:bg-rose-900/30"
+            dragHandleProps={dragHandleProps}
+        >
+            <div className="flex flex-col items-center gap-4 text-center">
+                <div>
+                    <p className="text-xs font-medium uppercase tracking-wide text-adaptive-muted">
+                        {SESSION_LABELS[currentSession] ?? "Focus session"}
+                    </p>
+                    <p
+                        className="mt-1 text-4xl font-bold tabular-nums text-adaptive-primary"
+                        aria-live="polite"
+                    >
+                        {formatTime(timeLeft)}
+                    </p>
+                </div>
+
+                <div
+                    className="h-2 w-full overflow-hidden rounded-full bg-light-hover dark:bg-dark-hover"
+                    role="progressbar"
+                    aria-valuenow={Math.round(progress)}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-label="Session progress"
+                >
+                    <div
+                        className="h-full rounded-full bg-gradient-to-r from-wevie-teal to-wevie-mint transition-[width] duration-500"
+                        style={{ width: `${progress}%` }}
+                    />
+                </div>
+
+                <div className="flex items-center gap-2">
+                    {isRunning ? (
+                        <button
+                            type="button"
+                            onClick={pauseTimer}
+                            className="btn-secondary px-3 py-1.5 text-sm"
+                        >
+                            <Pause className="mr-1.5 h-4 w-4" />
+                            Pause
+                        </button>
+                    ) : (
+                        <button
+                            type="button"
+                            onClick={startTimer}
+                            className="btn-primary px-3 py-1.5 text-sm"
+                        >
+                            <Play className="mr-1.5 h-4 w-4" />
+                            {isIdle ? "Start" : "Resume"}
+                        </button>
+                    )}
+                    <button
+                        type="button"
+                        onClick={resetTimer}
+                        aria-label="Reset timer"
+                        className="btn-secondary px-3 py-1.5 text-sm"
+                    >
+                        <RotateCcw className="h-4 w-4" />
+                    </button>
+                </div>
+
+                <p className="text-xs text-adaptive-muted">
+                    {sessionsCompleted} session
+                    {sessionsCompleted === 1 ? "" : "s"} completed today
+                </p>
+            </div>
+        </WidgetFrame>
+    );
+}

--- a/resources/js/Components/widgets/ProductivityWidget.jsx
+++ b/resources/js/Components/widgets/ProductivityWidget.jsx
@@ -1,0 +1,73 @@
+import { AreaChart } from "@tremor/react";
+import { Activity } from "lucide-react";
+import WidgetFrame from "@/Components/Dashboard/WidgetFrame";
+import StatCard from "@/Components/Finance/UI/StatCard";
+import EmptyState from "@/Components/Finance/UI/EmptyState";
+
+function humanize(key) {
+    return key.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+/**
+ * Productivity trends. `productivity` carries `trends` (a time series) and a
+ * `metrics` object. Trend rows are normalised defensively since the exact keys
+ * are backend-owned; the chart plots a single "Completed" series and up to two
+ * headline metrics render as StatCards.
+ */
+export default function ProductivityWidget({ data, dragHandleProps }) {
+    const trends = data?.trends ?? [];
+    const metrics = data?.metrics ?? {};
+
+    const chartData = trends.map((row, index) => ({
+        label: row.label ?? row.date ?? row.day ?? `#${index + 1}`,
+        Completed: row.completed ?? row.value ?? row.count ?? 0,
+    }));
+
+    const metricTiles = Object.entries(metrics).slice(0, 2);
+
+    return (
+        <WidgetFrame
+            title="Productivity"
+            icon={Activity}
+            iconClassName="bg-violet-100/60 text-violet-500 dark:bg-violet-900/30"
+            dragHandleProps={dragHandleProps}
+        >
+            {chartData.length === 0 && metricTiles.length === 0 ? (
+                <EmptyState
+                    icon={Activity}
+                    title="No trends yet"
+                    description="Complete a few tasks and your productivity trend will appear here."
+                />
+            ) : (
+                <div className="space-y-4">
+                    {metricTiles.length > 0 && (
+                        <div className="grid grid-cols-2 gap-3">
+                            {metricTiles.map(([key, value]) => (
+                                <StatCard
+                                    key={key}
+                                    label={humanize(key)}
+                                    value={value ?? 0}
+                                    icon={Activity}
+                                    iconClassName="bg-violet-100/60 text-violet-500 dark:bg-violet-900/30"
+                                />
+                            ))}
+                        </div>
+                    )}
+                    {chartData.length > 0 && (
+                        <AreaChart
+                            className="h-40"
+                            data={chartData}
+                            index="label"
+                            categories={["Completed"]}
+                            colors={["emerald"]}
+                            showLegend={false}
+                            showGridLines={false}
+                            startEndOnly
+                            showYAxis={false}
+                        />
+                    )}
+                </div>
+            )}
+        </WidgetFrame>
+    );
+}

--- a/resources/js/Components/widgets/TaskStatsWidget.jsx
+++ b/resources/js/Components/widgets/TaskStatsWidget.jsx
@@ -1,0 +1,81 @@
+import {
+    ListTodo,
+    CheckCircle,
+    Clock,
+    Loader,
+    AlertTriangle,
+    CalendarDays,
+    TrendingUp,
+} from "lucide-react";
+import WidgetFrame from "@/Components/Dashboard/WidgetFrame";
+import StatCard from "@/Components/Finance/UI/StatCard";
+
+/**
+ * Task overview widget — a grid of KPI tiles derived from the `task_stats`
+ * slice of `widgetData`. Every value guards against a missing payload so the
+ * widget renders zeros rather than crashing when disabled server-side.
+ */
+export default function TaskStatsWidget({ data, dragHandleProps }) {
+    const stats = data ?? {};
+
+    const tiles = [
+        {
+            label: "Total tasks",
+            value: stats.total_tasks ?? 0,
+            icon: ListTodo,
+            iconClassName: "bg-wevie-teal/10 text-wevie-teal",
+        },
+        {
+            label: "Completed",
+            value: stats.completed_tasks ?? 0,
+            icon: CheckCircle,
+            iconClassName: "bg-emerald-100/60 text-emerald-500 dark:bg-emerald-900/30",
+        },
+        {
+            label: "Open",
+            value: stats.pending_tasks ?? 0,
+            icon: Clock,
+            iconClassName: "bg-sky-100/60 text-sky-500 dark:bg-sky-900/30",
+        },
+        {
+            label: "In progress",
+            value: stats.in_progress_tasks ?? 0,
+            icon: Loader,
+            iconClassName: "bg-indigo-100/60 text-indigo-500 dark:bg-indigo-900/30",
+        },
+        {
+            label: "Overdue",
+            value: stats.overdue_tasks ?? 0,
+            icon: AlertTriangle,
+            iconClassName: "bg-amber-100/60 text-amber-500 dark:bg-amber-900/30",
+        },
+        {
+            label: "Due today",
+            value: stats.due_today_tasks ?? 0,
+            icon: CalendarDays,
+            iconClassName: "bg-rose-100/60 text-rose-500 dark:bg-rose-900/30",
+        },
+        {
+            label: "Completion",
+            value: `${stats.completion_rate ?? 0}%`,
+            icon: TrendingUp,
+            iconClassName: "bg-wevie-mint/20 text-wevie-mint dark:bg-wevie-mint/10",
+        },
+    ];
+
+    return (
+        <WidgetFrame title="Task overview" icon={ListTodo} dragHandleProps={dragHandleProps}>
+            <div className="grid grid-cols-2 gap-3 lg:grid-cols-3 xl:grid-cols-4">
+                {tiles.map((tile) => (
+                    <StatCard
+                        key={tile.label}
+                        label={tile.label}
+                        value={tile.value}
+                        icon={tile.icon}
+                        iconClassName={tile.iconClassName}
+                    />
+                ))}
+            </div>
+        </WidgetFrame>
+    );
+}

--- a/resources/js/Components/widgets/TodayTasksWidget.jsx
+++ b/resources/js/Components/widgets/TodayTasksWidget.jsx
@@ -1,0 +1,17 @@
+import { CalendarDays } from "lucide-react";
+import WidgetFrame from "@/Components/Dashboard/WidgetFrame";
+import TaskList from "@/Components/widgets/partials/TaskList";
+
+export default function TodayTasksWidget({ data, dragHandleProps }) {
+    return (
+        <WidgetFrame title="Today’s tasks" icon={CalendarDays} dragHandleProps={dragHandleProps}>
+            <TaskList
+                tasks={data ?? []}
+                emptyIcon={CalendarDays}
+                emptyTitle="A clear day ahead"
+                emptyDescription="Nothing due today — enjoy the breathing room."
+                dueLabel="Due"
+            />
+        </WidgetFrame>
+    );
+}

--- a/resources/js/Components/widgets/UpcomingPaymentsWidget.jsx
+++ b/resources/js/Components/widgets/UpcomingPaymentsWidget.jsx
@@ -1,0 +1,92 @@
+import { Wallet, CalendarClock } from "lucide-react";
+import { format, isValid, parseISO } from "date-fns";
+import WidgetFrame from "@/Components/Dashboard/WidgetFrame";
+import EmptyState from "@/Components/Finance/UI/EmptyState";
+import { formatCurrency } from "@/Utils/currency";
+
+function toDate(value) {
+    if (!value) return null;
+    const parsed = typeof value === "string" ? parseISO(value) : new Date(value);
+    return isValid(parsed) ? parsed : null;
+}
+
+/**
+ * Upcoming finance payments. Reads the `upcoming_payments` slice — an array of
+ * transactions each optionally carrying a `loan` or a `category`. Amounts use
+ * the shared en-PH currency helper.
+ */
+export default function UpcomingPaymentsWidget({ data, dragHandleProps }) {
+    const payments = data ?? [];
+
+    return (
+        <WidgetFrame
+            title="Upcoming payments"
+            icon={Wallet}
+            iconClassName="bg-emerald-100/60 text-emerald-500 dark:bg-emerald-900/30"
+            dragHandleProps={dragHandleProps}
+        >
+            {payments.length === 0 ? (
+                <EmptyState
+                    icon={CalendarClock}
+                    title="Nothing scheduled yet"
+                    description="We’ll keep watch here when you add a payment."
+                />
+            ) : (
+                <ul className="space-y-2">
+                    {payments.map((payment) => {
+                        const due = toDate(payment.occurred_at);
+                        const title =
+                            payment.description ||
+                            payment.loan?.name ||
+                            payment.category?.name ||
+                            "Payment";
+
+                        return (
+                            <li
+                                key={payment.id}
+                                className="flex items-center justify-between gap-3 rounded-xl bg-light-hover px-3 py-2 dark:bg-dark-hover"
+                            >
+                                <div className="min-w-0">
+                                    <p className="truncate text-sm font-medium text-adaptive-primary">
+                                        {title}
+                                    </p>
+                                    {payment.loan ? (
+                                        <p className="truncate text-xs text-amber-700 dark:text-amber-200">
+                                            Loan · {payment.loan.name}
+                                        </p>
+                                    ) : (
+                                        payment.category && (
+                                            <span className="mt-0.5 flex items-center gap-1">
+                                                <span
+                                                    className="h-2 w-2 flex-shrink-0 rounded-full"
+                                                    style={{
+                                                        backgroundColor:
+                                                            payment.category.color ?? "#8FA3A6",
+                                                    }}
+                                                    aria-hidden="true"
+                                                />
+                                                <span className="truncate text-xs text-adaptive-muted">
+                                                    {payment.category.name}
+                                                </span>
+                                            </span>
+                                        )
+                                    )}
+                                </div>
+                                <div className="flex-shrink-0 text-right">
+                                    <p className="text-sm font-semibold text-adaptive-primary">
+                                        {formatCurrency(payment.amount, payment.currency ?? "PHP")}
+                                    </p>
+                                    {due && (
+                                        <p className="text-xs text-adaptive-muted">
+                                            {format(due, "MMM d")}
+                                        </p>
+                                    )}
+                                </div>
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+        </WidgetFrame>
+    );
+}

--- a/resources/js/Components/widgets/UpcomingTasksWidget.jsx
+++ b/resources/js/Components/widgets/UpcomingTasksWidget.jsx
@@ -1,0 +1,17 @@
+import { CalendarClock } from "lucide-react";
+import WidgetFrame from "@/Components/Dashboard/WidgetFrame";
+import TaskList from "@/Components/widgets/partials/TaskList";
+
+export default function UpcomingTasksWidget({ data, dragHandleProps }) {
+    return (
+        <WidgetFrame title="Coming up" icon={CalendarClock} dragHandleProps={dragHandleProps}>
+            <TaskList
+                tasks={data ?? []}
+                emptyIcon={CalendarClock}
+                emptyTitle="Nothing scheduled yet"
+                emptyDescription="Add plans when it feels right and they’ll appear here."
+                dueLabel="Due"
+            />
+        </WidgetFrame>
+    );
+}

--- a/resources/js/Components/widgets/partials/TaskList.jsx
+++ b/resources/js/Components/widgets/partials/TaskList.jsx
@@ -1,0 +1,102 @@
+import { Link } from "@inertiajs/react";
+import { format, isValid, parseISO } from "date-fns";
+import EmptyState from "@/Components/Finance/UI/EmptyState";
+
+const PRIORITY_STYLES = {
+    urgent: "bg-amber-100/70 text-amber-700 dark:bg-amber-900/20 dark:text-amber-200",
+    high: "bg-orange-100/70 text-orange-700 dark:bg-orange-900/20 dark:text-orange-200",
+    medium: "bg-sky-100/70 text-sky-700 dark:bg-sky-900/20 dark:text-sky-200",
+    low: "bg-emerald-100/70 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-200",
+};
+
+const PRIORITY_LABELS = {
+    urgent: "Focus",
+    high: "High",
+    medium: "Medium",
+    low: "Low",
+};
+
+function toDate(value) {
+    if (!value) return null;
+    const parsed = typeof value === "string" ? parseISO(value) : new Date(value);
+    return isValid(parsed) ? parsed : null;
+}
+
+/**
+ * Compact task row used by the Today / Overdue / Upcoming / In-progress
+ * dashboard widgets. Shows a category dot, the title, a due date, and a
+ * priority badge. Rows link through to the task list so the widget stays
+ * read-only and lightweight.
+ */
+export default function TaskList({
+    tasks,
+    emptyIcon,
+    emptyTitle,
+    emptyDescription,
+    dueLabel = "Due",
+    accentDue = false,
+}) {
+    const items = tasks ?? [];
+
+    if (items.length === 0) {
+        return <EmptyState icon={emptyIcon} title={emptyTitle} description={emptyDescription} />;
+    }
+
+    return (
+        <ul className="space-y-2">
+            {items.map((task) => {
+                const due = toDate(task.due_date);
+                const priority = task.priority ?? "medium";
+                const isDone = task.status === "completed";
+
+                return (
+                    <li key={task.id}>
+                        <Link
+                            href={route("tasks.index")}
+                            className="flex items-center justify-between gap-3 rounded-xl bg-light-hover px-3 py-2 transition-colors hover:bg-light-border/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-wevie-teal/40 dark:bg-dark-hover dark:hover:bg-dark-border/40"
+                        >
+                            <div className="flex min-w-0 items-center gap-2">
+                                <span
+                                    className="h-2.5 w-2.5 flex-shrink-0 rounded-full"
+                                    style={{
+                                        backgroundColor: task.category?.color ?? "#8FA3A6",
+                                    }}
+                                    aria-hidden="true"
+                                />
+                                <div className="min-w-0">
+                                    <p
+                                        className={`truncate text-sm font-medium ${
+                                            isDone
+                                                ? "text-light-muted line-through dark:text-dark-muted"
+                                                : "text-adaptive-primary"
+                                        }`}
+                                    >
+                                        {task.title}
+                                    </p>
+                                    {due && (
+                                        <p
+                                            className={`truncate text-xs ${
+                                                accentDue
+                                                    ? "text-amber-700 dark:text-amber-200"
+                                                    : "text-adaptive-muted"
+                                            }`}
+                                        >
+                                            {dueLabel} {format(due, "MMM d")}
+                                        </p>
+                                    )}
+                                </div>
+                            </div>
+                            <span
+                                className={`inline-flex flex-shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                                    PRIORITY_STYLES[priority] ?? PRIORITY_STYLES.medium
+                                }`}
+                            >
+                                {PRIORITY_LABELS[priority] ?? priority}
+                            </span>
+                        </Link>
+                    </li>
+                );
+            })}
+        </ul>
+    );
+}

--- a/resources/js/Pages/Dashboard.jsx
+++ b/resources/js/Pages/Dashboard.jsx
@@ -1,276 +1,67 @@
-import TodoLayout from "@/Layouts/TodoLayout";
-import { Head, Link, router } from "@inertiajs/react";
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
+import { Head, router } from "@inertiajs/react";
 import { toast } from "react-toastify";
-import {
-    Plus,
-    CheckCircle,
-    Clock,
-    AlertTriangle,
-    Calendar,
-    TrendingUp,
-    CheckSquare,
-    Circle,
-    Edit,
-    Trash2,
-    X,
-    CalendarDays,
-    Target,
-    Zap,
-    Eye,
-} from "lucide-react";
-import TaskModal from "@/Components/TaskModal";
-import GettingStartedChecklist from "@/Components/GettingStartedChecklist";
+import { SlidersHorizontal } from "lucide-react";
+import TodoLayout from "@/Layouts/TodoLayout";
 import SampleDataBanner from "@/Components/SampleDataBanner";
-import TaskViewModal from "@/Components/TaskViewModal";
-import TaskEditModal from "@/Components/TaskEditModal";
-import ScheduleModal from "@/Components/ScheduleModal";
+import GettingStartedChecklist from "@/Components/GettingStartedChecklist";
+import DailySummaryCard from "@/Components/DailySummary/DailySummaryCard";
+import WidgetGrid from "@/Components/Dashboard/WidgetGrid";
+import CustomizeDashboardModal from "@/Components/Dashboard/CustomizeDashboardModal";
 
+/**
+ * Customizable widget dashboard. Server state (widget layout, per-widget data,
+ * the AI summary) arrives via Inertia props; the only local state here is the
+ * optimistic layout and the customize-modal visibility.
+ */
 export default function Dashboard({
-    currentTasks = [],
-    todayTasks = [],
-    overdueTasks = [],
-    upcomingTasks = [],
-    weeklyTasks = [],
-    upcomingPayments = [],
-    stats = {},
-    categories = [],
+    availableWidgets = [],
+    widgetLayout = [],
+    widgetData = {},
+    dailySummary = null,
+    dailySummaryEnabled = true,
+    canUseDailySummary,
     gettingStarted = {},
 }) {
-    const [localCurrentTasks, setLocalCurrentTasks] = useState(
-        currentTasks || []
-    );
-    const [localTodayTasks, setLocalTodayTasks] = useState(todayTasks || []);
-    const [localOverdueTasks, setLocalOverdueTasks] = useState(
-        overdueTasks || []
-    );
-    const [localUpcomingTasks, setLocalUpcomingTasks] = useState(
-        upcomingTasks || []
-    );
-    const [showQuickTask, setShowQuickTask] = useState(false);
-    const [showTaskModal, setShowTaskModal] = useState(false);
-    const [showViewModal, setShowViewModal] = useState(false);
-    const [showEditModal, setShowEditModal] = useState(false);
-    const [showScheduleModal, setShowScheduleModal] = useState(false);
-    const [selectedTask, setSelectedTask] = useState(null);
+    const [layout, setLayout] = useState(widgetLayout);
+    const [showCustomize, setShowCustomize] = useState(false);
 
-    const formatCurrency = (value, currency = "PHP") =>
-        new Intl.NumberFormat("en-PH", {
-            style: "currency",
-            currency,
-            maximumFractionDigits: 2,
-        }).format(value ?? 0);
-
-    // Handle task updates from modals
-    const handleTaskUpdate = (updatedTask) => {
-        setSelectedTask(updatedTask);
-        // Update the task in all relevant lists
-        const updateTaskInList = (taskList, setTaskList) => {
-            setTaskList(
-                taskList.map((t) => (t.id === updatedTask.id ? updatedTask : t))
-            );
-        };
-
-        updateTaskInList(localCurrentTasks, setLocalCurrentTasks);
-        updateTaskInList(localTodayTasks, setLocalTodayTasks);
-        updateTaskInList(localOverdueTasks, setLocalOverdueTasks);
-        updateTaskInList(localUpcomingTasks, setLocalUpcomingTasks);
-    };
-
-    const [quickTask, setQuickTask] = useState({
-        title: "",
-        description: "",
-        category_id: "",
-        priority: "medium",
-        due_date: "",
-        start_time: "",
-        end_time: "",
-        is_all_day: true,
-        is_recurring: false,
-        recurrence_type: "",
-        recurring_until: "",
-        tags: [],
-    });
-
+    // Keep local layout in sync when the server sends a new one.
     useEffect(() => {
-        setLocalCurrentTasks(currentTasks || []);
-        setLocalTodayTasks(todayTasks || []);
-        setLocalOverdueTasks(overdueTasks || []);
-        setLocalUpcomingTasks(upcomingTasks || []);
-    }, [currentTasks, todayTasks, overdueTasks, upcomingTasks]);
+        setLayout(widgetLayout);
+    }, [widgetLayout]);
 
-    const handleQuickTaskSubmit = (e) => {
-        e.preventDefault();
-        router.post(route("tasks.store"), quickTask, {
-            onSuccess: () => {
-                setQuickTask({
-                    title: "",
-                    description: "",
-                    category_id: "",
-                    priority: "medium",
-                    due_date: "",
-                    start_time: "",
-                    end_time: "",
-                    is_all_day: true,
-                    is_recurring: false,
-                    recurrence_type: "",
-                    recurring_until: "",
-                    tags: [],
-                });
-                setShowQuickTask(false);
-                toast.success("Task saved. You can add details anytime.");
-            },
-        });
-    };
+    const persistLayout = (nextLayout, previousLayout) => {
+        const widgets = nextLayout.map((item) => ({
+            key: item.key,
+            size: item.size,
+            enabled: item.enabled,
+        }));
 
-    const toggleTaskStatus = (task) => {
-        const newStatus = task.status === "completed" ? "pending" : "completed";
-
-        // Update local state immediately for instant feedback
-        const updateTaskInList = (taskList, setTaskList) => {
-            setTaskList(
-                taskList.map((t) =>
-                    t.id === task.id
-                        ? {
-                              ...t,
-                              status: newStatus,
-                              completed_at:
-                                  newStatus === "completed"
-                                      ? new Date().toISOString()
-                                      : null,
-                          }
-                        : t
-                )
-            );
-        };
-
-        updateTaskInList(localCurrentTasks, setLocalCurrentTasks);
-        updateTaskInList(localTodayTasks, setLocalTodayTasks);
-        updateTaskInList(localOverdueTasks, setLocalOverdueTasks);
-        updateTaskInList(localUpcomingTasks, setLocalUpcomingTasks);
-
-        // Send request to server
         router.post(
-            route("tasks.toggle-status", task.id),
-            {},
+            route("dashboard.layout.update"),
+            { widgets },
             {
                 preserveScroll: true,
-                onSuccess: () => {
-                    toast.success(
-                        newStatus === "completed"
-                            ? "Nice work. Task set to done."
-                            : "Task is back on your list."
-                    );
-                },
+                preserveState: true,
                 onError: () => {
-                    // Revert changes on error
-                    const revertStatus =
-                        newStatus === "completed" ? "pending" : "completed";
-                    updateTaskInList(localCurrentTasks, setLocalCurrentTasks);
-                    updateTaskInList(localTodayTasks, setLocalTodayTasks);
-                    updateTaskInList(localOverdueTasks, setLocalOverdueTasks);
-                    updateTaskInList(localUpcomingTasks, setLocalUpcomingTasks);
-                    toast.error(
-                        "We couldn't update that just now. Try again when you’re ready."
-                    );
+                    if (previousLayout) setLayout(previousLayout);
+                    toast.error("We couldn’t save your layout just now. Please try again.");
                 },
             }
         );
     };
 
-    const handleDeleteTask = (task) => {
-        if (
-            !confirm(
-                `Remove "${task.title}"? You can always add it again later.`
-            )
-        ) {
-            return;
-        }
-
-        // Helper function to remove task from a list
-        const removeTaskFromList = (taskList, setTaskList) => {
-            setTaskList(taskList.filter((t) => t.id !== task.id));
-        };
-
-        // Store original state for potential revert
-        const originalCurrentTasks = [...localCurrentTasks];
-        const originalTodayTasks = [...localTodayTasks];
-        const originalOverdueTasks = [...localOverdueTasks];
-        const originalUpcomingTasks = [...localUpcomingTasks];
-
-        // Optimistically remove the task from all lists
-        removeTaskFromList(localCurrentTasks, setLocalCurrentTasks);
-        removeTaskFromList(localTodayTasks, setLocalTodayTasks);
-        removeTaskFromList(localOverdueTasks, setLocalOverdueTasks);
-        removeTaskFromList(localUpcomingTasks, setLocalUpcomingTasks);
-
-        // Send delete request to server
-        router.delete(route("tasks.destroy", task.id), {
-            preserveScroll: true,
-            preserveState: true,
-            only: [], // Don't reload any data
-            onSuccess: () => {
-                toast.success("Task removed. It’s here if you need it again.");
-            },
-            onError: () => {
-                // Revert to original state on error
-                setLocalCurrentTasks(originalCurrentTasks);
-                setLocalTodayTasks(originalTodayTasks);
-                setLocalOverdueTasks(originalOverdueTasks);
-                setLocalUpcomingTasks(originalUpcomingTasks);
-                toast.error(
-                    "We couldn’t remove that just now. Please try again."
-                );
-            },
-        });
+    const handleReorder = (nextLayout) => {
+        const previousLayout = layout;
+        setLayout(nextLayout); // optimistic
+        persistLayout(nextLayout, previousLayout);
     };
 
-    const getPriorityColor = (priority) => {
-        switch (priority) {
-            case "urgent":
-                return "text-amber-700 bg-amber-100/70 dark:text-amber-200 dark:bg-amber-900/20";
-            case "high":
-                return "text-orange-700 bg-orange-100/70 dark:text-orange-200 dark:bg-orange-900/20";
-            case "medium":
-                return "text-sky-700 bg-sky-100/70 dark:text-sky-200 dark:bg-sky-900/20";
-            case "low":
-                return "text-emerald-700 bg-emerald-100/70 dark:text-emerald-200 dark:bg-emerald-900/20";
-            default:
-                return "text-slate-600 bg-slate-100/70 dark:text-slate-300 dark:bg-slate-800/40";
-        }
-    };
-
-    const getPriorityLabel = (priority) =>
-        priority === "urgent"
-            ? "Focus"
-            : priority.charAt(0).toUpperCase() + priority.slice(1);
-
-    const getStatusIcon = (status) => {
-        switch (status) {
-            case "completed":
-                return (
-                    <CheckCircle className="h-5 w-5 text-emerald-500" />
-                );
-            case "in_progress":
-                return <Clock className="h-5 w-5 text-sky-500" />;
-            case "cancelled":
-                return <AlertTriangle className="h-5 w-5 text-slate-400" />;
-            default:
-                return <Circle className="h-5 w-5 text-slate-300" />;
-        }
-    };
-
-    const formatDate = (date) => {
-        if (!date) return "";
-        return new Date(date).toLocaleDateString();
-    };
-
-    const isOverdue = (dueDate, status) => {
-        if (!dueDate || status === "completed") return false;
-        return (
-            new Date(dueDate) < new Date() &&
-            new Date(dueDate).toDateString() !== new Date().toDateString()
-        );
+    // The customize modal persists on its own; mirror the saved layout locally
+    // so the grid updates without waiting for a full page reload.
+    const handleCustomizeSaved = (widgets) => {
+        setLayout(widgets.map((w) => ({ ...w })));
     };
 
     return (
@@ -278,643 +69,40 @@ export default function Dashboard({
             <Head title="Dashboard" />
 
             <div className="space-y-4 sm:space-y-6">
-                <SampleDataBanner show={!!gettingStarted.hasSampleData} />
-
-                <GettingStartedChecklist
-                    gettingStarted={gettingStarted}
-                    onAddTask={() => setShowQuickTask(true)}
+                <DailySummaryCard
+                    summary={dailySummary}
+                    enabled={dailySummaryEnabled}
+                    canUse={canUseDailySummary ?? true}
                 />
 
-                {/* Stats Cards */}
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6">
-                    <div className="card">
-                        <div className="p-4 sm:p-5">
-                            <div className="flex items-center">
-                                <div className="flex-shrink-0 rounded-full bg-wevie-teal/10 p-2">
-                                    <CheckSquare className="h-5 w-5 sm:h-6 sm:w-6 text-wevie-teal" />
-                                </div>
-                                <div className="ml-4 sm:ml-5 w-0 flex-1">
-                                    <dl>
-                                        <dt className="text-xs sm:text-sm font-medium text-adaptive-muted truncate">
-                                            Total tasks
-                                        </dt>
-                                        <dd className="text-base sm:text-lg font-medium text-adaptive-primary">
-                                            {stats.total_tasks}
-                                        </dd>
-                                    </dl>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                <SampleDataBanner show={!!gettingStarted.hasSampleData} />
 
-                    <div className="card">
-                        <div className="p-4 sm:p-5">
-                            <div className="flex items-center">
-                                <div className="flex-shrink-0 rounded-full bg-emerald-100/60 p-2 dark:bg-emerald-900/30">
-                                    <CheckCircle className="h-5 w-5 sm:h-6 sm:w-6 text-emerald-500" />
-                                </div>
-                                <div className="ml-4 sm:ml-5 w-0 flex-1">
-                                    <dl>
-                                        <dt className="text-xs sm:text-sm font-medium text-adaptive-muted truncate">
-                                            Completed
-                                        </dt>
-                                        <dd className="text-base sm:text-lg font-medium text-adaptive-primary">
-                                            {stats.completed_tasks}
-                                        </dd>
-                                    </dl>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                <GettingStartedChecklist gettingStarted={gettingStarted} />
 
-                    <div className="card">
-                        <div className="p-4 sm:p-5">
-                            <div className="flex items-center">
-                                <div className="flex-shrink-0 rounded-full bg-sky-100/60 p-2 dark:bg-sky-900/30">
-                                    <Clock className="h-5 w-5 sm:h-6 sm:w-6 text-sky-500" />
-                                </div>
-                                <div className="ml-4 sm:ml-5 w-0 flex-1">
-                                    <dl>
-                                        <dt className="text-xs sm:text-sm font-medium text-adaptive-muted truncate">
-                                            Open tasks
-                                        </dt>
-                                        <dd className="text-base sm:text-lg font-medium text-adaptive-primary">
-                                            {stats.pending_tasks}
-                                        </dd>
-                                    </dl>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div className="card">
-                        <div className="p-4 sm:p-5">
-                            <div className="flex items-center">
-                                <div className="flex-shrink-0 rounded-full bg-wevie-mint/20 p-2 dark:bg-wevie-mint/10">
-                                    <TrendingUp className="h-5 w-5 sm:h-6 sm:w-6 text-wevie-mint" />
-                                </div>
-                                <div className="ml-4 sm:ml-5 w-0 flex-1">
-                                    <dl>
-                                        <dt className="text-xs sm:text-sm font-medium text-adaptive-muted truncate">
-                                            Completion pace
-                                        </dt>
-                                        <dd className="text-base sm:text-lg font-medium text-adaptive-primary">
-                                            {stats.completion_rate}%
-                                        </dd>
-                                    </dl>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                <div className="flex items-center justify-between gap-3">
+                    <h2 className="text-base font-semibold text-adaptive-primary sm:text-lg">
+                        Your widgets
+                    </h2>
+                    <button
+                        type="button"
+                        onClick={() => setShowCustomize(true)}
+                        className="btn-secondary"
+                        data-tour="customize-dashboard"
+                    >
+                        <SlidersHorizontal className="mr-2 h-4 w-4" />
+                        Customize
+                    </button>
                 </div>
 
-                {/* Quick Actions */}
-                <div className="card p-4 sm:p-6" data-tour="quick-actions">
-                    <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-4 gap-3">
-                        <h2 className="text-base sm:text-lg font-medium text-adaptive-primary">
-                            Gentle shortcuts
-                        </h2>
-                        <div className="flex gap-2">
-                            <button
-                                onClick={() => setShowTaskModal(true)}
-                                className="btn-primary"
-                            >
-                                <Plus className="mr-2 h-4 w-4" />
-                                New task
-                            </button>
-                            <button
-                                onClick={() => setShowQuickTask(!showQuickTask)}
-                                className="btn-secondary"
-                            >
-                                <Zap className="mr-2 h-4 w-4" />
-                                Quick add
-                            </button>
-                            <button
-                                className="btn-secondary"
-                                onClick={() => setShowScheduleModal(true)}
-                            >
-                                <Calendar className="mr-2 h-4 w-4" />
-                                Schedule
-                            </button>
-                        </div>
-                    </div>
-
-                    {showQuickTask && (
-                        <div className="bg-light-hover dark:bg-dark-hover rounded-xl p-4 mb-4">
-                            <form
-                                onSubmit={handleQuickTaskSubmit}
-                                className="space-y-4"
-                            >
-                                <div className="flex items-center justify-between">
-                                    <h3 className="text-sm font-medium text-light-primary dark:text-dark-primary">
-                                        Quick task
-                                    </h3>
-                                    <button
-                                        type="button"
-                                        onClick={() => setShowQuickTask(false)}
-                                        className="text-light-muted hover:text-light-secondary dark:text-dark-muted dark:hover:text-dark-secondary"
-                                    >
-                                        <X className="h-5 w-5" />
-                                    </button>
-                                </div>
-
-                                <div>
-                                    <input
-                                        type="text"
-                                        placeholder="What would you like to do?"
-                                        value={quickTask.title}
-                                        onChange={(e) =>
-                                            setQuickTask({
-                                                ...quickTask,
-                                                title: e.target.value,
-                                            })
-                                        }
-                                        className="w-full px-3 py-2 border border-light-border/70 dark:border-dark-border/70 rounded-xl focus:ring-wevie-teal/40 focus:border-wevie-teal dark:bg-dark-card dark:text-dark-primary"
-                                        required
-                                    />
-                                </div>
-
-                                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-                                    <select
-                                        value={quickTask.category_id}
-                                        onChange={(e) =>
-                                            setQuickTask({
-                                                ...quickTask,
-                                                category_id: e.target.value,
-                                            })
-                                        }
-                                        className="px-3 py-2 border border-light-border/70 dark:border-dark-border/70 rounded-xl focus:ring-wevie-teal/40 focus:border-wevie-teal dark:bg-dark-card dark:text-dark-primary"
-                                    >
-                                        <option value="">
-                                            Category (optional)
-                                        </option>
-                                        {(categories || []).map((category) => (
-                                            <option
-                                                key={category.id}
-                                                value={category.id}
-                                            >
-                                                {category.name}
-                                            </option>
-                                        ))}
-                                    </select>
-
-                                    <select
-                                        value={quickTask.priority}
-                                        onChange={(e) =>
-                                            setQuickTask({
-                                                ...quickTask,
-                                                priority: e.target.value,
-                                            })
-                                        }
-                                        className="px-3 py-2 border border-light-border/70 dark:border-dark-border/70 rounded-xl focus:ring-wevie-teal/40 focus:border-wevie-teal dark:bg-dark-card dark:text-dark-primary"
-                                    >
-                                        <option value="low">Low</option>
-                                        <option value="medium">Medium</option>
-                                        <option value="high">High</option>
-                                        <option value="urgent">Focus</option>
-                                    </select>
-
-                                    <input
-                                        type="date"
-                                        value={quickTask.due_date}
-                                        onChange={(e) =>
-                                            setQuickTask({
-                                                ...quickTask,
-                                                due_date: e.target.value,
-                                            })
-                                        }
-                                        className="px-3 py-2 border border-light-border/70 dark:border-dark-border/70 rounded-xl focus:ring-wevie-teal/40 focus:border-wevie-teal dark:bg-dark-card dark:text-dark-primary"
-                                    />
-                                </div>
-
-                                <div className="flex justify-end space-x-3">
-                                    <button
-                                        type="button"
-                                        onClick={() => setShowQuickTask(false)}
-                                        className="px-4 py-2 text-sm font-medium text-light-secondary dark:text-dark-secondary bg-white dark:bg-dark-card border border-light-border/70 dark:border-dark-border/70 rounded-xl hover:bg-light-hover dark:hover:bg-dark-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-wevie-teal/30"
-                                    >
-                                        Not now
-                                    </button>
-                                    <button
-                                        type="submit"
-                                        className="px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-wevie-teal to-wevie-mint border border-transparent rounded-xl hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-wevie-teal/40"
-                                    >
-                                        Save task
-                                    </button>
-                                </div>
-                            </form>
-                        </div>
-                    )}
-
-                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                        <button
-                            onClick={() => setShowTaskModal(true)}
-                            className="card-hover flex items-center p-4"
-                        >
-                            <div className="mr-3 flex h-9 w-9 items-center justify-center rounded-full bg-wevie-teal/10">
-                                <Plus className="h-5 w-5 text-wevie-teal" />
-                            </div>
-                            <div>
-                                <h3 className="text-sm text-left font-medium text-light-primary dark:text-dark-primary">
-                                    Create a task
-                                </h3>
-                                <p className="text-xs text-light-muted dark:text-dark-muted">
-                                    Add details now or later
-                                </p>
-                            </div>
-                        </button>
-
-                        <Link
-                            href={route("categories.create")}
-                            className="card-hover flex items-center p-4"
-                        >
-                            <div className="mr-3 flex h-9 w-9 items-center justify-center rounded-full bg-emerald-100/60 dark:bg-emerald-900/30">
-                                <Target className="h-5 w-5 text-emerald-500" />
-                            </div>
-                            <div>
-                                <h3 className="text-sm font-medium text-light-primary dark:text-dark-primary">
-                                    New category
-                                </h3>
-                                <p className="text-xs text-light-muted dark:text-dark-muted">
-                                    Group tasks gently
-                                </p>
-                            </div>
-                        </Link>
-
-                        <Link
-                            href={route("tasks.index")}
-                            className="card-hover flex items-center p-4"
-                        >
-                            <div className="mr-3 flex h-9 w-9 items-center justify-center rounded-full bg-amber-100/60 dark:bg-amber-900/30">
-                                <Zap className="h-5 w-5 text-amber-500" />
-                            </div>
-                            <div>
-                                <h3 className="text-sm font-medium text-light-primary dark:text-dark-primary">
-                                    See all tasks
-                                </h3>
-                                <p className="text-xs text-light-muted dark:text-dark-muted">
-                                    Everything in one place
-                                </p>
-                            </div>
-                        </Link>
-                    </div>
-                </div>
-
-                {/* Current Tasks */}
-                <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
-                    {/* Upcoming Payments */}
-                    <div className="card">
-                        <div className="px-4 sm:px-6 py-4 border-b border-light-border/70 dark:border-dark-border/70">
-                            <h2 className="text-base sm:text-lg font-medium text-light-primary dark:text-dark-primary">
-                                Upcoming payments
-                            </h2>
-                        </div>
-                        <div className="p-4 sm:p-6">
-                            {upcomingPayments.length === 0 ? (
-                                <div className="text-center py-8">
-                                    <Calendar className="mx-auto h-12 w-12 text-light-muted dark:text-dark-muted" />
-                                    <h3 className="mt-2 text-sm font-medium text-light-primary dark:text-dark-primary">
-                                        Nothing scheduled yet
-                                    </h3>
-                                    <p className="mt-1 text-sm text-light-muted dark:text-dark-muted">
-                                        We’ll keep watch when you add one.
-                                    </p>
-                                </div>
-                            ) : (
-                                <div className="space-y-3">
-                                    {upcomingPayments.map((payment) => (
-                                        <div
-                                            key={payment.id}
-                                            className="flex items-center justify-between p-3 bg-light-hover dark:bg-dark-hover rounded-xl"
-                                        >
-                                            <div className="flex items-center space-x-3 flex-1">
-                                                <div className="flex-1 min-w-0">
-                                                    <p className="text-sm font-medium text-light-primary dark:text-dark-primary">
-                                                        {payment.description}
-                                                    </p>
-                                                    {payment.loan && (
-                                                        <div className="flex items-center space-x-1 mt-1">
-                                                            <span className="text-xs text-amber-700 dark:text-amber-200">
-                                                                Loan ·{" "}
-                                                                {payment.loan.name}
-                                                            </span>
-                                                        </div>
-                                                    )}
-                                                    {!payment.loan &&
-                                                        payment.category && (
-                                                            <div className="flex items-center space-x-1 mt-1">
-                                                                <div
-                                                                    className="w-2 h-2 rounded-full"
-                                                                    style={{
-                                                                        backgroundColor:
-                                                                            payment
-                                                                                .category
-                                                                                .color,
-                                                                    }}
-                                                                />
-                                                                <span className="text-xs text-light-muted dark:text-dark-muted">
-                                                                    {
-                                                                        payment
-                                                                            .category
-                                                                            .name
-                                                                    }
-                                                                </span>
-                                                            </div>
-                                                        )}
-                                                </div>
-                                            </div>
-                                            <div className="text-right">
-                                                <p className="text-sm font-semibold text-light-primary dark:text-dark-primary">
-                                                    {formatCurrency(
-                                                        payment.amount,
-                                                        payment.currency ?? "PHP"
-                                                    )}
-                                                </p>
-                                                <p className="text-xs text-light-muted dark:text-dark-muted">
-                                                    {formatDate(
-                                                        payment.occurred_at
-                                                    )}
-                                                </p>
-                                            </div>
-                                        </div>
-                                    ))}
-                                </div>
-                            )}
-                        </div>
-                    </div>
-
-                    {/* Today's Tasks */}
-                    <div className="card">
-                        <div className="px-4 sm:px-6 py-4 border-b border-light-border/70 dark:border-dark-border/70">
-                            <h2 className="text-base sm:text-lg font-medium text-light-primary dark:text-dark-primary">
-                                Today’s tasks
-                            </h2>
-                        </div>
-                        <div className="p-4 sm:p-6">
-                            {localTodayTasks.length === 0 ? (
-                                <div className="flex flex-col items-center py-8 text-center">
-                                    <span className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-primary-400/15 to-[#5FDDE0]/15 dark:from-primary-400/25 dark:to-[#5FDDE0]/25">
-                                        <CalendarDays className="h-7 w-7 text-primary-500 dark:text-[#2ED7A1]" />
-                                    </span>
-                                    <h3 className="mt-3 text-sm font-semibold text-light-primary dark:text-dark-primary">
-                                        A clear day ahead
-                                    </h3>
-                                    <p className="mt-1 max-w-xs text-sm text-light-muted dark:text-dark-muted">
-                                        Add your first task and Wevie will keep it
-                                        front and center when it's due.
-                                    </p>
-                                    <button
-                                        onClick={() => setShowQuickTask(true)}
-                                        className="btn-primary mt-4"
-                                    >
-                                        <Plus className="mr-2 h-4 w-4" />
-                                        Add your first task
-                                    </button>
-                                </div>
-                            ) : (
-                                <div className="space-y-3">
-                                    {localTodayTasks.map((task) => (
-                                        <div
-                                            key={task.id}
-                                            className="flex items-center justify-between p-3 bg-light-hover dark:bg-dark-hover rounded-xl"
-                                        >
-                                            <div className="flex items-center space-x-3 flex-1">
-                                                <button
-                                                    onClick={() =>
-                                                        toggleTaskStatus(task)
-                                                    }
-                                                    className="flex-shrink-0"
-                                                >
-                                                    {getStatusIcon(task.status)}
-                                                </button>
-                                                <div className="flex-1 min-w-0">
-                                                    <p
-                                                        className={`text-sm font-medium ${
-                                                            task.status ===
-                                                            "completed"
-                                                                ? "text-light-muted dark:text-dark-muted line-through"
-                                                                : "text-light-primary dark:text-dark-primary"
-                                                        }`}
-                                                    >
-                                                        {task.title}
-                                                    </p>
-                                                    {task.due_date && (
-                                                        <p className="text-xs text-light-muted dark:text-dark-muted mt-1">
-                                                            Planned for{" "}
-                                                            {formatDate(
-                                                                task.due_date
-                                                            )}
-                                                        </p>
-                                                    )}
-                                                </div>
-                                            </div>
-                                            <div className="flex items-center space-x-2">
-                                                <span
-                                                    className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${getPriorityColor(
-                                                        task.priority
-                                                    )}`}
-                                                >
-                                                    {getPriorityLabel(
-                                                        task.priority
-                                                    )}
-                                                </span>
-                                            </div>
-                                        </div>
-                                    ))}
-                                </div>
-                            )}
-                        </div>
-                    </div>
-                </div>
-
-                {/* Overdue and Upcoming Tasks */}
-                <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                    {/* Overdue Tasks */}
-                    <div className="card">
-                        <div className="px-6 py-4 border-b border-light-border/70 dark:border-dark-border/70">
-                            <h2 className="text-base sm:text-lg font-medium text-light-primary dark:text-dark-primary flex items-center">
-                                <AlertTriangle className="h-5 w-5 text-amber-500 mr-2" />
-                                Tasks to revisit
-                            </h2>
-                        </div>
-                        <div className="p-6">
-                            {localOverdueTasks.length === 0 ? (
-                                <div className="text-center py-8">
-                                    <CheckCircle className="mx-auto h-12 w-12 text-emerald-400" />
-                                    <h3 className="mt-2 text-sm font-medium text-light-primary dark:text-dark-primary">
-                                        Nothing waiting here
-                                    </h3>
-                                    <p className="mt-1 text-sm text-light-muted dark:text-dark-muted">
-                                        You’re all set for now.
-                                    </p>
-                                </div>
-                            ) : (
-                                <div className="space-y-3">
-                                    {localOverdueTasks.map((task) => (
-                                        <div
-                                            key={task.id}
-                                            className="flex items-center justify-between p-3 bg-amber-50/70 dark:bg-amber-900/10 rounded-xl border border-amber-200/60 dark:border-amber-800/40"
-                                        >
-                                            <div className="flex items-center space-x-3 flex-1">
-                                                <button
-                                                    onClick={() =>
-                                                        toggleTaskStatus(task)
-                                                    }
-                                                    className="flex-shrink-0"
-                                                >
-                                                    {getStatusIcon(task.status)}
-                                                </button>
-                                                <div className="flex-1 min-w-0">
-                                                    <p className="text-sm font-medium text-light-primary dark:text-dark-primary">
-                                                        {task.title}
-                                                    </p>
-                                                    <p className="text-xs text-amber-700 dark:text-amber-200 mt-1">
-                                                        Planned for{" "}
-                                                        {formatDate(
-                                                            task.due_date
-                                                        )}
-                                                    </p>
-                                                </div>
-                                            </div>
-                                            <div className="flex items-center space-x-2">
-                                                <span
-                                                    className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${getPriorityColor(
-                                                        task.priority
-                                                    )}`}
-                                                >
-                                                    {getPriorityLabel(
-                                                        task.priority
-                                                    )}
-                                                </span>
-                                                <button
-                                                    onClick={() => handleDeleteTask(task)}
-                                                    className="text-light-muted hover:text-rose-500 dark:text-dark-muted dark:hover:text-rose-300"
-                                                >
-                                                    <Trash2 className="h-4 w-4" />
-                                                </button>
-                                            </div>
-                                        </div>
-                                    ))}
-                                </div>
-                            )}
-                        </div>
-                    </div>
-
-                    {/* Upcoming Tasks */}
-                    <div className="card">
-                        <div className="px-6 py-4 border-b border-light-border/70 dark:border-dark-border/70">
-                            <h2 className="text-base sm:text-lg font-medium text-light-primary dark:text-dark-primary flex items-center">
-                                <Calendar className="h-5 w-5 text-wevie-teal mr-2" />
-                                Coming up
-                            </h2>
-                        </div>
-                        <div className="p-6">
-                            {localUpcomingTasks.length === 0 ? (
-                                <div className="text-center py-8">
-                                    <Calendar className="mx-auto h-12 w-12 text-light-muted dark:text-dark-muted" />
-                                    <h3 className="mt-2 text-sm font-medium text-light-primary dark:text-dark-primary">
-                                        Nothing scheduled yet
-                                    </h3>
-                                    <p className="mt-1 text-sm text-light-muted dark:text-dark-muted">
-                                        Add plans when it feels right.
-                                    </p>
-                                </div>
-                            ) : (
-                                <div className="space-y-3">
-                                    {localUpcomingTasks.map((task) => (
-                                        <div
-                                            key={task.id}
-                                            className="flex items-center justify-between p-3 bg-light-hover dark:bg-dark-hover rounded-xl"
-                                        >
-                                            <div className="flex items-center space-x-3 flex-1">
-                                                <button
-                                                    onClick={() =>
-                                                        toggleTaskStatus(task)
-                                                    }
-                                                    className="flex-shrink-0"
-                                                >
-                                                    {getStatusIcon(task.status)}
-                                                </button>
-                                                <div className="flex-1 min-w-0">
-                                                    <div className="flex items-center space-x-2">
-                                                        <p className="text-sm font-medium text-light-primary dark:text-dark-primary">
-                                                            {task.title}
-                                                        </p>
-                                                        {task.is_recurring && (
-                                                            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-violet-100/70 text-violet-700 dark:bg-violet-900/20 dark:text-violet-200">
-                                                                Steady rhythm
-                                                            </span>
-                                                        )}
-                                                    </div>
-                                                    <p className="text-xs text-light-muted dark:text-dark-muted mt-1">
-                                                        Planned for{" "}
-                                                        {formatDate(
-                                                            task.due_date
-                                                        )}
-                                                    </p>
-                                                </div>
-                                            </div>
-                                            <div className="flex items-center space-x-2">
-                                                <span
-                                                    className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${getPriorityColor(
-                                                        task.priority
-                                                    )}`}
-                                                >
-                                                    {getPriorityLabel(
-                                                        task.priority
-                                                    )}
-                                                </span>
-                                                <button
-                                                    onClick={() => handleDeleteTask(task)}
-                                                    className="text-light-muted hover:text-rose-500 dark:text-dark-muted dark:hover:text-rose-300"
-                                                >
-                                                    <Trash2 className="h-4 w-4" />
-                                                </button>
-                                            </div>
-                                        </div>
-                                    ))}
-                                </div>
-                            )}
-                        </div>
-                    </div>
-                </div>
+                <WidgetGrid layout={layout} widgetData={widgetData} onReorder={handleReorder} />
             </div>
-            <TaskModal
-                show={showTaskModal}
-                onClose={() => setShowTaskModal(false)}
-            />
-            <TaskViewModal
-                show={showViewModal}
-                onClose={() => {
-                    setShowViewModal(false);
-                    setSelectedTask(null);
-                }}
-                task={selectedTask}
-                onTaskUpdate={handleTaskUpdate}
-            />
-            <TaskEditModal
-                show={showEditModal}
-                onClose={() => {
-                    setShowEditModal(false);
-                    setSelectedTask(null);
-                }}
-                task={selectedTask}
-                categories={categories}
-                onTaskUpdate={handleTaskUpdate}
-            />
 
-            <ScheduleModal
-                show={showScheduleModal}
-                onClose={() => setShowScheduleModal(false)}
-                currentTasks={localCurrentTasks}
-                todayTasks={localTodayTasks}
-                overdueTasks={localOverdueTasks}
-                upcomingTasks={localUpcomingTasks}
-                weeklyTasks={weeklyTasks}
-                toggleTaskStatus={toggleTaskStatus}
-                setSelectedTask={setSelectedTask}
-                setShowViewModal={setShowViewModal}
-                setShowEditModal={setShowEditModal}
+            <CustomizeDashboardModal
+                show={showCustomize}
+                onClose={() => setShowCustomize(false)}
+                availableWidgets={availableWidgets}
+                widgetLayout={layout}
+                onSaved={handleCustomizeSaved}
             />
         </TodoLayout>
     );

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
@@ -2,30 +2,25 @@ import InputError from "@/Components/InputError";
 import InputLabel from "@/Components/InputLabel";
 import PrimaryButton from "@/Components/PrimaryButton";
 import TextInput from "@/Components/TextInput";
-import { Transition } from "@headlessui/react";
+import { Switch, Transition } from "@headlessui/react";
 import { Link, useForm, usePage } from "@inertiajs/react";
+import { Sparkles } from "lucide-react";
 import { useEffect } from "react";
 
-export default function UpdateProfileInformation({
-    mustVerifyEmail,
-    status,
-    className = "",
-}) {
+export default function UpdateProfileInformation({ mustVerifyEmail, status, className = "" }) {
     const user = usePage().props.auth.user;
 
-    const { data, setData, patch, errors, processing, recentlySuccessful } =
-        useForm({
-            name: user.name,
-            email: user.email,
-            timezone:
-                user.timezone ||
-                Intl.DateTimeFormat().resolvedOptions().timeZone,
-        });
+    const { data, setData, patch, errors, processing, recentlySuccessful } = useForm({
+        name: user.name,
+        email: user.email,
+        timezone: user.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone,
+        daily_summary_enabled: user.daily_summary_enabled ?? false,
+        daily_summary_time: user.daily_summary_time || "08:00",
+    });
 
     // Auto-detect timezone on component mount
     useEffect(() => {
-        const detectedTimezone =
-            Intl.DateTimeFormat().resolvedOptions().timeZone;
+        const detectedTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
         if (!user.timezone && detectedTimezone) {
             setData("timezone", detectedTimezone);
         }
@@ -94,18 +89,10 @@ export default function UpdateProfileInformation({
                     >
                         <option value="">Select Timezone</option>
                         <option value="UTC">UTC</option>
-                        <option value="America/New_York">
-                            Eastern Time (US & Canada)
-                        </option>
-                        <option value="America/Chicago">
-                            Central Time (US & Canada)
-                        </option>
-                        <option value="America/Denver">
-                            Mountain Time (US & Canada)
-                        </option>
-                        <option value="America/Los_Angeles">
-                            Pacific Time (US & Canada)
-                        </option>
+                        <option value="America/New_York">Eastern Time (US & Canada)</option>
+                        <option value="America/Chicago">Central Time (US & Canada)</option>
+                        <option value="America/Denver">Mountain Time (US & Canada)</option>
+                        <option value="America/Los_Angeles">Pacific Time (US & Canada)</option>
                         <option value="Europe/London">London</option>
                         <option value="Europe/Paris">Paris</option>
                         <option value="Europe/Berlin">Berlin</option>
@@ -123,9 +110,65 @@ export default function UpdateProfileInformation({
                     <InputError className="mt-2" message={errors.timezone} />
 
                     <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                        Your timezone is automatically detected. You can change
-                        it if needed.
+                        Your timezone is automatically detected. You can change it if needed.
                     </p>
+                </div>
+
+                <div className="rounded-xl border border-light-border/70 p-4 dark:border-dark-border/70">
+                    <div className="flex items-start justify-between gap-4">
+                        <div className="flex items-start gap-3">
+                            <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-wevie-teal to-wevie-mint text-white">
+                                <Sparkles className="h-5 w-5" aria-hidden="true" />
+                            </span>
+                            <div>
+                                <InputLabel
+                                    htmlFor="daily_summary_enabled"
+                                    value="Daily AI summary"
+                                    className="!text-base !font-medium text-gray-900 dark:text-gray-100"
+                                />
+                                <p className="mt-0.5 text-sm text-gray-600 dark:text-gray-400">
+                                    Get an AI recap of your tasks and priorities each morning on
+                                    your dashboard.
+                                </p>
+                            </div>
+                        </div>
+                        <Switch
+                            id="daily_summary_enabled"
+                            checked={data.daily_summary_enabled}
+                            onChange={(value) => setData("daily_summary_enabled", value)}
+                            className={`${
+                                data.daily_summary_enabled
+                                    ? "bg-gradient-to-r from-wevie-teal to-wevie-mint"
+                                    : "bg-gray-300 dark:bg-gray-600"
+                            } relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-wevie-teal/40`}
+                        >
+                            <span className="sr-only">Toggle daily AI summary</span>
+                            <span
+                                className={`${
+                                    data.daily_summary_enabled ? "translate-x-6" : "translate-x-1"
+                                } inline-block h-4 w-4 transform rounded-full bg-white transition-transform`}
+                            />
+                        </Switch>
+                    </div>
+
+                    {data.daily_summary_enabled && (
+                        <div className="mt-4">
+                            <InputLabel htmlFor="daily_summary_time" value="Delivery time" />
+                            <input
+                                id="daily_summary_time"
+                                type="time"
+                                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-white/10 dark:bg-dark-card dark:text-gray-300 dark:focus:border-indigo-600 dark:focus:ring-indigo-600 sm:w-48"
+                                value={data.daily_summary_time}
+                                onChange={(e) => setData("daily_summary_time", e.target.value)}
+                            />
+                            <InputError className="mt-2" message={errors.daily_summary_time} />
+                            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                                We’ll prepare your summary around this time in your timezone.
+                            </p>
+                        </div>
+                    )}
+
+                    <InputError className="mt-2" message={errors.daily_summary_enabled} />
                 </div>
 
                 {mustVerifyEmail && user.email_verified_at === null && (
@@ -143,9 +186,8 @@ export default function UpdateProfileInformation({
                         </p>
 
                         {status === "verification-link-sent" && (
-                        <div className="mt-2 text-sm font-medium text-green-600 dark:text-green-300">
-                                A new verification link has been sent to your
-                                email address.
+                            <div className="mt-2 text-sm font-medium text-green-600 dark:text-green-300">
+                                A new verification link has been sent to your email address.
                             </div>
                         )}
                     </div>
@@ -161,9 +203,7 @@ export default function UpdateProfileInformation({
                         leave="transition ease-in-out"
                         leaveTo="opacity-0"
                     >
-                        <p className="text-sm text-gray-600 dark:text-gray-400">
-                            Saved.
-                        </p>
+                        <p className="text-sm text-gray-600 dark:text-gray-400">Saved.</p>
                     </Transition>
                 </div>
             </form>

--- a/resources/js/tours/index.js
+++ b/resources/js/tours/index.js
@@ -24,6 +24,16 @@ export const onboardingSteps = [
         mobilePlacement: "top",
     },
     {
+        target: '[data-tour="customize-dashboard"]',
+        mobileTarget: "body",
+        mobilePlacement: "center",
+        emoji: "🧩",
+        title: "Make the dashboard yours",
+        content:
+            "Tap Customize to switch widgets on or off, resize them, and drag them into the order that suits you. Your layout saves automatically.",
+        placement: "bottom",
+    },
+    {
         target: '[data-tour="nav-tasks"]',
         mobileTarget: '[data-tour="mobile-nav-tasks"]',
         emoji: "✅",
@@ -216,8 +226,7 @@ export const tasksSteps = [
     {
         target: '[data-tour="tasks-filters"]',
         title: "Find what you need",
-        content:
-            "Search by keyword, or filter by status, priority, category, or tag.",
+        content: "Search by keyword, or filter by status, priority, category, or tag.",
         placement: "bottom",
     },
     {
@@ -330,8 +339,7 @@ export const walletSavingsGoalsSteps = [
     {
         target: '[data-tour="goals-filters"]',
         title: "Filter & sort",
-        content:
-            "Filter by status or account to see only the goals you care about right now.",
+        content: "Filter by status or account to see only the goals you care about right now.",
         placement: "bottom",
     },
     {
@@ -362,8 +370,7 @@ export const walletLoansSteps = [
     {
         target: '[data-tour="loans-filters"]',
         title: "Filter the list",
-        content:
-            "Filter by loan type, status, or counterparty to find a specific loan quickly.",
+        content: "Filter by loan type, status, or counterparty to find a specific loan quickly.",
         placement: "bottom",
     },
     {
@@ -387,24 +394,21 @@ export const addTaskFormSteps = [
     {
         target: '[data-tour="task-title"]',
         title: "Title",
-        content:
-            "A short summary, e.g. \"Pay electricity bill\" or \"Send draft to manager\".",
+        content: 'A short summary, e.g. "Pay electricity bill" or "Send draft to manager".',
         placement: "bottom",
         mobilePlacement: "top",
     },
     {
         target: '[data-tour="task-category"]',
         title: "Category",
-        content:
-            "Drop the task into a bucket so you can filter and color-code later. Optional.",
+        content: "Drop the task into a bucket so you can filter and color-code later. Optional.",
         placement: "bottom",
         mobilePlacement: "top",
     },
     {
         target: '[data-tour="task-priority"]',
         title: "Priority",
-        content:
-            'Use Focus for "do this today" tasks. Lower priorities surface less aggressively.',
+        content: 'Use Focus for "do this today" tasks. Lower priorities surface less aggressively.',
         placement: "bottom",
         mobilePlacement: "top",
     },
@@ -471,8 +475,7 @@ export const addTransactionFormSteps = [
     {
         target: '[data-tour="txn-amount"]',
         title: "Amount",
-        content:
-            "Always positive — Wevie figures out the sign based on the type you picked above.",
+        content: "Always positive — Wevie figures out the sign based on the type you picked above.",
         placement: "bottom",
         mobilePlacement: "top",
     },

--- a/resources/js/widgets/registry.js
+++ b/resources/js/widgets/registry.js
@@ -1,0 +1,57 @@
+import TaskStatsWidget from "@/Components/widgets/TaskStatsWidget";
+import TodayTasksWidget from "@/Components/widgets/TodayTasksWidget";
+import OverdueTasksWidget from "@/Components/widgets/OverdueTasksWidget";
+import UpcomingTasksWidget from "@/Components/widgets/UpcomingTasksWidget";
+import InProgressWidget from "@/Components/widgets/InProgressWidget";
+import UpcomingPaymentsWidget from "@/Components/widgets/UpcomingPaymentsWidget";
+import BudgetWidget from "@/Components/widgets/BudgetWidget";
+import CalendarWidget from "@/Components/widgets/CalendarWidget";
+import ProductivityWidget from "@/Components/widgets/ProductivityWidget";
+import PomodoroWidget from "@/Components/widgets/PomodoroWidget";
+import WeatherWidget from "@/Components/widgets/WeatherWidget";
+
+/**
+ * Client-side registry mapping a widget `key` (from the backend layout) to its
+ * React component and display title. `selfContained` marks widgets that render
+ * their own `.card` shell (Weather) instead of a shared WidgetFrame — the grid
+ * uses this to overlay the drag handle rather than pass it through.
+ */
+export const WIDGET_REGISTRY = {
+    task_stats: { Component: TaskStatsWidget, title: "Task overview" },
+    today_tasks: { Component: TodayTasksWidget, title: "Today’s tasks" },
+    overdue_tasks: { Component: OverdueTasksWidget, title: "Tasks to revisit" },
+    upcoming_tasks: { Component: UpcomingTasksWidget, title: "Coming up" },
+    in_progress: { Component: InProgressWidget, title: "In progress" },
+    upcoming_payments: {
+        Component: UpcomingPaymentsWidget,
+        title: "Upcoming payments",
+    },
+    budgets: { Component: BudgetWidget, title: "Budgets" },
+    calendar: { Component: CalendarWidget, title: "Next 7 days" },
+    productivity: { Component: ProductivityWidget, title: "Productivity" },
+    pomodoro: { Component: PomodoroWidget, title: "Pomodoro" },
+    weather: { Component: WeatherWidget, title: "Weather", selfContained: true },
+};
+
+/**
+ * Look up a registry entry by key. Returns `null` for unknown keys so the grid
+ * can skip anything the backend sends that this client build doesn't know yet.
+ */
+export function getWidget(key) {
+    return WIDGET_REGISTRY[key] ?? null;
+}
+
+/**
+ * Size → column-span class. Full static strings (never concatenated) so
+ * Tailwind's JIT keeps them; also mirrored in tailwind.config safelist.
+ *   sm → 1 col, md → 2 cols, lg → full row (4 cols) on lg screens.
+ */
+export const SIZE_COLSPAN = {
+    sm: "sm:col-span-2 lg:col-span-1",
+    md: "sm:col-span-2 lg:col-span-2",
+    lg: "sm:col-span-2 lg:col-span-4",
+};
+
+export function getColSpanClass(size) {
+    return SIZE_COLSPAN[size] ?? SIZE_COLSPAN.md;
+}

--- a/routes/console.php
+++ b/routes/console.php
@@ -12,3 +12,9 @@ Artisan::command('inspire', function () {
 Schedule::command('tasks:reset-recurring')
     ->daily()
     ->description('Reset completed recurring tasks for the next occurrence');
+
+// Dispatch AI daily summaries every hour; the command decides which users are
+// due based on their per-user local time preference.
+Schedule::command('app:generate-daily-summaries')
+    ->hourly()
+    ->description('Generate AI daily summaries');

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\BoardController;
 use App\Http\Controllers\CalendarController;
 use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\DashboardLayoutController;
 use App\Http\Controllers\GoogleCalendarController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ReminderController;
@@ -46,6 +47,14 @@ Route::get('/offline', function () {
 Route::get('/dashboard', [DashboardController::class, 'index'])
     ->middleware(['auth', 'verified'])
     ->name('dashboard');
+
+// Dashboard widget layout + AI daily summary
+Route::middleware('auth')->group(function () {
+    Route::post('dashboard/layout', [DashboardLayoutController::class, 'update'])
+        ->name('dashboard.layout.update');
+    Route::post('dashboard/summary/refresh', [DashboardLayoutController::class, 'refreshSummary'])
+        ->name('dashboard.summary.refresh');
+});
 
 // Main todo app routes
 Route::middleware(['auth', 'verified'])->group(function () {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,12 @@ export default {
         {
             pattern: /(bg|text|stroke|fill)-(slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(100|200|300|400|500|600|700|800|900)/,
         },
+        // Dashboard widget column spans — mapped from widget size in
+        // resources/js/widgets/registry.js. Safelisted so the JIT keeps them.
+        'sm:col-span-2',
+        'lg:col-span-1',
+        'lg:col-span-2',
+        'lg:col-span-4',
     ],
 
     darkMode: 'class',

--- a/tests/Feature/DailySummaryServiceTest.php
+++ b/tests/Feature/DailySummaryServiceTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\Models\DailySummary;
+use App\Models\User;
+use App\Services\Ai\Contracts\TextGenerator;
+use App\Services\DailySummaryService;
+
+function fakeGenerator(callable $handler): TextGenerator
+{
+    return new class($handler) implements TextGenerator
+    {
+        public function __construct(private $handler) {}
+
+        public function generate(string $system, string $prompt, array $options = []): string
+        {
+            return ($this->handler)($system, $prompt, $options);
+        }
+    };
+}
+
+it('generates and upserts a summary using the text generator', function () {
+    $user = User::factory()->create();
+
+    $this->app->bind(TextGenerator::class, fn () => fakeGenerator(
+        fn () => 'Here is your friendly AI summary for today.'
+    ));
+
+    $service = $this->app->make(DailySummaryService::class);
+    $summary = $service->generateForUser($user);
+
+    expect($summary)->toBeInstanceOf(DailySummary::class)
+        ->and($summary->content)->toBe('Here is your friendly AI summary for today.')
+        ->and($summary->provider)->not->toBe('fallback');
+
+    $this->assertDatabaseCount('daily_summaries', 1);
+    $this->assertDatabaseHas('daily_summaries', ['user_id' => $user->id]);
+
+    // Re-generating the same day upserts rather than duplicating.
+    $service->generateForUser($user);
+    $this->assertDatabaseCount('daily_summaries', 1);
+});
+
+it('falls back to a deterministic template when the provider fails', function () {
+    $user = User::factory()->create();
+
+    $this->app->bind(TextGenerator::class, fn () => fakeGenerator(
+        fn () => throw new RuntimeException('provider down')
+    ));
+
+    $service = $this->app->make(DailySummaryService::class);
+    $summary = $service->generateForUser($user);
+
+    expect($summary->provider)->toBe('fallback')
+        ->and($summary->model)->toBe('template')
+        ->and($summary->content)->toContain('task')
+        ->and($summary->content)->toContain('overdue');
+
+    $this->assertDatabaseCount('daily_summaries', 1);
+});
+
+it('returns the cached summary for today', function () {
+    $user = User::factory()->create();
+
+    expect(app(DailySummaryService::class)->getCachedForToday($user))->toBeNull();
+
+    DailySummary::factory()->create([
+        'user_id' => $user->id,
+        'summary_date' => $user->nowInUserTimezone()->toDateString(),
+    ]);
+
+    expect(app(DailySummaryService::class)->getCachedForToday($user))
+        ->not->toBeNull();
+});

--- a/tests/Feature/DashboardLayoutTest.php
+++ b/tests/Feature/DashboardLayoutTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Models\User;
+use App\Support\DashboardWidgets;
+
+it('persists a valid widget layout', function () {
+    $user = User::factory()->create();
+
+    $layout = [
+        ['key' => 'task_stats', 'size' => 'lg', 'enabled' => true],
+        ['key' => 'pomodoro', 'size' => 'sm', 'enabled' => false],
+    ];
+
+    $this->actingAs($user)
+        ->post(route('dashboard.layout.update'), ['widgets' => $layout])
+        ->assertRedirect();
+
+    $user->refresh();
+
+    expect($user->dashboard_widgets)->toBe($layout);
+});
+
+it('rejects unknown widget keys', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->from(route('dashboard'))
+        ->post(route('dashboard.layout.update'), [
+            'widgets' => [
+                ['key' => 'not_a_widget', 'size' => 'md', 'enabled' => true],
+            ],
+        ])
+        ->assertSessionHasErrors('widgets.0.key');
+
+    expect($user->fresh()->dashboard_widgets)->toBeNull();
+});
+
+it('rejects an invalid size value', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->from(route('dashboard'))
+        ->post(route('dashboard.layout.update'), [
+            'widgets' => [
+                ['key' => 'task_stats', 'size' => 'xl', 'enabled' => true],
+            ],
+        ])
+        ->assertSessionHasErrors('widgets.0.size');
+});
+
+it('rejects a size not allowed for that specific widget', function () {
+    $user = User::factory()->create();
+
+    // weather only allows sm|md, so lg must be rejected.
+    $this->actingAs($user)
+        ->from(route('dashboard'))
+        ->post(route('dashboard.layout.update'), [
+            'widgets' => [
+                ['key' => 'weather', 'size' => 'lg', 'enabled' => true],
+            ],
+        ])
+        ->assertSessionHasErrors('widgets.0.size');
+});
+
+it('exposes every registry key with the default layout', function () {
+    $keys = DashboardWidgets::keys();
+
+    expect($keys)->toContain('task_stats', 'pomodoro', 'weather')
+        ->and(DashboardWidgets::defaultLayout())->toHaveCount(count($keys));
+});

--- a/tests/Feature/DashboardWidgetsTest.php
+++ b/tests/Feature/DashboardWidgetsTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Models\DailySummary;
+use App\Models\User;
+
+it('renders the dashboard with the widget props contract', function () {
+    $user = User::factory()->create();
+
+    $this->withoutVite();
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('Dashboard')
+            ->has('availableWidgets')
+            ->has('widgetLayout')
+            ->has('widgetData')
+            ->has('categories')
+            ->has('gettingStarted')
+            ->where('canUseDailySummary', true)
+            ->where('dailySummaryEnabled', true)
+            ->where('dailySummaryTime', '08:00')
+            ->where('dailySummary', null)
+        );
+});
+
+it('surfaces a cached daily summary in the dashboard props', function () {
+    $user = User::factory()->create();
+
+    DailySummary::factory()->create([
+        'user_id' => $user->id,
+        'summary_date' => $user->nowInUserTimezone()->toDateString(),
+        'content' => 'Today looks manageable.',
+        'provider' => 'anthropic',
+        'model' => 'claude-sonnet-5',
+    ]);
+
+    $this->withoutVite();
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('dailySummary.content', 'Today looks manageable.')
+            ->where('dailySummary.provider', 'anthropic')
+        );
+});
+
+it('refresh endpoint regenerates the summary and redirects back', function () {
+    $user = User::factory()->create();
+
+    $this->app->bind(\App\Services\Ai\Contracts\TextGenerator::class, fn () => new class implements \App\Services\Ai\Contracts\TextGenerator
+    {
+        public function generate(string $system, string $prompt, array $options = []): string
+        {
+            return 'Fresh summary generated on demand.';
+        }
+    });
+
+    $this->actingAs($user)
+        ->from(route('dashboard'))
+        ->post(route('dashboard.summary.refresh'))
+        ->assertRedirect();
+
+    $this->assertDatabaseHas('daily_summaries', [
+        'user_id' => $user->id,
+        'content' => 'Fresh summary generated on demand.',
+    ]);
+});

--- a/tests/Feature/GenerateDailySummariesCommandTest.php
+++ b/tests/Feature/GenerateDailySummariesCommandTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use App\Jobs\GenerateDailySummaryJob;
+use App\Models\DailySummary;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Queue;
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+it('dispatches the job only for enabled users whose local hour matches', function () {
+    Queue::fake();
+
+    // 2026-07-23 06:00 UTC.
+    Carbon::setTestNow(Carbon::create(2026, 7, 23, 6, 0, 0, 'UTC'));
+
+    // Manila is UTC+8 => local time is 14:00, matches "14:00".
+    $due = User::factory()->create([
+        'timezone' => 'Asia/Manila',
+        'daily_summary_enabled' => true,
+        'daily_summary_time' => '14:00',
+    ]);
+
+    // Same tz but preference is a different hour.
+    $wrongHour = User::factory()->create([
+        'timezone' => 'Asia/Manila',
+        'daily_summary_enabled' => true,
+        'daily_summary_time' => '09:00',
+    ]);
+
+    // Right hour but summaries disabled.
+    $disabled = User::factory()->create([
+        'timezone' => 'Asia/Manila',
+        'daily_summary_enabled' => false,
+        'daily_summary_time' => '14:00',
+    ]);
+
+    $this->artisan('app:generate-daily-summaries')->assertSuccessful();
+
+    Queue::assertPushed(GenerateDailySummaryJob::class, 1);
+    Queue::assertPushed(
+        GenerateDailySummaryJob::class,
+        fn (GenerateDailySummaryJob $job) => $job->userId === $due->id
+    );
+});
+
+it('does not re-dispatch when a summary already exists for today', function () {
+    Queue::fake();
+
+    Carbon::setTestNow(Carbon::create(2026, 7, 23, 6, 0, 0, 'UTC'));
+
+    $user = User::factory()->create([
+        'timezone' => 'Asia/Manila',
+        'daily_summary_enabled' => true,
+        'daily_summary_time' => '14:00',
+    ]);
+
+    DailySummary::factory()->create([
+        'user_id' => $user->id,
+        'summary_date' => $user->nowInUserTimezone()->toDateString(),
+    ]);
+
+    $this->artisan('app:generate-daily-summaries')->assertSuccessful();
+
+    Queue::assertNotPushed(GenerateDailySummaryJob::class);
+});


### PR DESCRIPTION
Redevelops the user dashboard into a customizable widget grid where users toggle, drag-reorder (dnd-kit), and size (S/M/L) widgets covering tasks, calendar, finance, analytics, and pomodoro, with the layout persisted per-user via a widget registry that is the single source of truth on both server and client. Adds an AI "summary of your day" banner backed by a provider-agnostic driver layer (Claude Sonnet 5 default; OpenAI and Gemini selectable via config), drawing from tasks + calendar + finance, cached per-day and generated by a queued job on an hourly per-timezone schedule (default 8 AM, user-configurable) plus on-demand refresh, with a templated fallback if a provider call fails. The summary is gated as a Pro feature behind a config flag (open to all during testing; one-line flip to pro later), and a dashboard-setup step was added to the onboarding tour. New Pest tests cover layout validation, summary generation/fallback, and the scheduled command; the frontend build passes and there are no test regressions against the pre-existing baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)