### PR TITLE
Add AI spending insights coach to the Finance dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,3 +84,6 @@ OPENAI_API_KEY=
 OPENAI_MODEL=gpt-4o-mini
 GEMINI_API_KEY=
 GEMINI_MODEL=gemini-1.5-flash
+# Feature gating (open beta = free for everyone until a paid plan exists).
+AI_DAILY_SUMMARY_OPEN_BETA=true
+AI_FINANCE_INSIGHTS_OPEN_BETA=true

--- a/app/Modules/Finance/Controllers/FinanceDashboardController.php
+++ b/app/Modules/Finance/Controllers/FinanceDashboardController.php
@@ -5,6 +5,7 @@ namespace App\Modules\Finance\Controllers;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Modules\Finance\Services\FinanceAccessService;
+use App\Modules\Finance\Services\FinanceInsightService;
 use App\Modules\Finance\Services\FinanceService;
 use App\Modules\Finance\Services\FinanceWalletService;
 use Illuminate\Http\Request;
@@ -17,7 +18,8 @@ class FinanceDashboardController extends Controller
     public function __construct(
         private FinanceService $financeService,
         private FinanceAccessService $accessService,
-        private FinanceWalletService $walletService
+        private FinanceWalletService $walletService,
+        private FinanceInsightService $insightService
     ) {}
 
     public function index(Request $request): Response
@@ -32,10 +34,18 @@ class FinanceDashboardController extends Controller
             ->select(['id', 'name', 'email'])
             ->find($walletUserId);
 
+        $range = $request->string('range')->toString() ?: null;
+
         $data = $this->financeService->getDashboardData(
             $walletUserId,
-            $request->string('range')->toString() ?: null
+            $range
         );
+
+        // Spending insights are personal to the signed-in user's own wallet.
+        $isWalletOwner = $walletUserId === $user->id;
+        $financeInsight = $isWalletOwner
+            ? $this->insightService->getCachedForCurrentPeriod($user, $range)
+            : null;
 
         return Inertia::render('Finance/Dashboard', [
             'transactions' => $data['transactions'],
@@ -51,10 +61,12 @@ class FinanceDashboardController extends Controller
             'walletUserId' => $walletUserId,
             'collaborators' => $user->walletCollaborators()
                 ->get(['users.id', 'users.name', 'users.email', 'finance_wallet_collaborators.role']),
-            'isWalletOwner' => $walletUserId === $user->id,
+            'isWalletOwner' => $isWalletOwner,
             'tier' => $this->accessService->getTier($user),
             'canAccessAdvancedCharts' => $this->accessService->canAccessAdvancedCharts($user),
+            'financeInsight' => $financeInsight,
+            'canUseFinanceInsights' => $isWalletOwner && $this->insightService->userCanUseInsights($user),
+            'insightRange' => $data['summary']['range'] ?? 'this_month',
         ]);
     }
-
 }

