### PR TITLE
Pro-gate AI features via shared seam, add NL task capture, peso currency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,8 @@ OPENAI_API_KEY=
 OPENAI_MODEL=gpt-4o-mini
 GEMINI_API_KEY=
 GEMINI_MODEL=gemini-1.5-flash
-# Feature gating (open beta = free for everyone until a paid plan exists).
+# AI feature gating. Every AI feature is pro-gated (premium-only) by default;
+# an open-beta flag opens a feature to everyone during public testing.
 AI_DAILY_SUMMARY_OPEN_BETA=true
 AI_FINANCE_INSIGHTS_OPEN_BETA=true
+AI_TASK_CAPTURE_OPEN_BETA=false

--- a/app/Http/Controllers/TaskCaptureController.php
+++ b/app/Http/Controllers/TaskCaptureController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\Ai\AiEntitlementService;
+use App\Services\Ai\Exceptions\TaskExtractionException;
+use App\Services\Ai\TaskExtractionService;
+use App\Services\CategoryService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class TaskCaptureController extends Controller
+{
+    public function __construct(
+        private TaskExtractionService $extractionService,
+        private AiEntitlementService $entitlement,
+        private CategoryService $categoryService,
+    ) {}
+
+    /**
+     * Turn a natural-language description into a structured task payload the
+     * client uses to pre-fill the task modal. Returns JSON (not an Inertia
+     * redirect) because the frontend needs the extracted fields, not a page.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $user = Auth::user();
+
+        if (! $this->entitlement->canUse($user, 'task_capture')) {
+            return response()->json([
+                'message' => 'AI task capture is a Pro feature.',
+            ], 403);
+        }
+
+        $validated = $request->validate([
+            'input' => 'required|string|max:500',
+        ]);
+
+        $categories = $this->categoryService->getActiveCategoriesForUser($user->id);
+
+        try {
+            $task = $this->extractionService->extract($user, $validated['input'], $categories);
+        } catch (TaskExtractionException $e) {
+            return response()->json(['message' => $e->getMessage()], 422);
+        }
+
+        return response()->json(['task' => $task]);
+    }
+}

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Task;
+use App\Services\Ai\AiEntitlementService;
 use App\Services\CategoryService;
 use App\Services\TagService;
 use App\Services\TaskService;
@@ -17,7 +18,8 @@ class TaskController extends Controller
     public function __construct(
         private TaskService $taskService,
         private CategoryService $categoryService,
-        private TagService $tagService
+        private TagService $tagService,
+        private AiEntitlementService $entitlement
     ) {}
 
     /**
@@ -46,10 +48,9 @@ class TaskController extends Controller
             'categories' => $categories,
             'tags' => $tags,
             'filters' => $request->only(['search', 'status', 'priority', 'category_id', 'tag_id', 'due_date_filter']),
+            'canUseTaskCapture' => $this->entitlement->canUse(Auth::user(), 'task_capture'),
         ]);
     }
-
-
 
     /**
      * Store a newly created resource in storage.
@@ -59,7 +60,7 @@ class TaskController extends Controller
         $validated = $request->validate([
             'title' => 'required|string|max:255',
             'description' => 'nullable|string',
-            'category_id' => 'nullable|exists:categories,id,user_id,' . Auth::id(),
+            'category_id' => 'nullable|exists:categories,id,user_id,'.Auth::id(),
             'priority' => 'required|in:low,medium,high,urgent',
             'due_date' => 'nullable|date',
             'start_time' => 'nullable|date_format:H:i',
@@ -80,14 +81,14 @@ class TaskController extends Controller
         ]);
 
         // Clear recurring fields for non-recurring tasks
-        if (!isset($validated['is_recurring']) || !$validated['is_recurring']) {
+        if (! isset($validated['is_recurring']) || ! $validated['is_recurring']) {
             $validated['recurring_until'] = null;
             $validated['recurrence_type'] = null;
             $validated['recurrence_config'] = null;
         }
 
         // Set is_all_day to true if no times are provided
-        if (!isset($validated['is_all_day'])) {
+        if (! isset($validated['is_all_day'])) {
             $validated['is_all_day'] = empty($validated['start_time']) && empty($validated['end_time']);
         }
 
@@ -99,6 +100,7 @@ class TaskController extends Controller
 
         try {
             $task = $this->taskService->createTask($validated, Auth::id());
+
             return redirect()->back()->with('message', 'Task created successfully');
         } catch (\InvalidArgumentException $e) {
             return redirect()->back()->withErrors(['error' => $e->getMessage()])->withInput();
@@ -115,7 +117,7 @@ class TaskController extends Controller
         $validated = $request->validate([
             'title' => 'required|string|max:255',
             'description' => 'nullable|string',
-            'category_id' => 'nullable|exists:categories,id,user_id,' . Auth::id(),
+            'category_id' => 'nullable|exists:categories,id,user_id,'.Auth::id(),
             'priority' => 'required|in:low,medium,high,urgent',
             'status' => 'required|in:pending,in_progress,completed,cancelled',
             'due_date' => 'nullable|date',
@@ -137,14 +139,14 @@ class TaskController extends Controller
         ]);
 
         // Clear recurring fields for non-recurring tasks
-        if (!isset($validated['is_recurring']) || !$validated['is_recurring']) {
+        if (! isset($validated['is_recurring']) || ! $validated['is_recurring']) {
             $validated['recurring_until'] = null;
             $validated['recurrence_type'] = null;
             $validated['recurrence_config'] = null;
         }
 
         // Set is_all_day to true if no times are provided
-        if (!isset($validated['is_all_day'])) {
+        if (! isset($validated['is_all_day'])) {
             $validated['is_all_day'] = empty($validated['start_time']) && empty($validated['end_time']);
         }
 
@@ -156,6 +158,7 @@ class TaskController extends Controller
 
         try {
             $updatedTask = $this->taskService->updateTask($task, $validated, Auth::id());
+
             return redirect()->back()->with('message', 'Task updated successfully');
         } catch (\InvalidArgumentException $e) {
             return redirect()->back()->withErrors(['error' => $e->getMessage()])->withInput();
@@ -171,6 +174,7 @@ class TaskController extends Controller
     {
         try {
             $this->taskService->deleteTask($task, Auth::id());
+
             return back()->with('status', 'Task deleted successfully');
         } catch (\Exception $e) {
             return back()->withErrors(['error' => 'Failed to delete task. Please try again.']);
@@ -191,6 +195,7 @@ class TaskController extends Controller
                     'message' => 'Tasks reordered successfully',
                 ]);
             }
+
             return back()->with('message', 'Tasks reordered successfully');
         } catch (\Exception $e) {
             if ($request->expectsJson()) {
@@ -199,6 +204,7 @@ class TaskController extends Controller
                     422
                 );
             }
+
             return back()->withErrors(['error' => 'Failed to reorder tasks. Please try again.']);
         }
     }
@@ -208,7 +214,7 @@ class TaskController extends Controller
         // If a specific status is provided, use it; otherwise toggle between completed/pending
         if ($request->has('status')) {
             $validated = $request->validate([
-                'status' => 'required|in:pending,in_progress,completed,cancelled'
+                'status' => 'required|in:pending,in_progress,completed,cancelled',
             ]);
             $newStatus = $validated['status'];
         } else {
@@ -217,6 +223,7 @@ class TaskController extends Controller
 
         try {
             $this->taskService->toggleTaskStatus($task, $newStatus, Auth::id());
+
             return back()->with('status', 'Task status updated successfully');
         } catch (\Exception $e) {
             return back()->withErrors(['error' => 'Failed to update task status. Please try again.']);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -159,6 +159,16 @@ class User extends Authenticatable
         return $this->role === 'member';
     }
 
+    /**
+     * The canonical "premium" predicate — the single source of truth for paid
+     * entitlement (used by AiEntitlementService and FinanceAccessService). Today
+     * premium maps to admins; future subscription/plan logic lands here.
+     */
+    public function isPremium(): bool
+    {
+        return $this->isAdmin();
+    }
+
     public function getTimezone(): string
     {
         return $this->timezone ?? 'UTC';

--- a/app/Modules/Finance/Services/FinanceAccessService.php
+++ b/app/Modules/Finance/Services/FinanceAccessService.php
@@ -8,11 +8,7 @@ class FinanceAccessService
 {
     public function getTier(User $user): string
     {
-        if ($user->role === 'admin') {
-            return 'premium';
-        }
-
-        return 'free';
+        return $user->isPremium() ? 'premium' : 'free';
     }
 
     public function canAccessAdvancedCharts(User $user): bool

--- a/app/Modules/Finance/Services/FinanceInsightService.php
+++ b/app/Modules/Finance/Services/FinanceInsightService.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use App\Modules\Finance\Models\FinanceInsight;
 use App\Modules\Finance\Repositories\FinanceInsightRepository;
 use App\Modules\Finance\Repositories\FinanceSavingsGoalRepository;
+use App\Services\Ai\AiEntitlementService;
 use App\Services\Ai\Contracts\TextGenerator;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Log;
@@ -19,23 +20,19 @@ class FinanceInsightService
         private FinanceInsightRepository $repository,
         private FinanceAccessService $accessService,
         private TextGenerator $textGenerator,
+        private AiEntitlementService $entitlement,
     ) {}
 
     /**
      * Whether the user is entitled to AI spending insights (a "pro" feature).
      *
-     * Centralized so gating the feature to a paid plan later is a one-line
-     * change. During the open beta everyone is entitled; once the beta ends the
-     * real tier check in FinanceAccessService takes over.
+     * Thin wrapper over the shared entitlement seam so gating stays consistent
+     * across every AI feature. The feature keeps its open-beta override
+     * (config('ai.open_beta.finance_insights')) until a paid tier takes over.
      */
     public function userCanUseInsights(User $user): bool
     {
-        // Open beta: treat everyone as entitled while we test publicly.
-        if (config('ai.finance_insights_open_beta', true)) {
-            return true;
-        }
-
-        return $this->accessService->canUseInsights($user);
+        return $this->entitlement->canUse($user, 'finance_insights');
     }
 
     /**
@@ -57,6 +54,7 @@ class FinanceInsightService
             .'Highlight where the money went, flag categories or budgets that look overspent, note progress toward savings goals, '
             .'and give one or two concrete, actionable suggestions for the rest of the period. '
             .'Address the user directly by their first name and close with a short, genuine note of encouragement. '
+            .'All monetary amounts are in Philippine Pesos (PHP) — always write them with the ₱ symbol (e.g. ₱1,200.00) and never use "$" or any other currency symbol. '
             .'Write in plain prose only — no markdown, no headings, no bullet lists.';
         $prompt = $this->buildPrompt($user, $context);
 
@@ -294,6 +292,6 @@ class FinanceInsightService
 
     private function money(mixed $value): string
     {
-        return number_format((float) $value, 2);
+        return '₱'.number_format((float) $value, 2);
     }
 }

--- a/app/Services/Ai/AiEntitlementService.php
+++ b/app/Services/Ai/AiEntitlementService.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Services\Ai;
+
+use App\Models\User;
+
+/**
+ * Single seam for gating AI features. Every AI feature routes its entitlement
+ * check through canUse() so pro-gating is the default: a feature is locked to
+ * premium users unless an explicit per-feature open-beta override opens it up
+ * for public testing.
+ */
+class AiEntitlementService
+{
+    /**
+     * Whether the user may use the given AI feature.
+     *
+     * Premium users always may. Everyone else is locked out unless the feature
+     * has an open-beta override in config/ai.php (config('ai.open_beta.<feature>')).
+     * Absence of an override means premium-only — the pro-gated default.
+     */
+    public function canUse(User $user, string $feature): bool
+    {
+        if ($this->isPremium($user)) {
+            return true;
+        }
+
+        return (bool) config("ai.open_beta.{$feature}", false);
+    }
+
+    /**
+     * The single source of truth for "premium". Future subscription/plan logic
+     * lands here; today premium maps to the admin role (mirrors the tier check
+     * in FinanceAccessService).
+     */
+    public function isPremium(User $user): bool
+    {
+        return $user->isPremium();
+    }
+}

--- a/app/Services/Ai/Exceptions/TaskExtractionException.php
+++ b/app/Services/Ai/Exceptions/TaskExtractionException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Services\Ai\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Thrown when the AI could not turn a natural-language description into a
+ * usable task (provider failure or unparseable output). The controller turns
+ * this into a friendly 422 so the user can still add the task manually.
+ */
+class TaskExtractionException extends RuntimeException {}

--- a/app/Services/Ai/TaskExtractionService.php
+++ b/app/Services/Ai/TaskExtractionService.php
@@ -1,0 +1,336 @@
+<?php
+
+namespace App\Services\Ai;
+
+use App\Models\User;
+use App\Services\Ai\Contracts\TextGenerator;
+use App\Services\Ai\Exceptions\TaskExtractionException;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Turns a natural-language task description ("pay rent every 1st at 9am, high
+ * priority") into a structured, validated task payload that pre-fills the task
+ * modal. Built on the free-text TextGenerator seam: it prompts for strict JSON
+ * and validates the result against the real task schema before returning it —
+ * the AI never creates a task directly.
+ */
+class TaskExtractionService
+{
+    private const PRIORITIES = ['low', 'medium', 'high', 'urgent'];
+
+    private const RECURRENCE_TYPES = ['daily', 'weekly', 'monthly', 'yearly'];
+
+    private const DEFAULT_TAG_COLOR = '#6B7280';
+
+    public function __construct(
+        private TextGenerator $textGenerator,
+    ) {}
+
+    /**
+     * Extract a normalized task payload from free-text input.
+     *
+     * @param  iterable<mixed>  $categories  The user's active categories (id + name).
+     * @return array<string, mixed> Fields matching the task-create form / store contract.
+     *
+     * @throws TaskExtractionException When the provider fails or returns unusable output.
+     */
+    public function extract(User $user, string $input, iterable $categories): array
+    {
+        $today = $user->nowInUserTimezone();
+        $categoryMap = $this->categoryMap($categories);
+
+        $system = $this->systemPrompt();
+        $prompt = $this->userPrompt($input, $today, $categoryMap);
+
+        try {
+            $raw = $this->textGenerator->generate($system, $prompt);
+            $data = $this->decode($raw);
+        } catch (TaskExtractionException $e) {
+            throw $e;
+        } catch (Throwable $e) {
+            Log::warning('Task capture extraction failed.', [
+                'user_id' => $user->id,
+                'error' => $e->getMessage(),
+            ]);
+
+            throw new TaskExtractionException('The AI could not read that. Try rephrasing, or add the task manually.', 0, $e);
+        }
+
+        return $this->normalize($data, $today, $categoryMap);
+    }
+
+    private function systemPrompt(): string
+    {
+        return 'You extract a single structured task from a user\'s natural-language description. '
+            .'Respond with ONE minified JSON object and nothing else — no prose, no markdown, no code fences. '
+            .'Use exactly these keys: '
+            .'"title" (string, required, concise), '
+            .'"description" (string or null), '
+            .'"priority" (one of "low","medium","high","urgent"; default "medium"), '
+            .'"due_date" (YYYY-MM-DD or null), '
+            .'"start_time" ("HH:MM" 24-hour or null), '
+            .'"end_time" ("HH:MM" 24-hour or null), '
+            .'"is_all_day" (boolean), '
+            .'"is_recurring" (boolean), '
+            .'"recurrence_type" (one of "daily","weekly","monthly","yearly" or null), '
+            .'"recurrence_config" (object or null: for weekly use {"days_of_week":[0-6]} where 0=Sunday..6=Saturday; for monthly use {"day_of_month":1-31}; null for daily/yearly), '
+            .'"recurring_until" (YYYY-MM-DD or null), '
+            .'"category_id" (an id from the provided category list, or null), '
+            .'"tags" (array of short tag name strings, or []). '
+            .'Resolve relative dates and times against the provided "Today" date. '
+            .'If a detail is not mentioned, use null (or a sensible default for priority/is_all_day). '
+            .'Only set category_id to an id that appears in the provided list; otherwise use null.';
+    }
+
+    /**
+     * @param  array<int, string>  $categoryMap
+     */
+    private function userPrompt(string $input, Carbon $today, array $categoryMap): string
+    {
+        $lines = [];
+        $lines[] = 'Today: '.$today->format('Y-m-d').' ('.$today->format('l').')';
+
+        if ($categoryMap === []) {
+            $lines[] = 'Available categories: none';
+        } else {
+            $lines[] = 'Available categories (id: name):';
+            foreach ($categoryMap as $id => $name) {
+                $lines[] = "- {$id}: {$name}";
+            }
+        }
+
+        $lines[] = '';
+        $lines[] = 'Task description:';
+        $lines[] = trim($input);
+        $lines[] = '';
+        $lines[] = 'Return the JSON object now.';
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * Decode the model's response into an array, tolerating stray code fences
+     * or surrounding prose by extracting the first JSON object.
+     *
+     * @return array<string, mixed>
+     */
+    private function decode(string $raw): array
+    {
+        $text = trim($raw);
+
+        if ($text === '') {
+            throw new TaskExtractionException('The AI returned an empty response.');
+        }
+
+        // Strip a ```json ... ``` fence if the model added one.
+        if (str_starts_with($text, '```')) {
+            $text = preg_replace('/^```[a-zA-Z]*\s*|\s*```$/', '', $text) ?? $text;
+        }
+
+        $decoded = json_decode($text, true);
+
+        if (! is_array($decoded)) {
+            // Fall back to the first {...} block anywhere in the text.
+            if (preg_match('/\{.*\}/s', $text, $m)) {
+                $decoded = json_decode($m[0], true);
+            }
+        }
+
+        if (! is_array($decoded)) {
+            throw new TaskExtractionException('The AI response was not valid JSON.');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * Validate and coerce the decoded object into the task-create form shape.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<int, string>  $categoryMap
+     * @return array<string, mixed>
+     */
+    private function normalize(array $data, Carbon $today, array $categoryMap): array
+    {
+        $title = trim((string) ($data['title'] ?? ''));
+
+        if ($title === '') {
+            throw new TaskExtractionException('The AI could not find a task title. Try rephrasing.');
+        }
+
+        $priority = strtolower((string) ($data['priority'] ?? 'medium'));
+        if (! in_array($priority, self::PRIORITIES, true)) {
+            $priority = 'medium';
+        }
+
+        $startTime = $this->normalizeTime($data['start_time'] ?? null);
+        $endTime = $this->normalizeTime($data['end_time'] ?? null);
+
+        $isAllDay = array_key_exists('is_all_day', $data)
+            ? (bool) $data['is_all_day']
+            : ($startTime === null && $endTime === null);
+
+        if ($isAllDay) {
+            $startTime = null;
+            $endTime = null;
+        }
+
+        $isRecurring = (bool) ($data['is_recurring'] ?? false);
+        $recurrenceType = null;
+        $recurrenceConfig = null;
+        $recurringUntil = null;
+
+        if ($isRecurring) {
+            $type = strtolower((string) ($data['recurrence_type'] ?? ''));
+            $recurrenceType = in_array($type, self::RECURRENCE_TYPES, true) ? $type : null;
+
+            if ($recurrenceType === null) {
+                // No usable cadence — treat as a one-off rather than an invalid recurring task.
+                $isRecurring = false;
+            } else {
+                $recurrenceConfig = $this->normalizeRecurrenceConfig($recurrenceType, $data['recurrence_config'] ?? null);
+                $recurringUntil = $this->normalizeDate($data['recurring_until'] ?? null)
+                    ?? $today->copy()->addYear()->format('Y-m-d');
+            }
+        }
+
+        return [
+            'title' => mb_substr($title, 0, 255),
+            'description' => $this->normalizeString($data['description'] ?? null),
+            'priority' => $priority,
+            'due_date' => $this->normalizeDate($data['due_date'] ?? null),
+            'start_time' => $startTime,
+            'end_time' => $endTime,
+            'is_all_day' => $isAllDay,
+            'is_recurring' => $isRecurring,
+            'recurrence_type' => $recurrenceType,
+            'recurrence_config' => $recurrenceConfig,
+            'recurring_until' => $recurringUntil,
+            'category_id' => $this->normalizeCategoryId($data['category_id'] ?? null, $categoryMap),
+            'tags' => $this->normalizeTags($data['tags'] ?? []),
+        ];
+    }
+
+    /**
+     * @param  array<int, string>  $categoryMap
+     */
+    private function normalizeCategoryId(mixed $value, array $categoryMap): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        $id = (int) $value;
+
+        return array_key_exists($id, $categoryMap) ? $id : null;
+    }
+
+    /**
+     * @param  array<int, string>|mixed  $recurrenceConfig
+     * @return array<string, mixed>|null
+     */
+    private function normalizeRecurrenceConfig(string $type, mixed $recurrenceConfig): ?array
+    {
+        $config = is_array($recurrenceConfig) ? $recurrenceConfig : [];
+
+        if ($type === 'weekly') {
+            $days = collect($config['days_of_week'] ?? [])
+                ->map(fn ($d) => (int) $d)
+                ->filter(fn ($d) => $d >= 0 && $d <= 6)
+                ->unique()
+                ->values()
+                ->all();
+
+            return ['days_of_week' => $days];
+        }
+
+        if ($type === 'monthly') {
+            $day = (int) ($config['day_of_month'] ?? 0);
+            $day = max(1, min(31, $day ?: 1));
+
+            return ['day_of_month' => $day];
+        }
+
+        // daily / yearly need no config.
+        return null;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function normalizeTags(mixed $tags): array
+    {
+        if (! is_array($tags)) {
+            return [];
+        }
+
+        return collect($tags)
+            ->map(fn ($tag) => is_array($tag) ? ($tag['name'] ?? null) : $tag)
+            ->map(fn ($name) => trim((string) $name))
+            ->filter(fn ($name) => $name !== '')
+            ->unique()
+            ->take(10)
+            ->map(fn ($name) => [
+                'name' => mb_substr($name, 0, 255),
+                'color' => self::DEFAULT_TAG_COLOR,
+                'is_new' => true,
+            ])
+            ->values()
+            ->all();
+    }
+
+    private function normalizeTime(mixed $value): ?string
+    {
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        return preg_match('/^([01]\d|2[0-3]):[0-5]\d$/', trim($value)) === 1 ? trim($value) : null;
+    }
+
+    private function normalizeDate(mixed $value): ?string
+    {
+        if (empty($value)) {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($value)->format('Y-m-d');
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    /**
+     * @param  iterable<mixed>  $categories
+     * @return array<int, string>
+     */
+    private function categoryMap(iterable $categories): array
+    {
+        $map = [];
+
+        foreach ($categories as $category) {
+            $id = data_get($category, 'id');
+            $name = data_get($category, 'name');
+
+            if ($id !== null && $name !== null) {
+                $map[(int) $id] = (string) $name;
+            }
+        }
+
+        return $map;
+    }
+}

--- a/app/Services/DailySummaryService.php
+++ b/app/Services/DailySummaryService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\DailySummary;
 use App\Models\User;
 use App\Repositories\Contracts\DailySummaryRepositoryInterface;
+use App\Services\Ai\AiEntitlementService;
 use App\Services\Ai\Contracts\TextGenerator;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Log;
@@ -16,26 +17,19 @@ class DailySummaryService
         private DashboardService $dashboardService,
         private DailySummaryRepositoryInterface $repository,
         private TextGenerator $textGenerator,
+        private AiEntitlementService $entitlement,
     ) {}
 
     /**
      * Whether the user is entitled to the AI daily summary (a "pro" feature).
      *
-     * Centralized so gating the feature to a paid plan later is a one-line
-     * change. Today it returns true for everyone via the open-beta flag.
+     * Thin wrapper over the shared entitlement seam so gating stays consistent
+     * across every AI feature. The feature keeps its open-beta override
+     * (config('ai.open_beta.daily_summary')) until a paid tier takes over.
      */
     public function userCanUseSummary(User $user): bool
     {
-        // Open beta: treat everyone as entitled while we test publicly.
-        if (config('ai.daily_summary_open_beta', true)) {
-            return true;
-        }
-
-        // TODO: gate to pro plan. When a real paid tier/subscription exists,
-        // replace this with the entitlement check (mirroring the tier pattern
-        // in App\Modules\Finance\Services\FinanceAccessService::getTier()), e.g.
-        // return $user->hasProPlan();
-        return false;
+        return $this->entitlement->canUse($user, 'daily_summary');
     }
 
     /**

--- a/config/ai.php
+++ b/config/ai.php
@@ -17,30 +17,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Daily Summary Open Beta
+    | AI Feature Open Beta Overrides
     |--------------------------------------------------------------------------
     |
-    | The AI daily summary is a "pro" feature, but during the open beta every
-    | user is entitled to it. Flip this to false (and implement the real tier
-    | check in DailySummaryService::userCanUseSummary) once a paid plan exists.
+    | Every AI feature is pro-gated by default: AiEntitlementService::canUse()
+    | allows only premium users unless the feature is listed here with a truthy
+    | value, which opens it to everyone during a public beta. A feature that is
+    | absent from this map (e.g. a brand-new AI feature) is premium-only — the
+    | pro-gated default. Flip a flag to false to end that feature's open beta.
     |
     */
 
-    'daily_summary_open_beta' => env('AI_DAILY_SUMMARY_OPEN_BETA', true),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Finance Insights Open Beta
-    |--------------------------------------------------------------------------
-    |
-    | The AI finance spending insights are a "pro" feature, but during the open
-    | beta every user is entitled to them. Flip this to false to fall back to
-    | the real tier check in FinanceAccessService::canUseInsights once a paid
-    | plan exists.
-    |
-    */
-
-    'finance_insights_open_beta' => env('AI_FINANCE_INSIGHTS_OPEN_BETA', true),
+    'open_beta' => [
+        'daily_summary' => env('AI_DAILY_SUMMARY_OPEN_BETA', true),
+        'finance_insights' => env('AI_FINANCE_INSIGHTS_OPEN_BETA', true),
+        'task_capture' => env('AI_TASK_CAPTURE_OPEN_BETA', false),
+    ],
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/js/Components/TaskModal.jsx
+++ b/resources/js/Components/TaskModal.jsx
@@ -1,5 +1,7 @@
 import { useForm, usePage } from "@inertiajs/react";
 import { useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import { Sparkles, Wand2, RefreshCw, Lock } from "lucide-react";
 import Modal from "./Modal";
 import OnboardingTour from "./OnboardingTour";
 import SecondaryButton from "./SecondaryButton";
@@ -9,14 +11,15 @@ import CategoryTagSelector from "./CategoryTagSelector";
 import RecurrenceConfigFields from "./RecurrenceConfigFields";
 import { addTaskFormSteps } from "@/tours";
 
-export default function TaskModal({
-    show,
-    onClose,
-    onSubmitting,
-    defaultCategoryId = null,
-}) {
-    const { categories } = usePage().props;
+export default function TaskModal({ show, onClose, onSubmitting, defaultCategoryId = null }) {
+    // `canUseTaskCapture` is only provided on pages that offer AI capture (the
+    // Tasks page). `undefined` → feature not available here (render nothing);
+    // `true`/`false` → entitled / locked-upsell states.
+    const { categories, canUseTaskCapture } = usePage().props;
+    const captureAvailable = canUseTaskCapture !== undefined;
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [captureInput, setCaptureInput] = useState("");
+    const [capturing, setCapturing] = useState(false);
 
     const initialFormData = {
         title: "",
@@ -58,8 +61,50 @@ export default function TaskModal({
             });
             clearErrors();
             setIsSubmitting(false);
+            setCaptureInput("");
+            setCapturing(false);
         }
     }, [show, defaultCategoryId]);
+
+    // Turn a natural-language description into structured fields via AI, then
+    // pre-fill the form for the user to review before saving. The AI never
+    // creates the task directly — the normal Save path still applies.
+    const handleCapture = () => {
+        const input = captureInput.trim();
+        if (!input || capturing || !canUseTaskCapture) return;
+
+        setCapturing(true);
+        window.axios
+            .post(route("tasks.capture"), { input })
+            .then(({ data }) => {
+                const t = data.task || {};
+                setData((prev) => ({
+                    ...prev,
+                    title: t.title ?? prev.title,
+                    description: t.description ?? "",
+                    priority: t.priority ?? "medium",
+                    category_id: t.category_id != null ? String(t.category_id) : "",
+                    is_recurring: !!t.is_recurring,
+                    recurrence_type: t.recurrence_type ?? "",
+                    recurrence_config: t.recurrence_config ?? {},
+                    recurring_until: t.recurring_until ?? "",
+                    due_date: t.is_recurring ? "" : (t.due_date ?? ""),
+                    start_time: t.start_time ?? "",
+                    end_time: t.end_time ?? "",
+                    is_all_day: t.is_all_day ?? true,
+                    tags: Array.isArray(t.tags) ? t.tags : prev.tags,
+                }));
+                clearErrors();
+                toast.success("Filled in from your description — review and save.");
+            })
+            .catch((error) => {
+                const message =
+                    error?.response?.data?.message ||
+                    "Couldn’t read that. Try rephrasing, or fill it in below.";
+                toast.error(message);
+            })
+            .finally(() => setCapturing(false));
+    };
 
     // Notify parent about submission state
     useEffect(() => {
@@ -135,6 +180,71 @@ export default function TaskModal({
                         Add what feels helpful now. Details can come later.
                     </p>
 
+                    {captureAvailable &&
+                        (canUseTaskCapture ? (
+                            <div className="mb-4 rounded-xl border border-primary-100 bg-gradient-to-br from-primary-50 via-light-card to-secondary-50 p-3 dark:border-primary-900/40 dark:from-primary-900/20 dark:via-dark-card dark:to-secondary-900/20">
+                                <div className="mb-2 flex items-center gap-2">
+                                    <Sparkles
+                                        className="h-4 w-4 text-wevie-teal dark:text-wevie-mint"
+                                        aria-hidden="true"
+                                    />
+                                    <span className="text-sm font-medium text-light-secondary dark:text-dark-secondary">
+                                        Capture with AI
+                                    </span>
+                                </div>
+                                <div className="flex flex-col gap-2 sm:flex-row">
+                                    <input
+                                        type="text"
+                                        className="w-full input-primary"
+                                        placeholder='e.g. "pay rent every 1st at 9am, high priority"'
+                                        value={captureInput}
+                                        onChange={(e) => setCaptureInput(e.target.value)}
+                                        onKeyDown={(e) => {
+                                            if (e.key === "Enter") {
+                                                e.preventDefault();
+                                                handleCapture();
+                                            }
+                                        }}
+                                        disabled={capturing}
+                                        maxLength={500}
+                                    />
+                                    <PrimaryButton
+                                        type="button"
+                                        onClick={handleCapture}
+                                        disabled={capturing || !captureInput.trim()}
+                                        className="flex-shrink-0 justify-center"
+                                    >
+                                        {capturing ? (
+                                            <RefreshCw
+                                                className="mr-2 h-4 w-4 animate-spin"
+                                                aria-hidden="true"
+                                            />
+                                        ) : (
+                                            <Wand2 className="mr-2 h-4 w-4" aria-hidden="true" />
+                                        )}
+                                        {capturing ? "Reading…" : "Capture"}
+                                    </PrimaryButton>
+                                </div>
+                            </div>
+                        ) : (
+                            <div className="mb-4 flex flex-col items-start gap-3 rounded-xl border border-primary-100 bg-gradient-to-br from-primary-50 via-light-card to-secondary-50 p-3 dark:border-primary-900/40 dark:from-primary-900/20 dark:via-dark-card dark:to-secondary-900/20 sm:flex-row sm:items-center sm:justify-between">
+                                <div className="flex items-start gap-2">
+                                    <Lock
+                                        className="mt-0.5 h-4 w-4 flex-shrink-0 text-wevie-teal dark:text-wevie-mint"
+                                        aria-hidden="true"
+                                    />
+                                    <p className="text-sm text-light-muted dark:text-dark-muted">
+                                        Describe a task in plain words and let AI fill in the
+                                        details.
+                                    </p>
+                                </div>
+                                <span className="inline-flex flex-shrink-0 items-center gap-1 rounded-full bg-gradient-to-r from-wevie-teal to-wevie-mint px-2 py-0.5 text-xs font-semibold text-white">
+                                    <Sparkles className="h-3 w-3" aria-hidden="true" />
+                                    Pro
+                                </span>
+                            </div>
+                        ))}
+
                     <div className="space-y-4">
                         <div>
                             <label className="block text-sm font-medium mb-1 text-light-secondary dark:text-dark-secondary">
@@ -145,15 +255,11 @@ export default function TaskModal({
                                 type="text"
                                 className="w-full input-primary"
                                 value={data.title}
-                                onChange={(e) =>
-                                    setData("title", e.target.value)
-                                }
+                                onChange={(e) => setData("title", e.target.value)}
                                 required
                             />
                             {errors.title && (
-                                <div className="text-red-500 text-xs mt-1">
-                                    {errors.title}
-                                </div>
+                                <div className="text-red-500 text-xs mt-1">{errors.title}</div>
                             )}
                         </div>
                         <div>
@@ -163,9 +269,7 @@ export default function TaskModal({
                             <textarea
                                 className="w-full input-primary"
                                 value={data.description}
-                                onChange={(e) =>
-                                    setData("description", e.target.value)
-                                }
+                                onChange={(e) => setData("description", e.target.value)}
                             />
                             {errors.description && (
                                 <div className="text-red-500 text-xs mt-1">
@@ -181,9 +285,7 @@ export default function TaskModal({
                                 data-tour="task-category"
                                 className="w-full input-primary"
                                 value={data.category_id}
-                                onChange={(e) =>
-                                    setData("category_id", e.target.value)
-                                }
+                                onChange={(e) => setData("category_id", e.target.value)}
                             >
                                 <option value="">Choose when ready</option>
                                 {categories &&
@@ -207,9 +309,7 @@ export default function TaskModal({
                                 data-tour="task-priority"
                                 className="w-full input-primary"
                                 value={data.priority}
-                                onChange={(e) =>
-                                    setData("priority", e.target.value)
-                                }
+                                onChange={(e) => setData("priority", e.target.value)}
                             >
                                 <option value="urgent">Focus</option>
                                 <option value="high">High</option>
@@ -236,9 +336,7 @@ export default function TaskModal({
                                 maxTags={5}
                             />
                             {errors.tags && (
-                                <div className="text-red-500 text-xs mt-1">
-                                    {errors.tags}
-                                </div>
+                                <div className="text-red-500 text-xs mt-1">{errors.tags}</div>
                             )}
                         </div>
                         <div className="flex items-center">
@@ -278,10 +376,7 @@ export default function TaskModal({
                                         className="w-full input-primary"
                                         value={data.recurrence_type}
                                         onChange={(e) => {
-                                            setData(
-                                                "recurrence_type",
-                                                e.target.value
-                                            );
+                                            setData("recurrence_type", e.target.value);
                                             // Reset pattern-specific config on change
                                             setData("recurrence_config", {});
                                         }}
@@ -302,9 +397,7 @@ export default function TaskModal({
                                 <RecurrenceConfigFields
                                     recurrenceType={data.recurrence_type}
                                     config={data.recurrence_config}
-                                    onChange={(config) =>
-                                        setData("recurrence_config", config)
-                                    }
+                                    onChange={(config) => setData("recurrence_config", config)}
                                 />
                                 <div>
                                     <label className="block text-sm font-medium mb-1 text-light-secondary dark:text-dark-secondary">
@@ -314,12 +407,7 @@ export default function TaskModal({
                                         type="date"
                                         className="w-full input-primary"
                                         value={data.recurring_until}
-                                        onChange={(e) =>
-                                            setData(
-                                                "recurring_until",
-                                                e.target.value
-                                            )
-                                        }
+                                        onChange={(e) => setData("recurring_until", e.target.value)}
                                         required={data.is_recurring}
                                     />
                                     {errors.recurring_until && (
@@ -338,9 +426,7 @@ export default function TaskModal({
                                     type="date"
                                     className="w-full input-primary"
                                     value={data.due_date}
-                                    onChange={(e) =>
-                                        setData("due_date", e.target.value)
-                                    }
+                                    onChange={(e) => setData("due_date", e.target.value)}
                                 />
                                 {errors.due_date && (
                                     <div className="text-red-500 text-xs mt-1">
@@ -360,10 +446,7 @@ export default function TaskModal({
                                         className="rounded border-light-border text-wevie-teal shadow-sm focus:border-wevie-teal focus:ring focus:ring-wevie-teal/30 dark:border-dark-border dark:text-wevie-mint"
                                         checked={data.is_all_day}
                                         onChange={(e) => {
-                                            setData(
-                                                "is_all_day",
-                                                e.target.checked
-                                            );
+                                            setData("is_all_day", e.target.checked);
                                             if (e.target.checked) {
                                                 setData("start_time", "");
                                                 setData("end_time", "");
@@ -389,10 +472,7 @@ export default function TaskModal({
                                                 className="w-full input-primary"
                                                 value={data.start_time}
                                                 onChange={(e) =>
-                                                    setData(
-                                                        "start_time",
-                                                        e.target.value
-                                                    )
+                                                    setData("start_time", e.target.value)
                                                 }
                                                 required={!data.is_all_day}
                                             />
@@ -411,10 +491,7 @@ export default function TaskModal({
                                                 className="w-full input-primary"
                                                 value={data.end_time}
                                                 onChange={(e) =>
-                                                    setData(
-                                                        "end_time",
-                                                        e.target.value
-                                                    )
+                                                    setData("end_time", e.target.value)
                                                 }
                                                 required={!data.is_all_day}
                                             />
@@ -428,26 +505,20 @@ export default function TaskModal({
                                 )}
 
                                 {errors.time && (
-                                    <div className="text-red-500 text-xs mt-1">
-                                        {errors.time}
-                                    </div>
+                                    <div className="text-red-500 text-xs mt-1">{errors.time}</div>
                                 )}
                             </div>
                         )}
                     </div>
 
                     <div className="mt-6 flex justify-end gap-3">
-                        <SecondaryButton onClick={handleClose}>
-                            Not now
-                        </SecondaryButton>
+                        <SecondaryButton onClick={handleClose}>Not now</SecondaryButton>
                         <PrimaryButton
                             data-tour="task-submit"
                             type="submit"
                             disabled={processing || isSubmitting}
                         >
-                            {processing || isSubmitting
-                                ? "Saving..."
-                                : "Save task"}
+                            {processing || isSubmitting ? "Saving..." : "Save task"}
                         </PrimaryButton>
                     </div>
                 </form>

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\ReminderController;
 use App\Http\Controllers\SubtaskController;
 use App\Http\Controllers\SwimlaneController;
 use App\Http\Controllers\TagController;
+use App\Http\Controllers\TaskCaptureController;
 use App\Http\Controllers\TaskController;
 use App\Http\Controllers\WorkspaceController;
 use App\Modules\Finance\Controllers\FinanceAccountController;
@@ -61,6 +62,7 @@ Route::middleware('auth')->group(function () {
 Route::middleware(['auth', 'verified'])->group(function () {
     // Tasks
     Route::resource('tasks', TaskController::class)->except(['create', 'show', 'edit']);
+    Route::post('tasks/capture', [TaskCaptureController::class, 'store'])->name('tasks.capture');
     Route::post('tasks/{task}/toggle-status', [TaskController::class, 'toggleStatus'])->name('tasks.toggle-status');
     Route::post('tasks/reorder', [TaskController::class, 'reorder'])->name('tasks.reorder');
 

--- a/tests/Feature/AiEntitlementServiceTest.php
+++ b/tests/Feature/AiEntitlementServiceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Models\User;
+use App\Services\Ai\AiEntitlementService;
+
+beforeEach(function () {
+    $this->service = $this->app->make(AiEntitlementService::class);
+});
+
+it('always allows premium (admin) users regardless of the open-beta flag', function () {
+    $premium = User::factory()->create(['role' => 'admin']);
+
+    config()->set('ai.open_beta.some_feature', false);
+    expect($this->service->canUse($premium, 'some_feature'))->toBeTrue();
+    expect($this->service->isPremium($premium))->toBeTrue();
+});
+
+it('allows a free user only when the feature has a truthy open-beta override', function () {
+    $free = User::factory()->create(['role' => 'member']);
+
+    config()->set('ai.open_beta.some_feature', true);
+    expect($this->service->canUse($free, 'some_feature'))->toBeTrue();
+
+    config()->set('ai.open_beta.some_feature', false);
+    expect($this->service->canUse($free, 'some_feature'))->toBeFalse();
+});
+
+it('locks a free user out of any feature with no open-beta override (pro-gated default)', function () {
+    $free = User::factory()->create(['role' => 'member']);
+
+    expect($this->service->canUse($free, 'brand_new_feature'))->toBeFalse();
+    expect($this->service->isPremium($free))->toBeFalse();
+});

--- a/tests/Feature/DailySummaryServiceTest.php
+++ b/tests/Feature/DailySummaryServiceTest.php
@@ -18,6 +18,20 @@ function fakeGenerator(callable $handler): TextGenerator
     };
 }
 
+it('honors the open-beta flag and falls back to the premium tier when off', function () {
+    $freeUser = User::factory()->create(['role' => 'member']);
+    $premiumUser = User::factory()->create(['role' => 'admin']);
+
+    $service = $this->app->make(DailySummaryService::class);
+
+    config()->set('ai.open_beta.daily_summary', true);
+    expect($service->userCanUseSummary($freeUser))->toBeTrue();
+
+    config()->set('ai.open_beta.daily_summary', false);
+    expect($service->userCanUseSummary($freeUser))->toBeFalse()
+        ->and($service->userCanUseSummary($premiumUser))->toBeTrue();
+});
+
 it('generates and upserts a summary using the text generator', function () {
     $user = User::factory()->create();
 

--- a/tests/Feature/Finance/FinanceInsightControllerTest.php
+++ b/tests/Feature/Finance/FinanceInsightControllerTest.php
@@ -42,7 +42,7 @@ it('generates and caches an insight for an entitled user', function () {
 });
 
 it('blocks an unentitled user when the open beta is off', function () {
-    config()->set('ai.finance_insights_open_beta', false);
+    config()->set('ai.open_beta.finance_insights', false);
 
     $user = User::factory()->create(['role' => 'member']);
     bindFakeInsightGenerator($this->app, fn () => 'Should never run.');

--- a/tests/Feature/Finance/FinanceInsightServiceTest.php
+++ b/tests/Feature/Finance/FinanceInsightServiceTest.php
@@ -53,7 +53,8 @@ it('falls back to a deterministic template when the provider fails', function ()
     expect($insight->provider)->toBe('fallback')
         ->and($insight->model)->toBe('template')
         ->and($insight->content)->toContain('spent')
-        ->and($insight->content)->toContain('savings');
+        ->and($insight->content)->toContain('savings')
+        ->and($insight->content)->toContain('₱');
 
     $this->assertDatabaseCount('finance_insights', 1);
 });
@@ -79,10 +80,10 @@ it('honors the open-beta flag and falls back to the premium tier when off', func
 
     $service = $this->app->make(FinanceInsightService::class);
 
-    config()->set('ai.finance_insights_open_beta', true);
+    config()->set('ai.open_beta.finance_insights', true);
     expect($service->userCanUseInsights($freeUser))->toBeTrue();
 
-    config()->set('ai.finance_insights_open_beta', false);
+    config()->set('ai.open_beta.finance_insights', false);
     expect($service->userCanUseInsights($freeUser))->toBeFalse()
         ->and($service->userCanUseInsights($premiumUser))->toBeTrue();
 });

--- a/tests/Feature/TaskCaptureTest.php
+++ b/tests/Feature/TaskCaptureTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use App\Models\User;
+use App\Services\Ai\Contracts\TextGenerator;
+
+function bindFakeCaptureGenerator($app, callable $handler): void
+{
+    $app->bind(TextGenerator::class, fn () => new class($handler) implements TextGenerator
+    {
+        public function __construct(private $handler) {}
+
+        public function generate(string $system, string $prompt, array $options = []): string
+        {
+            return ($this->handler)($system, $prompt, $options);
+        }
+    });
+}
+
+beforeEach(function () {
+    // Open the beta so a normal (free) user can exercise the happy path.
+    config()->set('ai.open_beta.task_capture', true);
+});
+
+it('extracts a structured recurring task from natural language', function () {
+    $user = User::factory()->create(['role' => 'member']);
+
+    bindFakeCaptureGenerator($this->app, fn () => json_encode([
+        'title' => 'Pay rent',
+        'description' => null,
+        'priority' => 'high',
+        'due_date' => null,
+        'start_time' => '09:00',
+        'end_time' => null,
+        'is_all_day' => false,
+        'is_recurring' => true,
+        'recurrence_type' => 'monthly',
+        'recurrence_config' => ['day_of_month' => 1],
+        'recurring_until' => null,
+        'category_id' => null,
+        'tags' => ['home'],
+    ]));
+
+    $response = $this->actingAs($user)
+        ->postJson(route('tasks.capture'), ['input' => 'pay rent every 1st at 9am, high priority']);
+
+    $response->assertOk();
+
+    $task = $response->json('task');
+
+    expect($task['title'])->toBe('Pay rent')
+        ->and($task['priority'])->toBe('high')
+        ->and($task['start_time'])->toBe('09:00')
+        ->and($task['is_all_day'])->toBeFalse()
+        ->and($task['is_recurring'])->toBeTrue()
+        ->and($task['recurrence_type'])->toBe('monthly')
+        ->and($task['recurrence_config'])->toBe(['day_of_month' => 1])
+        ->and($task['recurring_until'])->not->toBeNull()   // defaulted to keep the form submit-ready
+        ->and($task['tags'][0]['name'])->toBe('home')
+        ->and($task['tags'][0]['is_new'])->toBeTrue();
+});
+
+it('returns a friendly 422 when the AI response is not valid JSON', function () {
+    $user = User::factory()->create(['role' => 'member']);
+
+    bindFakeCaptureGenerator($this->app, fn () => 'Sorry, I could not parse that.');
+
+    $this->actingAs($user)
+        ->postJson(route('tasks.capture'), ['input' => 'do the thing'])
+        ->assertStatus(422)
+        ->assertJsonStructure(['message']);
+});
+
+it('returns a friendly 422 when the provider throws', function () {
+    $user = User::factory()->create(['role' => 'member']);
+
+    bindFakeCaptureGenerator($this->app, fn () => throw new RuntimeException('provider down'));
+
+    $this->actingAs($user)
+        ->postJson(route('tasks.capture'), ['input' => 'buy milk tomorrow'])
+        ->assertStatus(422)
+        ->assertJsonStructure(['message']);
+});
+
+it('blocks a non-premium user when the feature is not in open beta', function () {
+    config()->set('ai.open_beta.task_capture', false);
+
+    $user = User::factory()->create(['role' => 'member']);
+    bindFakeCaptureGenerator($this->app, fn () => 'should never run');
+
+    $this->actingAs($user)
+        ->postJson(route('tasks.capture'), ['input' => 'buy milk tomorrow'])
+        ->assertStatus(403);
+});
+
+it('allows a premium (admin) user even when the feature is not in open beta', function () {
+    config()->set('ai.open_beta.task_capture', false);
+
+    $user = User::factory()->create(['role' => 'admin']);
+    bindFakeCaptureGenerator($this->app, fn () => json_encode([
+        'title' => 'Buy milk',
+        'priority' => 'medium',
+        'is_recurring' => false,
+    ]));
+
+    $this->actingAs($user)
+        ->postJson(route('tasks.capture'), ['input' => 'buy milk'])
+        ->assertOk()
+        ->assertJsonPath('task.title', 'Buy milk');
+});
+
+it('requires an input string', function () {
+    $user = User::factory()->create(['role' => 'member']);
+
+    $this->actingAs($user)
+        ->postJson(route('tasks.capture'), [])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('input');
+});


### PR DESCRIPTION
Adds `AiEntitlementService::canUse(User, feature)` as the single AI-gating seam — premium-only by default, opened per feature via a new `config('ai.open_beta.*')` map, with `User::isPremium()` as the sole premium predicate — and routes the existing daily-summary and finance-insight gating through it (both stay in open beta). Introduces the flagship **natural-language task capture**: `TaskExtractionService` turns free text like "pay rent every 1st at 9am, high priority" into a validated task payload (premium-gated by default) that pre-fills the task modal for review before the normal save. Also fixes the finance spending-insight prose to render Philippine Pesos (₱) instead of `$`. Verified with Pint, Prettier/ESLint, `npm run build`, and the Pest suite against Docker MySQL (25 relevant tests passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)