### PR TITLE
Add mobile-dev skill and mobile-engineer agent for Android & iOS

### DIFF
--- a/.claude/agents/mobile-engineer.md
+++ b/.claude/agents/mobile-engineer.md
@@ -1,0 +1,28 @@
+---
+name: mobile-engineer
+description: Delegate Android & iOS mobile tasks — taking Wevie mobile via a Capacitor wrap of the existing React/Inertia PWA or as native SwiftUI / Jetpack Compose apps against the Laravel API, plus store packaging, push notifications, offline, deep links, and Sanctum auth. Use when a mobile delivery decision or implementation is needed end-to-end (decide path → implement → verify build).
+tools: Read, Edit, Write, Bash, Grep, Glob, WebSearch, WebFetch
+---
+
+You are a senior mobile engineer working on **Wevie** — today a Laravel 12 + Inertia v2 + React 18 **PWA** with **no native mobile code and no dedicated mobile API yet**. You take it to **Android and iOS**.
+
+## First step, every task
+Invoke the **`mobile-dev`** skill (`Skill(mobile-dev)`) and follow it. It carries the delivery-path decision matrix, the auth/backend requirements, the cross-cutting mobile concerns, and the platform references (`references/platform-strategy.md`, `references/ios.md`, `references/android.md`). Also consult the root `CLAUDE.md`.
+
+## How you work
+1. **Check what exists first:** the app is already an installable PWA (`vite-plugin-pwa`, `Components/Offline/`, `Components/Mobile/`) — confirm a native app is actually needed before adding a stack.
+2. **Decide and state the delivery path** at the top of the task: **Capacitor wrap** (recommended default — reuses ~100% of the React UI) vs. **fully native** (SwiftUI + Jetpack Compose against a Laravel API). Justify it against the matrix in `platform-strategy.md`.
+3. **Establish versions:** installed web (`package.json`/`composer.json` — React 18, Laravel 12, Sanctum 4) plus the native toolchain you're targeting (iOS deployment target, Android `minSdk`/`targetSdk`, Capacitor major). Build for those; `WebSearch` official docs for anything new — mobile SDKs and store rules move yearly.
+4. **Auth:** WebView/Capacitor rides the existing **session** (verify CORS / `SANCTUM_STATEFUL_DOMAINS`); native needs **Sanctum tokens + a versioned API you must build first** through the repo's layers (delegate PHP to the `laravel-backend` skill/engineer; **portable SQL**; keep `Modules/Finance` isolated).
+5. **Reuse, don't fork:** reuse the responsive `Components/Mobile/` screens and the Wevie design tokens (`#4ACF91`, `#5FDDE0`, `Inter`, light/dark); handle offline, push, deep links, and safe areas.
+6. **Verify it builds:** web/Capacitor → `npm run build` then `npx cap sync`; iOS → Xcode / `xcodebuild`; Android → `./gradlew assembleDebug`. Paste the result.
+
+## Guardrails
+- **No secrets in the app binary** — bundles are decompilable; keep keys server-side.
+- **Don't add a third UI stack** (React Native / Expo / Flutter) — it duplicates the React UI without Capacitor's reuse; needs explicit sign-off.
+- **Don't regress the PWA/offline** or the web build; keep native projects (`ios/`, `android/`) isolated from the Vite/Laravel build.
+- **Native code follows its platform idiom** (Swift API guidelines, Kotlin conventions) — don't force 4-space-JSX habits onto Swift/Kotlin. Web code you touch keeps the repo's rules (Inertia props, no Redux/Zustand/RQ).
+- **Don't silently bump** a minSdk / deployment target / Capacitor major — assess and recommend.
+
+## Report back
+Return: the delivery path chosen and why, what you changed (files), the auth/offline/push/deep-link concerns handled, store-compliance blockers to watch, the build result (paste key output), and anything left for review. Your final message is the deliverable — be concrete.

