### PR TITLE
Fix task saves 302-ing into a GET-less endpoint (404)

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -53,6 +53,33 @@ class TaskController extends Controller
     }
 
     /**
+     * Redirect back to the originating page, never into a GET-less task endpoint.
+     *
+     * Task mutations run on POST/PUT/DELETE routes whose paths have no GET
+     * counterpart — /tasks/{task} (show is excluded from the resource),
+     * /tasks/{task}/toggle-status, and /tasks/reorder. When back() resolves to
+     * the request's own URL (e.g. saving an edited task), Inertia follows the
+     * 302 into one of these dead endpoints and the save appears to fail with a
+     * 404. Fall back to the tasks index in that case; the bare /tasks index is a
+     * real GET route, so a previous URL that points there keeps its filters.
+     */
+    private function redirectBack(): RedirectResponse
+    {
+        $previous = url()->previous();
+        $path = ltrim(parse_url($previous, PHP_URL_PATH) ?? '', '/');
+
+        $isDeadEndpoint = $previous === url()->current()
+            || $path === 'tasks/reorder'
+            || preg_match('#^tasks/\d+(/|$)#', $path) === 1;
+
+        if ($isDeadEndpoint) {
+            return redirect()->route('tasks.index');
+        }
+
+        return redirect()->to($previous);
+    }
+
+    /**
      * Store a newly created resource in storage.
      */
     public function store(Request $request): RedirectResponse
@@ -101,11 +128,11 @@ class TaskController extends Controller
         try {
             $task = $this->taskService->createTask($validated, Auth::id());
 
-            return redirect()->back()->with('message', 'Task created successfully');
+            return $this->redirectBack()->with('message', 'Task created successfully');
         } catch (\InvalidArgumentException $e) {
-            return redirect()->back()->withErrors(['error' => $e->getMessage()])->withInput();
+            return $this->redirectBack()->withErrors(['error' => $e->getMessage()])->withInput();
         } catch (\Exception $e) {
-            return redirect()->back()->withErrors(['error' => 'Failed to create task. Please try again.'])->withInput();
+            return $this->redirectBack()->withErrors(['error' => 'Failed to create task. Please try again.'])->withInput();
         }
     }
 
@@ -159,11 +186,11 @@ class TaskController extends Controller
         try {
             $updatedTask = $this->taskService->updateTask($task, $validated, Auth::id());
 
-            return redirect()->back()->with('message', 'Task updated successfully');
+            return $this->redirectBack()->with('message', 'Task updated successfully');
         } catch (\InvalidArgumentException $e) {
-            return redirect()->back()->withErrors(['error' => $e->getMessage()])->withInput();
+            return $this->redirectBack()->withErrors(['error' => $e->getMessage()])->withInput();
         } catch (\Exception $e) {
-            return redirect()->back()->withErrors(['error' => 'Failed to update task. Please try again.'])->withInput();
+            return $this->redirectBack()->withErrors(['error' => 'Failed to update task. Please try again.'])->withInput();
         }
     }
 
@@ -175,9 +202,9 @@ class TaskController extends Controller
         try {
             $this->taskService->deleteTask($task, Auth::id());
 
-            return back()->with('status', 'Task deleted successfully');
+            return $this->redirectBack()->with('status', 'Task deleted successfully');
         } catch (\Exception $e) {
-            return back()->withErrors(['error' => 'Failed to delete task. Please try again.']);
+            return $this->redirectBack()->withErrors(['error' => 'Failed to delete task. Please try again.']);
         }
     }
 
@@ -196,7 +223,7 @@ class TaskController extends Controller
                 ]);
             }
 
-            return back()->with('message', 'Tasks reordered successfully');
+            return $this->redirectBack()->with('message', 'Tasks reordered successfully');
         } catch (\Exception $e) {
             if ($request->expectsJson()) {
                 return response()->json(
@@ -205,7 +232,7 @@ class TaskController extends Controller
                 );
             }
 
-            return back()->withErrors(['error' => 'Failed to reorder tasks. Please try again.']);
+            return $this->redirectBack()->withErrors(['error' => 'Failed to reorder tasks. Please try again.']);
         }
     }
 