--- a/app/Modules/Finance/Controllers/FinanceInsightController.php
+++ b/app/Modules/Finance/Controllers/FinanceInsightController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Modules\Finance\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Modules\Finance\Services\FinanceInsightService;
+use App\Modules\Finance\Services\FinanceReportService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class FinanceInsightController extends Controller
+{
+    public function __construct(
+        private FinanceInsightService $insightService,
+    ) {}
+
+    /**
+     * Synchronously generate the user's AI spending insight for a period.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+
+        if (! $this->insightService->userCanUseInsights($user)) {
+            return back()->with('error', 'Spending insights are not available on your plan.');
+        }
+
+        $validated = $request->validate([
+            'range' => ['nullable', 'string', 'in:'.implode(',', FinanceReportService::RANGES)],
+        ]);
+
+        $range = $validated['range'] ?? null;
+
+        // One insight per period: if this period's has already been generated,
+        // don't regenerate it.
+        if ($this->insightService->getCachedForCurrentPeriod($user, $range)) {
+            return back()->with('info', 'Your insight for this period has already been generated.');
+        }
+
+        $this->insightService->generateForUser($user, $range);
+
+        return back();
+    }
+}

--- a/app/Modules/Finance/Models/FinanceInsight.php
+++ b/app/Modules/Finance/Models/FinanceInsight.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Modules\Finance\Models;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FinanceInsight extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'period_start',
+        'period_end',
+        'range',
+        'content',
+        'provider',
+        'model',
+        'generated_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'period_start' => 'date',
+            'period_end' => 'date',
+            'generated_at' => 'datetime',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Modules/Finance/Repositories/FinanceInsightRepository.php
+++ b/app/Modules/Finance/Repositories/FinanceInsightRepository.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Modules\Finance\Repositories;
+
+use App\Modules\Finance\Models\FinanceInsight;
+use Carbon\CarbonInterface;
+
+class FinanceInsightRepository
+{
+    public function findForUserAndPeriod(
+        int $userId,
+        CarbonInterface $periodStart,
+        CarbonInterface $periodEnd
+    ): ?FinanceInsight {
+        return FinanceInsight::where('user_id', $userId)
+            ->whereDate('period_start', $periodStart->toDateString())
+            ->whereDate('period_end', $periodEnd->toDateString())
+            ->first();
+    }
+
+    public function upsertForUserAndPeriod(
+        int $userId,
+        CarbonInterface $periodStart,
+        CarbonInterface $periodEnd,
+        string $range,
+        array $attributes
+    ): FinanceInsight {
+        // Match on the calendar period via whereDate so a stored time component
+        // never causes a false miss (portable across MySQL/SQLite/Postgres).
+        // Falls through to a create when none exists.
+        $insight = $this->findForUserAndPeriod($userId, $periodStart, $periodEnd);
+
+        if ($insight) {
+            $insight->update($attributes);
+
+            return $insight;
+        }
+
+        return FinanceInsight::create(array_merge($attributes, [
+            'user_id' => $userId,
+            'period_start' => $periodStart->toDateString(),
+            'period_end' => $periodEnd->toDateString(),
+            'range' => $range,
+        ]));
+    }
+}

--- a/app/Modules/Finance/Services/FinanceAccessService.php
+++ b/app/Modules/Finance/Services/FinanceAccessService.php
@@ -19,4 +19,9 @@ class FinanceAccessService
     {
         return $this->getTier($user) === 'premium';
     }
+
+    public function canUseInsights(User $user): bool
+    {
+        return $this->getTier($user) === 'premium';
+    }
 }

--- a/app/Modules/Finance/Services/FinanceInsightService.php
+++ b/app/Modules/Finance/Services/FinanceInsightService.php
@@ -1,0 +1,299 @@
+<?php
+
+namespace App\Modules\Finance\Services;
+
+use App\Models\User;
+use App\Modules\Finance\Models\FinanceInsight;
+use App\Modules\Finance\Repositories\FinanceInsightRepository;
+use App\Modules\Finance\Repositories\FinanceSavingsGoalRepository;
+use App\Services\Ai\Contracts\TextGenerator;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class FinanceInsightService
+{
+    public function __construct(
+        private FinanceReportService $reportService,
+        private FinanceSavingsGoalRepository $savingsGoalRepository,
+        private FinanceInsightRepository $repository,
+        private FinanceAccessService $accessService,
+        private TextGenerator $textGenerator,
+    ) {}
+
+    /**
+     * Whether the user is entitled to AI spending insights (a "pro" feature).
+     *
+     * Centralized so gating the feature to a paid plan later is a one-line
+     * change. During the open beta everyone is entitled; once the beta ends the
+     * real tier check in FinanceAccessService takes over.
+     */
+    public function userCanUseInsights(User $user): bool
+    {
+        // Open beta: treat everyone as entitled while we test publicly.
+        if (config('ai.finance_insights_open_beta', true)) {
+            return true;
+        }
+
+        return $this->accessService->canUseInsights($user);
+    }
+
+    /**
+     * Generate (and persist) the spending-insight coach for a user and range.
+     * Falls back to a deterministic template if the AI provider fails, so the
+     * dashboard never breaks on provider errors.
+     */
+    public function generateForUser(User $user, ?string $range = null): FinanceInsight
+    {
+        $context = $this->buildContext($user, $range);
+        [$periodStart, $periodEnd] = $this->resolvePeriod($context);
+
+        $provider = (string) config('ai.default', 'anthropic');
+        $model = (string) config("ai.providers.{$provider}.model", $provider);
+
+        $system = 'You are a warm, practical personal finance coach writing a user\'s spending briefing. '
+            .'Write about 2-3 short paragraphs (roughly 5-8 sentences) in plain prose. '
+            .'Reference the user\'s actual numbers and category names when they are provided. '
+            .'Highlight where the money went, flag categories or budgets that look overspent, note progress toward savings goals, '
+            .'and give one or two concrete, actionable suggestions for the rest of the period. '
+            .'Address the user directly by their first name and close with a short, genuine note of encouragement. '
+            .'Write in plain prose only — no markdown, no headings, no bullet lists.';
+        $prompt = $this->buildPrompt($user, $context);
+
+        try {
+            $content = trim($this->textGenerator->generate($system, $prompt));
+
+            if ($content === '') {
+                throw new \RuntimeException('AI provider returned an empty insight.');
+            }
+        } catch (Throwable $e) {
+            Log::warning('Finance insight generation failed; using template fallback.', [
+                'user_id' => $user->id,
+                'provider' => $provider,
+                'error' => $e->getMessage(),
+            ]);
+
+            $content = $this->templateInsight($context);
+            $provider = 'fallback';
+            $model = 'template';
+        }
+
+        return $this->repository->upsertForUserAndPeriod(
+            $user->id,
+            $periodStart,
+            $periodEnd,
+            (string) ($context['summary']['range'] ?? 'this_month'),
+            [
+                'content' => $content,
+                'provider' => $provider,
+                'model' => $model,
+                'generated_at' => now(),
+            ]
+        );
+    }
+
+    /**
+     * The cached insight for the user's currently-selected period, if one
+     * exists. Used on dashboard load so we never regenerate on every visit.
+     */
+    public function getCachedForCurrentPeriod(User $user, ?string $range = null): ?FinanceInsight
+    {
+        $context = $this->buildContext($user, $range);
+        [$periodStart, $periodEnd] = $this->resolvePeriod($context);
+
+        return $this->repository->findForUserAndPeriod($user->id, $periodStart, $periodEnd);
+    }
+
+    /**
+     * Gather the finance context for the prompt by reusing the report layer —
+     * totals, category breakdown, and budgets — plus savings-goal progress.
+     * No new SQL: buildDashboardData already computes everything portably.
+     *
+     * @return array<string, mixed>
+     */
+    private function buildContext(User $user, ?string $range): array
+    {
+        $report = $this->reportService->buildDashboardData($user->id, $range);
+        $goals = $this->savingsGoalRepository->getForUser($user->id);
+
+        return [
+            'summary' => $report['summary'] ?? [],
+            'category_breakdown' => $report['charts']['category_breakdown'] ?? [],
+            'budgets' => $report['budgets'] ?? [],
+            'savings_goals' => $goals,
+        ];
+    }
+
+    /**
+     * Resolve the [start, end] Carbon boundaries the insight is keyed on from
+     * the report summary's period.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array{0: Carbon, 1: Carbon}
+     */
+    private function resolvePeriod(array $context): array
+    {
+        $period = $context['summary']['period'] ?? [];
+
+        $start = ! empty($period['start']) ? Carbon::parse($period['start']) : now()->startOfMonth();
+        $end = ! empty($period['end']) ? Carbon::parse($period['end']) : now()->endOfMonth();
+
+        return [$start, $end];
+    }
+
+    /**
+     * Build the user prompt from the gathered finance context.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    private function buildPrompt(User $user, array $context): string
+    {
+        $firstName = trim(explode(' ', trim((string) $user->name))[0] ?? (string) $user->name);
+        $summary = $context['summary'];
+
+        $lines = [];
+        $lines[] = "User's first name: {$firstName}";
+        $lines[] = 'Period: '.$this->periodLabel($summary);
+        $lines[] = '';
+
+        $lines[] = 'TOTALS:';
+        $lines[] = '- Income: '.$this->money($summary['income'] ?? 0);
+        $lines[] = '- Expenses: '.$this->money($summary['expenses'] ?? 0);
+        $lines[] = '- Savings: '.$this->money($summary['savings'] ?? 0);
+        $lines[] = '- Net (income + loans - expenses): '.$this->money($summary['net'] ?? 0);
+        if (isset($summary['budget_utilization'])) {
+            $lines[] = '- Budget utilization: '.number_format((float) $summary['budget_utilization'], 1).'% of budgeted amounts spent';
+        }
+        $lines[] = '';
+
+        $lines = array_merge($lines, $this->categorySection($context['category_breakdown'] ?? []));
+        $lines = array_merge($lines, $this->budgetSection($context['budgets'] ?? []));
+        $lines = array_merge($lines, $this->savingsGoalSection($context['savings_goals'] ?? []));
+
+        $lines[] = 'Write the spending briefing now.';
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * Render the top spending/savings categories for the prompt.
+     *
+     * @param  iterable<mixed>  $categories
+     * @return array<int, string>
+     */
+    private function categorySection(iterable $categories): array
+    {
+        $rows = collect($categories)
+            ->sortByDesc(fn ($row) => (float) ($row['total'] ?? 0))
+            ->take(8)
+            ->map(function ($row) {
+                $label = (string) ($row['label'] ?? $row['name'] ?? 'Uncategorized');
+
+                return '- '.$label.': '.$this->money($row['total'] ?? 0);
+            })
+            ->all();
+
+        if (empty($rows)) {
+            return ['TOP CATEGORIES: none', ''];
+        }
+
+        return array_merge(['TOP CATEGORIES (by amount):'], $rows, ['']);
+    }
+
+    /**
+     * Render active budgets (name, amount) for the prompt.
+     *
+     * @param  iterable<mixed>  $budgets
+     * @return array<int, string>
+     */
+    private function budgetSection(iterable $budgets): array
+    {
+        $rows = collect($budgets)->take(10)->map(function ($budget) {
+            $name = (string) (data_get($budget, 'name') ?? 'Budget');
+            $amount = data_get($budget, 'amount');
+            $spent = data_get($budget, 'current_spent');
+
+            $meta = array_filter([
+                $amount !== null ? 'limit '.$this->money($amount) : null,
+                $spent !== null ? 'spent '.$this->money($spent) : null,
+            ]);
+
+            return '- '.$name.($meta ? ' ('.implode(', ', $meta).')' : '');
+        })->all();
+
+        if (empty($rows)) {
+            return ['BUDGETS: none', ''];
+        }
+
+        return array_merge(['BUDGETS:'], $rows, ['']);
+    }
+
+    /**
+     * Render savings goals (name, progress) for the prompt.
+     *
+     * @param  iterable<mixed>  $goals
+     * @return array<int, string>
+     */
+    private function savingsGoalSection(iterable $goals): array
+    {
+        $rows = collect($goals)->take(8)->map(function ($goal) {
+            $name = (string) (data_get($goal, 'name') ?? 'Savings goal');
+            $current = (float) (data_get($goal, 'current_amount') ?? 0);
+            $target = (float) (data_get($goal, 'target_amount') ?? 0);
+
+            $progress = $target > 0
+                ? ' ('.$this->money($current).' of '.$this->money($target).', '.round(($current / $target) * 100).'%)'
+                : ' ('.$this->money($current).' saved)';
+
+            return '- '.$name.$progress;
+        })->all();
+
+        if (empty($rows)) {
+            return ['SAVINGS GOALS: none', ''];
+        }
+
+        return array_merge(['SAVINGS GOALS:'], $rows, ['']);
+    }
+
+    /**
+     * Deterministic fallback insight used when the AI provider is unavailable.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    private function templateInsight(array $context): string
+    {
+        $summary = $context['summary'];
+
+        return sprintf(
+            'This period you brought in %s and spent %s, setting aside %s in savings for a net of %s. '
+            .'Keep an eye on your largest spending categories and your budgets, and keep chipping away at your savings goals. '
+            .'You are staying on top of it — nice work.',
+            $this->money($summary['income'] ?? 0),
+            $this->money($summary['expenses'] ?? 0),
+            $this->money($summary['savings'] ?? 0),
+            $this->money($summary['net'] ?? 0),
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function periodLabel(array $summary): string
+    {
+        $period = $summary['period'] ?? [];
+
+        try {
+            $start = ! empty($period['start']) ? Carbon::parse($period['start'])->format('M j, Y') : '?';
+            $end = ! empty($period['end']) ? Carbon::parse($period['end'])->format('M j, Y') : '?';
+
+            return "{$start} – {$end}";
+        } catch (Throwable) {
+            return (string) ($summary['range'] ?? 'this month');
+        }
+    }
+
+    private function money(mixed $value): string
+    {
+        return number_format((float) $value, 2);
+    }
+}

--- a/config/ai.php
+++ b/config/ai.php
@@ -30,6 +30,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Finance Insights Open Beta
+    |--------------------------------------------------------------------------
+    |
+    | The AI finance spending insights are a "pro" feature, but during the open
+    | beta every user is entitled to them. Flip this to false to fall back to
+    | the real tier check in FinanceAccessService::canUseInsights once a paid
+    | plan exists.
+    |
+    */
+
+    'finance_insights_open_beta' => env('AI_FINANCE_INSIGHTS_OPEN_BETA', true),
+
+    /*
+    |--------------------------------------------------------------------------
     | Providers
     |--------------------------------------------------------------------------
     |

--- a/database/migrations/2026_07_23_100000_create_finance_insights_table.php
+++ b/database/migrations/2026_07_23_100000_create_finance_insights_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('finance_insights', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->date('period_start');
+            $table->date('period_end');
+            $table->string('range');
+            $table->text('content');
+            $table->string('provider');
+            $table->string('model');
+            $table->timestamp('generated_at');
+            $table->timestamps();
+
+            $table->index('user_id');
+            $table->unique(['user_id', 'period_start', 'period_end']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('finance_insights');
+    }
+};

--- a/resources/js/Components/Finance/FinanceInsightCard.jsx
+++ b/resources/js/Components/Finance/FinanceInsightCard.jsx
@@ -1,0 +1,145 @@
+import { useState } from "react";
+import { router } from "@inertiajs/react";
+import { formatDistanceToNow, isValid, parseISO } from "date-fns";
+import { Sparkles, RefreshCw, Lock, Wand2 } from "lucide-react";
+
+function relativeTime(value) {
+    if (!value) return null;
+    const parsed = typeof value === "string" ? parseISO(value) : new Date(value);
+    if (!isValid(parsed)) return null;
+    return formatDistanceToNow(parsed, { addSuffix: true });
+}
+
+/**
+ * AI spending-insight banner shown at the top of the finance dashboard.
+ *
+ * State precedence (highest first):
+ *   1. locked      — `canUse === false` (plan entitlement) → upsell
+ *   2. empty       — no insight generated yet → Generate prompt
+ *   3. has-insight — render the content + provenance
+ *
+ * `canUse` is treated as `true` when undefined so the banner keeps working
+ * before the backend entitlement prop lands.
+ */
+export default function FinanceInsightCard({ insight = null, canUse = true, range = null }) {
+    const [loading, setLoading] = useState(false);
+
+    const generate = () => {
+        if (loading || canUse === false) return;
+        router.post(
+            route("finance.insights.store"),
+            range ? { range } : {},
+            {
+                preserveScroll: true,
+                preserveState: true,
+                onStart: () => setLoading(true),
+                onFinish: () => setLoading(false),
+            }
+        );
+    };
+
+    const shellClass =
+        "card relative overflow-hidden bg-gradient-to-br from-primary-50 via-light-card to-secondary-50 p-5 dark:from-primary-900/20 dark:via-dark-card dark:to-secondary-900/20 sm:p-6";
+
+    // 1. Locked — plan entitlement (Pro feature).
+    if (canUse === false) {
+        return (
+            <section className={shellClass} aria-label="Spending insights (Pro)">
+                <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex items-start gap-3">
+                        <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-wevie-teal to-wevie-mint text-white">
+                            <Lock className="h-5 w-5" aria-hidden="true" />
+                        </span>
+                        <div>
+                            <div className="flex items-center gap-2">
+                                <h2 className="text-base font-semibold text-adaptive-primary sm:text-lg">
+                                    AI Spending Insights
+                                </h2>
+                                <span className="inline-flex items-center gap-1 rounded-full bg-gradient-to-r from-wevie-teal to-wevie-mint px-2 py-0.5 text-xs font-semibold text-white">
+                                    <Sparkles className="h-3 w-3" aria-hidden="true" />
+                                    Pro
+                                </span>
+                            </div>
+                            <p className="mt-1 max-w-lg text-sm text-adaptive-muted">
+                                Get an AI coach that reads your spending, budgets, and savings goals
+                                and tells you where to focus. Upgrade to Pro to unlock insights.
+                            </p>
+                        </div>
+                    </div>
+                    <button
+                        type="button"
+                        disabled
+                        aria-disabled="true"
+                        className="inline-flex flex-shrink-0 cursor-not-allowed items-center gap-2 rounded-xl bg-gradient-to-r from-wevie-teal to-wevie-mint px-4 py-2 text-sm font-medium text-white opacity-90"
+                        title="Upgrade to Pro to unlock spending insights"
+                    >
+                        <Sparkles className="h-4 w-4" aria-hidden="true" />
+                        Upgrade to Pro
+                    </button>
+                </div>
+            </section>
+        );
+    }
+
+    // 2. Empty — entitled, but nothing generated yet for this period.
+    if (!insight || !insight.content) {
+        return (
+            <section className={shellClass} aria-label="Spending insights">
+                <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex items-start gap-3">
+                        <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-wevie-teal to-wevie-mint text-white">
+                            <Sparkles className="h-5 w-5" aria-hidden="true" />
+                        </span>
+                        <div>
+                            <h2 className="text-base font-semibold text-adaptive-primary sm:text-lg">
+                                Your spending insight is ready to write
+                            </h2>
+                            <p className="mt-1 max-w-lg text-sm text-adaptive-muted">
+                                Generate an AI recap of this period’s spending, budgets, and savings
+                                progress — with tips on where to focus next.
+                            </p>
+                        </div>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={generate}
+                        disabled={loading}
+                        className="btn-primary flex-shrink-0 disabled:cursor-not-allowed disabled:opacity-70"
+                    >
+                        {loading ? (
+                            <RefreshCw className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                        ) : (
+                            <Wand2 className="mr-2 h-4 w-4" aria-hidden="true" />
+                        )}
+                        {loading ? "Generating…" : "Generate insight"}
+                    </button>
+                </div>
+            </section>
+        );
+    }
+
+    // 3. Has insight. One insight per period, so there is no refresh control —
+    // switching the dashboard range surfaces (or generates) that period's own.
+    const updated = relativeTime(insight.generated_at);
+
+    return (
+        <section className={shellClass} aria-label="Spending insights">
+            <div className="flex items-center gap-2">
+                <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-wevie-teal to-wevie-mint text-white">
+                    <Sparkles className="h-5 w-5" aria-hidden="true" />
+                </span>
+                <h2 className="text-base font-semibold text-adaptive-primary sm:text-lg">
+                    Your spending insight
+                </h2>
+            </div>
+
+            <p className="mt-3 whitespace-pre-line text-sm leading-relaxed text-adaptive-secondary">
+                {insight.content}
+            </p>
+
+            {updated && (
+                <div className="mt-4 text-xs text-adaptive-muted">Updated {updated}</div>
+            )}
+        </section>
+    );
+}

--- a/resources/js/Pages/Finance/Dashboard.jsx
+++ b/resources/js/Pages/Finance/Dashboard.jsx
@@ -1,4 +1,5 @@
 import FinanceDashboard from "@/Components/Finance/Dashboard/FinanceDashboard";
+import FinanceInsightCard from "@/Components/Finance/FinanceInsightCard";
 import Dropdown from "@/Components/Dropdown";
 import InputError from "@/Components/InputError";
 import InputLabel from "@/Components/InputLabel";
@@ -622,6 +623,13 @@ export default function Dashboard(props) {
         >
             <Head title="WevieWallet" />
             <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
+                {props.isWalletOwner && (
+                    <FinanceInsightCard
+                        insight={props.financeInsight ?? null}
+                        canUse={props.canUseFinanceInsights ?? true}
+                        range={props.insightRange ?? null}
+                    />
+                )}
                 <FinanceDashboard
                     summary={summary}
                     charts={charts}

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,7 @@ use App\Modules\Finance\Controllers\FinanceBudgetController;
 use App\Modules\Finance\Controllers\FinanceCategoryController;
 use App\Modules\Finance\Controllers\FinanceDashboardController;
 use App\Modules\Finance\Controllers\FinanceExportController;
+use App\Modules\Finance\Controllers\FinanceInsightController;
 use App\Modules\Finance\Controllers\FinanceLoanController;
 use App\Modules\Finance\Controllers\FinanceReportController;
 use App\Modules\Finance\Controllers\FinanceSavingsGoalController;
@@ -94,6 +95,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     // Finance
     Route::get('weviewallet', [FinanceDashboardController::class, 'index'])->name('weviewallet.dashboard');
+    Route::post('weviewallet/insights', [FinanceInsightController::class, 'store'])
+        ->name('finance.insights.store');
     Route::post('weviewallet/collaborators', [FinanceWalletCollaboratorController::class, 'store'])
         ->name('weviewallet.collaborators.store');
     Route::delete('weviewallet/collaborators/{user}', [FinanceWalletCollaboratorController::class, 'destroy'])

--- a/tests/Feature/Finance/FinanceInsightControllerTest.php
+++ b/tests/Feature/Finance/FinanceInsightControllerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Models\User;
+use App\Services\Ai\Contracts\TextGenerator;
+
+function bindFakeInsightGenerator($app, callable $handler): void
+{
+    $app->bind(TextGenerator::class, fn () => new class($handler) implements TextGenerator
+    {
+        public function __construct(private $handler) {}
+
+        public function generate(string $system, string $prompt, array $options = []): string
+        {
+            return ($this->handler)($system, $prompt, $options);
+        }
+    });
+}
+
+it('generates and caches an insight for an entitled user', function () {
+    $user = User::factory()->create();
+    bindFakeInsightGenerator($this->app, fn () => 'Generated spending insight.');
+
+    $response = $this->actingAs($user)
+        ->from(route('weviewallet.dashboard'))
+        ->post(route('finance.insights.store'), ['range' => 'this_month']);
+
+    $response->assertRedirect(route('weviewallet.dashboard'));
+
+    $this->assertDatabaseCount('finance_insights', 1);
+    $this->assertDatabaseHas('finance_insights', [
+        'user_id' => $user->id,
+        'content' => 'Generated spending insight.',
+    ]);
+
+    // A second request for the same period does not duplicate.
+    $this->actingAs($user)
+        ->from(route('weviewallet.dashboard'))
+        ->post(route('finance.insights.store'), ['range' => 'this_month'])
+        ->assertSessionHas('info');
+
+    $this->assertDatabaseCount('finance_insights', 1);
+});
+
+it('blocks an unentitled user when the open beta is off', function () {
+    config()->set('ai.finance_insights_open_beta', false);
+
+    $user = User::factory()->create(['role' => 'member']);
+    bindFakeInsightGenerator($this->app, fn () => 'Should never run.');
+
+    $this->actingAs($user)
+        ->from(route('weviewallet.dashboard'))
+        ->post(route('finance.insights.store'))
+        ->assertRedirect(route('weviewallet.dashboard'))
+        ->assertSessionHas('error');
+
+    $this->assertDatabaseCount('finance_insights', 0);
+});

--- a/tests/Feature/Finance/FinanceInsightServiceTest.php
+++ b/tests/Feature/Finance/FinanceInsightServiceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use App\Models\User;
+use App\Modules\Finance\Models\FinanceInsight;
+use App\Modules\Finance\Services\FinanceInsightService;
+use App\Services\Ai\Contracts\TextGenerator;
+
+function fakeInsightGenerator(callable $handler): TextGenerator
+{
+    return new class($handler) implements TextGenerator
+    {
+        public function __construct(private $handler) {}
+
+        public function generate(string $system, string $prompt, array $options = []): string
+        {
+            return ($this->handler)($system, $prompt, $options);
+        }
+    };
+}
+
+it('generates and upserts an insight using the text generator', function () {
+    $user = User::factory()->create();
+
+    $this->app->bind(TextGenerator::class, fn () => fakeInsightGenerator(
+        fn () => 'Here is your friendly spending insight for this period.'
+    ));
+
+    $service = $this->app->make(FinanceInsightService::class);
+    $insight = $service->generateForUser($user);
+
+    expect($insight)->toBeInstanceOf(FinanceInsight::class)
+        ->and($insight->content)->toBe('Here is your friendly spending insight for this period.')
+        ->and($insight->provider)->not->toBe('fallback');
+
+    $this->assertDatabaseCount('finance_insights', 1);
+    $this->assertDatabaseHas('finance_insights', ['user_id' => $user->id]);
+
+    // Re-generating the same period upserts rather than duplicating.
+    $service->generateForUser($user);
+    $this->assertDatabaseCount('finance_insights', 1);
+});
+
+it('falls back to a deterministic template when the provider fails', function () {
+    $user = User::factory()->create();
+
+    $this->app->bind(TextGenerator::class, fn () => fakeInsightGenerator(
+        fn () => throw new RuntimeException('provider down')
+    ));
+
+    $service = $this->app->make(FinanceInsightService::class);
+    $insight = $service->generateForUser($user);
+
+    expect($insight->provider)->toBe('fallback')
+        ->and($insight->model)->toBe('template')
+        ->and($insight->content)->toContain('spent')
+        ->and($insight->content)->toContain('savings');
+
+    $this->assertDatabaseCount('finance_insights', 1);
+});
+
+it('returns the cached insight for the current period', function () {
+    $user = User::factory()->create();
+
+    $service = $this->app->make(FinanceInsightService::class);
+    expect($service->getCachedForCurrentPeriod($user))->toBeNull();
+
+    $this->app->bind(TextGenerator::class, fn () => fakeInsightGenerator(
+        fn () => 'Cached insight content.'
+    ));
+
+    $this->app->make(FinanceInsightService::class)->generateForUser($user);
+
+    expect($service->getCachedForCurrentPeriod($user))->not->toBeNull();
+});
+
+it('honors the open-beta flag and falls back to the premium tier when off', function () {
+    $freeUser = User::factory()->create(['role' => 'member']);
+    $premiumUser = User::factory()->create(['role' => 'admin']);
+
+    $service = $this->app->make(FinanceInsightService::class);
+
+    config()->set('ai.finance_insights_open_beta', true);
+    expect($service->userCanUseInsights($freeUser))->toBeTrue();
+
+    config()->set('ai.finance_insights_open_beta', false);
+    expect($service->userCanUseInsights($freeUser))->toBeFalse()
+        ->and($service->userCanUseInsights($premiumUser))->toBeTrue();
+});


### PR DESCRIPTION
Adds a second AI feature to Wevie: an AI spending-insights coach on the Finance/WevieWallet dashboard that turns the existing `FinanceReportService` numbers (totals, budget utilization, category breakdown) plus savings-goal progress into a warm, actionable narrative for the selected period. It reuses the provider-agnostic `TextGenerator` abstraction and mirrors the daily-summary pattern end-to-end: a cached `finance_insights` table (one row per user/period), a deterministic template fallback when the AI provider fails, on-demand generation via `POST weviewallet/insights`, and a `FinanceInsightCard` cloning `DailySummaryCard`'s locked/empty/has-content states. The feature is pro-gated behind `config('ai.finance_insights_open_beta')` (open beta = free for all), falling back to `FinanceAccessService::canUseInsights` (premium tier) when the flag is off, and is scoped to the user's own wallet. Verified with Pint (clean), 6 new Pest tests passing against Docker MySQL, and a successful `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)