--- a/.claude/skills/mobile-dev/SKILL.md
+++ b/.claude/skills/mobile-dev/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: mobile-dev
+description: Native & hybrid mobile development for Wevie on Android and iOS — deciding and building the mobile delivery (Capacitor wrap of the existing React/Inertia PWA, or native SwiftUI / Jetpack Compose apps against the Laravel API), plus store packaging, push notifications, offline, deep links, and Sanctum auth. Use for any Android/iOS/Capacitor/Swift/Kotlin work or "take Wevie mobile" tasks.
+---
+
+# Mobile (Android & iOS) — Wevie
+
+Repo-aware guidance for taking **Wevie** to mobile. Wevie today is a **Laravel 12 + Inertia v2 + React 18 PWA** — there is **no native mobile code and no dedicated mobile API yet**. Read this before adding any `android/`, `ios/`, or Capacitor scaffolding. Load `references/platform-strategy.md` first to choose the path, then `references/ios.md` and/or `references/android.md` for the platform you're building.
+
+## 0. Understand what exists before adding anything
+
+- **The app is already a PWA** (`vite-plugin-pwa`, `resources/js/Components/Offline/`, service worker). Installable to a home screen today — confirm the requirement isn't already met before writing native code.
+- **There is a mobile-web layer**: `resources/js/Components/Mobile/` (`MobileTabBar`, `MobileFab`, …). Native shells should reuse these responsive React screens, not reimplement them.
+- **Auth is session/SPA (Sanctum + Breeze)** over `routes/web.php`; there is **no token API surface** for third-party native clients. Native (non-webview) apps need Sanctum **token** auth added deliberately — see §3.
+- **No native tooling is installed** (`package.json`/`composer.json` have no Capacitor/Cordova/RN). Adding a path is a real dependency + CI decision — justify it.
+
+## 1. Pick the delivery path first (this is the biggest decision)
+
+Two viable paths — `references/platform-strategy.md` has the full decision matrix. Default recommendation for this stack:
+
+- **Capacitor wrap (recommended default).** Wrap the existing Inertia/React PWA in a native WebView shell. One codebase, reuses every screen and the Wevie design system, ships to both stores, and adds native plugins (push, biometrics, share, filesystem) only where needed. Lowest cost, highest reuse — fits a Laravel+React monolith.
+- **Fully native (SwiftUI + Jetpack Compose).** Two native apps consuming a Laravel JSON API. Choose only when you need deep native UX, background work, or performance the WebView can't give. ~2× the build/maintenance and requires building & versioning a real mobile API.
+
+Do **not** introduce React Native / Expo / Flutter as a third stack without explicit sign-off — it duplicates the React UI you already have without the code reuse Capacitor gives.
+
+State which path you're on at the top of any mobile task; the rest of the skill branches on it.
+
+## 2. Version freshness protocol (do this first, like the other skills)
+
+- **Establish installed versions** before non-trivial work: `package.json` (React 18.2, Vite 6, Inertia 2), `composer.json` (Laravel 12, Sanctum 4, PHP 8.2+). Build for **these**.
+- **Establish platform toolchain versions** you're targeting and say so: iOS deployment target + Xcode/Swift, Android `minSdk`/`targetSdk` + Kotlin/AGP, and for Capacitor the major (`@capacitor/core`). If a task needs a new native API, `WebSearch` the official docs (developer.apple.com, developer.android.com, capacitorjs.com) — mobile SDKs move fast and store requirements change yearly.
+- Never silently bump a native minSdk / deployment target / Capacitor major as a side effect; assess and recommend.
+
+## 3. Backend & auth — what mobile needs from Laravel
+
+- **Capacitor/WebView** rides the existing **session cookie** auth as long as the WebView shares cookies and CSRF works — verify CORS/`SANCTUM_STATEFUL_DOMAINS`/`config/cors.php` for the app's origin. Prefer reusing the web session over inventing a token flow.
+- **Native apps** need **Sanctum personal-access tokens** (`createToken`) and a small, versioned **API surface** (e.g. `routes/api.php` under `auth:sanctum`) — this does not exist yet, so building native means building that API first, going through the repo's layers (thin controller → Service → Repository, Form Requests, **portable SQL**). Respect the `Modules/Finance` boundary.
+- **Keep the backend the single source of truth.** Don't duplicate business logic in the app; call the API/Service. Follow the root `CLAUDE.md` and the `laravel-backend` skill for any PHP you add.
+- **Never ship secrets in the app binary** — mobile bundles are trivially decompiled. No API keys, no signing secrets, no service-account JSON in the client.
+
+## 4. Cross-cutting mobile concerns (both paths)
+
+- **Offline** — Wevie already has offline UX on web; don't regress it. Capacitor: keep the service worker working inside the shell. Native: cache with the platform store (Core Data / Room) and reconcile on reconnect.
+- **Push notifications** — server side integrates with the existing `NotificationService`; client side is APNs (iOS) + FCM (Android), surfaced via a plugin (Capacitor) or native SDK. Handle permission prompts, denied state, and foreground vs background.
+- **Deep links / universal links** — map to Ziggy routes so a link opens the right screen; register Associated Domains (iOS) and App Links (Android).
+- **Safe areas & insets** — respect notches/home indicator/status bar; test small phones and tablets, portrait and landscape.
+- **Design system** — the mobile UI must read as Wevie: reuse the Tailwind tokens (`primary` #4ACF91, `secondary` #5FDDE0, `wevie.*`, `light-*`/`dark-*`) in the webview path, and mirror those exact colors + `Inter` font natively. Honor light/dark and `prefers-reduced-motion`.
+- **Store compliance** — privacy manifests / data-safety forms, required permission usage strings, account-deletion path, and current SDK-level requirements are release blockers. Check them before promising a submission.
+
+## 5. Conventions
+
+- **Repo web code** keeps its existing rules (4-space indent, PascalCase JS, double-quoted imports, Wevie tokens, Inertia props — no Redux/Zustand/React Query). Follow `react-ui-ux` / `laravel-backend` when you touch `resources/js` or `app/`.
+- **Native code** follows its platform idiom, not the web one: Swift API Design Guidelines + SwiftUI (`references/ios.md`); Kotlin coding conventions + Jetpack Compose + Material 3 (`references/android.md`). Don't force 4-space-JS habits onto Swift/Kotlin.
+- **Isolate native projects.** Capacitor `ios/` & `android/` or standalone native apps live in clearly separated directories (or a sibling repo) with their own gitignore/build config — keep them out of the Laravel/Vite build.
+- **Verify it builds** before returning: web/Capacitor → `npm run build` then `npx cap sync`; iOS → `xcodebuild` / builds in Xcode; Android → `./gradlew assembleDebug`. Paste the result.
+
+## Definition of done
+Delivery path stated & justified · reuses the PWA/design system (or documents why native) · auth path correct (session for WebView, Sanctum tokens + versioned API for native) · offline/push/deep-links/safe-areas handled as scoped · no secrets in the binary · native projects isolated from the web build · target build passes · store-compliance blockers called out.

--- a/.claude/skills/mobile-dev/references/android.md
+++ b/.claude/skills/mobile-dev/references/android.md
@@ -1,0 +1,41 @@
+# Android — native & Capacitor shell
+
+Guidance for the Android side of Wevie, whether it's the Capacitor `android/` shell or a fully native Jetpack Compose app. Verify toolchain specifics against developer.android.com — Google raises the required `targetSdk` for Play submissions on a yearly cadence.
+
+## Toolchain — establish and state it
+
+- **Kotlin** for app code; **Jetpack Compose** + **Material 3** for new UI.
+- **Gradle (AGP) with Kotlin DSL** (`build.gradle.kts`).
+- Pick `minSdk` (device reach vs. API availability) and `targetSdk` (Play requires a recent level) deliberately — state both. Don't silently accept the template defaults.
+
+## Conventions
+
+- Follow the official **Kotlin coding conventions** — do **not** carry the web repo's 4-space-JSX habits into Kotlin; use the Kotlin/Android idiom.
+- Compose UI + `ViewModel` (state holder) + repository for data; `Kotlin coroutines` / `Flow` for async; **Retrofit + kotlinx.serialization / Moshi** for the API; models mirror the API JSON.
+- Keep composables small and stateless where possible (hoist state); push logic into ViewModels/repositories, mirroring the backend's layered thinking.
+- Match the Wevie brand: a Compose theme with `#4ACF91` (primary) and `#5FDDE0` (secondary), `Inter` (or a bundled font), supporting light **and** dark via `dynamicColor`-off Material theming so brand colors hold.
+
+## Auth (native path)
+
+- Sanctum **personal-access token** from a login API call, stored via **EncryptedSharedPreferences** / DataStore (never plain SharedPreferences).
+- Send `Authorization: Bearer <token>`; on 401 clear the token and route to login.
+
+## Platform concerns
+
+- **Push:** **FCM** via the server + a `FirebaseMessagingService`; on Android 13+ request the `POST_NOTIFICATIONS` runtime permission and handle denial.
+- **App Links:** verified `android:autoVerify` intent filters + the `assetlinks.json` served by Laravel; route the deep link to the matching screen.
+- **Back navigation:** honor the system/predictive back gesture — hardware/gesture back maps to the app's nav stack (in Capacitor, to Inertia/router history).
+- **Insets:** edge-to-edge with `WindowInsets`; respect status/navigation bars and cutouts; test a small phone and a tablet.
+- **Permissions & Data safety:** request at point of use; complete the Play **Data safety** form and provide an account-deletion path. These are submission blockers.
+- **Biometrics:** `androidx.biometric` if gating sensitive Finance screens.
+
+## Capacitor shell specifics
+
+- The `android/` project is generated — treat most of it as managed; `npx cap sync` after every web build.
+- Custom native code goes in a Capacitor plugin, not by hand-editing generated files that sync overwrites.
+- Verify cookie/session sharing so the WebView stays authenticated against Sanctum; wire the hardware back button to router history.
+
+## Verify before returning
+
+- Build: `./gradlew assembleDebug`; for Capacitor run `npm run build && npx cap sync android` first.
+- Note `minSdk`/`targetSdk`, whether it installs/runs on an emulator, and any signing/keystore setup still required. Paste the build result.

--- a/.claude/skills/mobile-dev/references/ios.md
+++ b/.claude/skills/mobile-dev/references/ios.md
@@ -1,0 +1,40 @@
+# iOS — native & Capacitor shell
+
+Guidance for the iOS side of Wevie, whether it's the Capacitor `ios/` shell or a fully native SwiftUI app. Verify toolchain specifics against developer.apple.com — Apple changes SDK levels, privacy rules, and submission requirements yearly.
+
+## Toolchain — establish and state it
+
+- **Xcode / Swift** current stable; pick a **deployment target** deliberately (don't just accept Xcode's newest default — it drops older devices). State it in the task.
+- **Swift** for app code; **SwiftUI** for new UI, with UIKit interop only where SwiftUI lacks the API.
+- **Swift Package Manager** for dependencies (prefer over CocoaPods for new work; Capacitor may still use CocoaPods — follow its generated `Podfile`).
+
+## Conventions
+
+- Follow the **Swift API Design Guidelines** (naming, clarity at the call site) — do **not** carry the web repo's 4-space-JSX habits into Swift; use the Swift/Xcode idiom.
+- SwiftUI: `@Observable` / `@State` / `@Environment` for state; `async/await` + `URLSession` for networking; `Codable` models mirroring the API JSON.
+- Keep views small and composable; push logic into view models / services, mirroring the backend's layered thinking.
+- Match the Wevie brand: define a color asset catalog with `#4ACF91` (primary) and `#5FDDE0` (secondary), `Inter` (or the system font if Inter isn't bundled), and support light **and** dark appearance.
+
+## Auth (native path)
+
+- Sanctum **personal-access token** obtained via a login API call, stored in the **Keychain** (never `UserDefaults`).
+- Send `Authorization: Bearer <token>`; handle 401 by clearing the token and routing to login.
+
+## Platform concerns
+
+- **Push:** APNs via the server + `UNUserNotificationCenter`. Request permission at a sensible moment; handle denied and provisional states; handle foreground presentation.
+- **Universal Links:** Associated Domains entitlement + `apple-app-site-association` served by Laravel; route the incoming URL to the matching screen.
+- **Safe areas:** respect notch/Dynamic Island/home indicator via safe-area insets; test the smallest supported device and iPad.
+- **Privacy:** provide required `Info.plist` usage strings for any permission, and the **privacy manifest** (`PrivacyInfo.xcprivacy`) + App Store privacy answers. These are submission blockers.
+- **Biometrics:** `LocalAuthentication` (Face ID/Touch ID) if gating sensitive Finance screens — include the Face ID usage string.
+
+## Capacitor shell specifics
+
+- The `ios/` project is generated — treat most of it as managed; `npx cap sync` after every web build.
+- Custom native code goes in a Capacitor plugin, not by hand-editing generated files that sync overwrites.
+- Verify cookie/session sharing so the WebView stays authenticated against Sanctum.
+
+## Verify before returning
+
+- Build: open in Xcode or `xcodebuild -scheme <App> -sdk iphonesimulator build`; for Capacitor run `npm run build && npx cap sync ios` first.
+- Note the deployment target, whether it runs in the simulator, and any signing/capability setup still required. Paste the build result.

--- a/.claude/skills/mobile-dev/references/platform-strategy.md
+++ b/.claude/skills/mobile-dev/references/platform-strategy.md
@@ -1,0 +1,55 @@
+# Mobile delivery strategy — choosing the path
+
+Wevie is a Laravel + Inertia + React **PWA**. Before writing native code, decide *how* Wevie goes mobile. Get this wrong and you either ship a WebView you didn't need to eject from, or start a native app whose API doesn't exist.
+
+## Step 0 — is a native app even required?
+
+The app is already an installable PWA (`vite-plugin-pwa`, offline components). Ask what the store app buys that the PWA doesn't:
+
+- Store presence / discoverability, native push, biometrics, background sync, App Store payments, deep native gestures, or "must be in the store" org requirement → yes, build a shell/native app.
+- Just "installable on a phone" / "works offline" → the PWA may already satisfy it. Confirm the real requirement before adding a stack.
+
+## The decision matrix
+
+| Factor | Capacitor wrap (WebView) | Fully native (SwiftUI + Compose) |
+|---|---|---|
+| Code reuse | **~100%** of the React/Inertia UI | ~0% UI; reuses only the backend |
+| Codebases to maintain | 1 (web) + thin shells | web + **2 native apps** |
+| Backend work | Reuse session auth; verify CORS/Sanctum stateful | **Build a versioned token API first** |
+| Native UX ceiling | Good; native via plugins | Highest |
+| Offline | Reuse existing service worker | Rebuild with Room / Core Data |
+| Time-to-store | Low | High (~2×+) |
+| Best when | Reuse & speed matter (default here) | Deep native UX / background / perf needs |
+
+**Recommended default for this repo: Capacitor.** A React monolith with an existing PWA is the exact case Capacitor is for — one UI, two stores, native plugins only where needed.
+
+## Path A — Capacitor wrap (recommended)
+
+High-level (verify current commands against capacitorjs.com — the major version drives the API):
+
+1. Add Capacitor to the existing web project; set `webDir` to the Vite build output.
+2. `npx cap add ios` / `npx cap add android` → creates isolated `ios/` & `android/` native projects.
+3. Build web (`npm run build`) then `npx cap sync` on every web change to copy assets + plugins into the shells.
+4. **Auth:** the WebView loads the Laravel app; it rides the **session cookie**. Verify `SANCTUM_STATEFUL_DOMAINS`, `config/cors.php`, and CSRF work for the app origin (`capacitor://localhost` / the served origin). Prefer this over a token flow.
+5. **Native features via plugins:** `@capacitor/push-notifications` (APNs/FCM), `@capacitor/preferences`, `@capacitor/filesystem`, `@capacitor/share`, biometrics — add only what's used.
+6. **Keep the PWA service worker functioning** inside the shell so offline UX doesn't regress.
+7. Respect safe areas (env insets), status-bar theming, and the back button (Android hardware back → Inertia/router history).
+
+Guardrails: don't fork the UI for mobile — reuse `Components/Mobile/` responsive screens. Don't leak native-only code into the web bundle; gate on `Capacitor.isNativePlatform()`.
+
+## Path B — Fully native
+
+Choose only when Path A's ceiling is genuinely too low. Then:
+
+1. **Build the API first.** No mobile/token API exists today. Add `auth:sanctum` token routes (`createToken`), versioned (`/api/v1`), through the repo's layers (controller → Service → Repository, Form Requests, **portable SQL**, `Modules/Finance` isolated). See the `laravel-backend` skill.
+2. **iOS:** SwiftUI app — see `references/ios.md`.
+3. **Android:** Jetpack Compose app — see `references/android.md`.
+4. Mirror the Wevie brand exactly (`#4ACF91`, `#5FDDE0`, `Inter`, light/dark) so it reads as the same product.
+5. Two apps = two release trains, two sets of store metadata, double the QA. Budget for it.
+
+## Anti-patterns
+
+- **A third UI stack** (React Native / Expo / Flutter) — duplicates the React UI you already have, without Capacitor's reuse. Needs explicit sign-off.
+- **Starting native before the API exists** — you'll block on backend work mid-app.
+- **Secrets in the binary** — decompilable. Keep them server-side.
+- **Forking business logic into the app** — backend stays the source of truth.


### PR DESCRIPTION
Adds a repo-aware `mobile-dev` skill (with iOS, Android, and platform-strategy references) and a delegating `mobile-engineer` agent for taking Wevie to Android and iOS. The guidance leads with a Capacitor wrap of the existing React/Inertia PWA (recommended, reuses ~100% of the UI and the session auth) and treats fully native SwiftUI/Jetpack Compose apps — which would first require building a versioned Sanctum-token API — as the "only when needed" path. Both match the existing skill/agent conventions and bake in the repo's guardrails (Wevie design tokens, no secrets in the binary, no third UI stack, native projects isolated from the Vite build). Docs/config only — no application code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)