### PR TITLE
Make task end time optional on create and edit

### DIFF
--- a/resources/js/Components/TaskEditModal.jsx
+++ b/resources/js/Components/TaskEditModal.jsx
@@ -462,7 +462,7 @@ export default function TaskEditModal({
                                             </div>
                                             <div>
                                             <label className="block text-sm font-medium mb-1 text-light-secondary dark:text-dark-secondary">
-                                                End time
+                                                End time (optional)
                                                 </label>
                                                 <input
                                                     type="time"
@@ -474,7 +474,6 @@ export default function TaskEditModal({
                                                             e.target.value
                                                         )
                                                     }
-                                                    required={!data.is_all_day}
                                                 />
                                                 {errors.end_time && (
                                                     <div className="text-red-500 text-xs mt-1">

--- a/resources/js/Components/TaskModal.jsx
+++ b/resources/js/Components/TaskModal.jsx
@@ -484,7 +484,7 @@ export default function TaskModal({ show, onClose, onSubmitting, defaultCategory
                                         </div>
                                         <div>
                                             <label className="block text-sm font-medium mb-1 text-light-secondary dark:text-dark-secondary">
-                                                End time
+                                                End time (optional)
                                             </label>
                                             <input
                                                 type="time"
@@ -493,7 +493,6 @@ export default function TaskModal({ show, onClose, onSubmitting, defaultCategory
                                                 onChange={(e) =>
                                                     setData("end_time", e.target.value)
                                                 }
-                                                required={!data.is_all_day}
                                             />
                                             {errors.end_time && (
                                                 <div className="text-red-500 text-xs mt-1">

--- a/resources/js/Pages/Tasks/Index.jsx
+++ b/resources/js/Pages/Tasks/Index.jsx
@@ -1147,7 +1147,7 @@ export default function Index({ tasks = [], categories, tags = [], filters }) {
                                         onChange={(e) =>
                                             setGroupBy(e.target.value)
                                         }
-                                        className="border border-light-border/70 dark:border-dark-border/70 rounded-lg px-2.5 py-1.5 text-xs focus:ring-2 focus:ring-wevie-teal/40 focus:border-wevie-teal dark:bg-dark-card dark:text-dark-primary"
+                                        className="border border-light-border/70 dark:border-dark-border/70 rounded-lg pl-2.5 pr-8 py-1.5 text-xs focus:ring-2 focus:ring-wevie-teal/40 focus:border-wevie-teal dark:bg-dark-card dark:text-dark-primary"
                                     >
                                         <option value="none">None</option>
                                         <option value="category">Category</option>


### PR DESCRIPTION
Removes the `required` attribute from the **End time** input in both `TaskModal` (create) and `TaskEditModal` (edit), so a task can have a start time without being forced to set an end time. The field is relabeled "End time (optional)". No backend changes were needed: `end_time` is already validated as `nullable`, and the model falls back to end-of-day when it is absent (`Task::getFullEndDateTimeAttribute`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)