@@ -224,9 +251,9 @@ class TaskController extends Controller
         try {
             $this->taskService->toggleTaskStatus($task, $newStatus, Auth::id());
 
-            return back()->with('status', 'Task status updated successfully');
+            return $this->redirectBack()->with('status', 'Task status updated successfully');
         } catch (\Exception $e) {
-            return back()->withErrors(['error' => 'Failed to update task status. Please try again.']);
+            return $this->redirectBack()->withErrors(['error' => 'Failed to update task status. Please try again.']);
         }
     }
 }

--- a/tests/Feature/TaskRedirectTest.php
+++ b/tests/Feature/TaskRedirectTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use App\Models\Task;
+use App\Models\User;
+
+/**
+ * Task mutations run on POST/PUT/DELETE routes whose paths have no GET
+ * counterpart — /tasks/{task} (show is excluded from the resource),
+ * /tasks/{task}/toggle-status, and /tasks/reorder. A plain back() that
+ * resolves to the request's own URL leaves Inertia following the 302 into a
+ * dead endpoint, so the save appears to fail with a 404. These tests lock in
+ * that mutations never redirect into a GET-less task endpoint.
+ */
+function makeTask(User $user, array $attributes = []): Task
+{
+    return Task::create(array_merge([
+        'user_id' => $user->id,
+        'title' => 'Original title',
+        'priority' => 'medium',
+        'status' => 'pending',
+        'is_all_day' => true,
+    ], $attributes));
+}
+
+it('does not redirect a task update into the GET-less task detail endpoint', function () {
+    $user = User::factory()->create();
+    $task = makeTask($user);
+
+    $response = $this->actingAs($user)
+        ->from("/tasks/{$task->id}")
+        ->put(route('tasks.update', $task->id), [
+            'title' => 'Updated title',
+            'priority' => 'high',
+            'status' => 'pending',
+        ]);
+
+    $response->assertRedirect(route('tasks.index'));
+});
+
+it('redirects a task update back to the originating page when it is a real GET route', function () {
+    $user = User::factory()->create();
+    $task = makeTask($user);
+
+    $response = $this->actingAs($user)
+        ->from('/calendar')
+        ->put(route('tasks.update', $task->id), [
+            'title' => 'Updated title',
+            'priority' => 'high',
+            'status' => 'pending',
+        ]);
+
+    $response->assertRedirect('/calendar');
+});
+
+it('does not redirect a delete into the GET-less task detail endpoint', function () {
+    $user = User::factory()->create();
+    $task = makeTask($user);
+
+    $response = $this->actingAs($user)
+        ->from("/tasks/{$task->id}")
+        ->delete(route('tasks.destroy', $task->id));
+
+    $response->assertRedirect(route('tasks.index'));
+});
+
+it('does not redirect a status toggle into its own GET-less endpoint', function () {
+    $user = User::factory()->create();
+    $task = makeTask($user);
+
+    $response = $this->actingAs($user)
+        ->from("/tasks/{$task->id}/toggle-status")
+        ->post(route('tasks.toggle-status', $task->id), ['status' => 'completed']);
+
+    $response->assertRedirect(route('tasks.index'));
+});
+
+it('does not redirect a reorder into its own GET-less endpoint', function () {
+    $user = User::factory()->create();
+    $task = makeTask($user);
+
+    $response = $this->actingAs($user)
+        ->from('/tasks/reorder')
+        ->post(route('tasks.reorder'), ['taskIds' => [$task->id]]);
+
+    $response->assertRedirect(route('tasks.index'));
+});


### PR DESCRIPTION
Task mutations returned `back()`, which could resolve to the request's own POST/PUT/DELETE URL — but those task paths have no GET counterpart (`/tasks/{task}` since `show` is excluded, `/tasks/{task}/toggle-status`, and `/tasks/reorder`), so Inertia followed the 302 into a dead endpoint and the save appeared to fail with a 404 even though the row was saved. This adds a `redirectBack()` guard (mirroring the existing subtask fix #99) that never targets a GET-less task endpoint, falling back to the tasks index while preserving the `/tasks` index query string. Applied to `store`, `update`, `destroy`, `toggleStatus`, and the redirect branches of `reorder`; the JSON branch of `reorder` is untouched. Adds `TaskRedirectTest` covering the regression across all mutation routes plus a case confirming a legitimate referer (e.g. `/calendar`) is still honored.

Note: the suite couldn't be run in this workspace (MySQL-only, `vendor/` not installed); please run `composer test` and `vendor/bin/pint` in the Docker environment before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)