### PR TITLE
Consolidate per-task actions into an ellipsis menu

### DIFF
--- a/resources/js/Components/TaskActionsMenu.jsx
+++ b/resources/js/Components/TaskActionsMenu.jsx
@@ -1,0 +1,97 @@
+import { Menu } from "@headlessui/react";
+import { MoreVertical } from "lucide-react";
+import { useRef } from "react";
+
+// Overflow menu for a single task row's actions. Modeled on TaskStatusSelect:
+// a Headless UI `Menu` whose panel is portaled via `anchor` so it is never
+// clipped by the `overflow-hidden` Tasks card, with `stopPropagation` guards so
+// clicks never trigger the surrounding row drag/open handlers.
+//
+// Interaction: on hover-capable pointers (desktop) the menu opens on hover and
+// closes on hover-out, with a short close timer so crossing the gap between the
+// button and the portaled panel doesn't close it. On touch (no hover) the
+// hover handlers no-op and Headless UI's native tap-to-open / tap-outside-to-
+// close takes over.
+//
+// `items` is an array of { label, icon, onClick, danger? }.
+const canHover = () =>
+    typeof window !== "undefined" &&
+    window.matchMedia?.("(hover: hover) and (pointer: fine)").matches;
+
+export default function TaskActionsMenu({ items = [] }) {
+    const buttonRef = useRef(null);
+    const closeTimer = useRef(null);
+
+    const cancelClose = () => clearTimeout(closeTimer.current);
+
+    return (
+        <Menu as="div" className="relative" onClick={(e) => e.stopPropagation()}>
+            {({ open, close }) => {
+                const handleEnter = () => {
+                    if (!canHover()) return;
+                    cancelClose();
+                    if (!open) buttonRef.current?.click();
+                };
+                const scheduleClose = () => {
+                    if (!canHover()) return;
+                    cancelClose();
+                    closeTimer.current = setTimeout(() => close(), 120);
+                };
+
+                return (
+                    <>
+                        <Menu.Button
+                            ref={buttonRef}
+                            type="button"
+                            title="Task options"
+                            onClick={(e) => e.stopPropagation()}
+                            onMouseEnter={handleEnter}
+                            onMouseLeave={scheduleClose}
+                            className="rounded-md p-1 text-light-muted transition-colors hover:bg-light-hover hover:text-wevie-teal focus:outline-none focus:ring-2 focus:ring-wevie-teal/40 dark:text-dark-muted dark:hover:bg-dark-hover dark:hover:text-wevie-mint"
+                        >
+                            <MoreVertical className="h-4 w-4" aria-hidden="true" />
+                        </Menu.Button>
+
+                        <Menu.Items
+                            anchor={{ to: "bottom end", gap: 4 }}
+                            onMouseEnter={cancelClose}
+                            onMouseLeave={scheduleClose}
+                            className="z-50 w-44 rounded-lg border border-light-border/70 bg-light-card py-1 shadow-soft focus:outline-none dark:border-dark-border/70 dark:bg-dark-card"
+                        >
+                            {items.map((item) => (
+                                <Menu.Item key={item.label}>
+                                    {({ active }) => (
+                                        <button
+                                            type="button"
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                item.onClick?.();
+                                            }}
+                                            className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs ${
+                                                item.danger
+                                                    ? "text-rose-600 dark:text-rose-300"
+                                                    : "text-light-primary dark:text-dark-primary"
+                                            } ${
+                                                active
+                                                    ? "bg-light-hover dark:bg-dark-hover"
+                                                    : ""
+                                            }`}
+                                        >
+                                            <item.icon
+                                                className="h-4 w-4"
+                                                aria-hidden="true"
+                                            />
+                                            <span className="flex-1">
+                                                {item.label}
+                                            </span>
+                                        </button>
+                                    )}
+                                </Menu.Item>
+                            ))}
+                        </Menu.Items>
+                    </>
+                );
+            }}
+        </Menu>
+    );
+}

--- a/resources/js/Pages/Tasks/Index.jsx
+++ b/resources/js/Pages/Tasks/Index.jsx
@@ -26,7 +26,6 @@ import {
     CheckCircle,
     Circle,
     AlertTriangle,
-    MoreVertical,
     Edit,
     Trash2,
     GripVertical,
@@ -51,6 +50,7 @@ import TaskEditModal from "@/Components/TaskEditModal";
 import TaskStatusSelect, {
     TASK_STATUS_OPTIONS,
 } from "@/Components/TaskStatusSelect";
+import TaskActionsMenu from "@/Components/TaskActionsMenu";
 import QuickSubtaskModal from "@/Components/QuickSubtaskModal";
 import Toast from "@/Components/Toast";
 import OnboardingTour from "@/Components/OnboardingTour";
@@ -288,44 +288,41 @@ function SortableTask({
                     )}
 
                     {/* Actions */}
-                    <div className="flex items-center space-x-1 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
-                        <button
-                            onClick={() => {
-                                setSelectedTask(task);
-                                setShowSubtaskModal(true);
-                            }}
-                            className="p-1 text-light-muted hover:text-emerald-500 dark:text-dark-muted dark:hover:text-emerald-300 transition-colors"
-                            title="Add Subtask"
-                        >
-                            <ListTodo className="h-4 w-4" />
-                        </button>
-                        <button
-                            onClick={() => {
-                                setSelectedTask(task);
-                                setShowViewModal(true);
-                            }}
-                            className="p-1 text-light-muted hover:text-wevie-teal dark:text-dark-muted dark:hover:text-wevie-mint transition-colors"
-                            title="View Task"
-                        >
-                            <Eye className="h-4 w-4" />
-                        </button>
-                        <button
-                            onClick={() => {
-                                setSelectedTask(task);
-                                setShowEditModal(true);
-                            }}
-                            className="p-1 text-light-muted hover:text-wevie-teal dark:text-dark-muted dark:hover:text-wevie-mint transition-colors"
-                            title="Edit Task"
-                        >
-                            <Edit className="h-4 w-4" />
-                        </button>
-                        <button
-                            onClick={() => handleDeleteTask(task)}
-                            className="p-1 text-light-muted hover:text-rose-500 dark:text-dark-muted dark:hover:text-rose-300 transition-colors"
-                            title="Remove Task"
-                        >
-                            <Trash2 className="h-4 w-4" />
-                        </button>
+                    <div className="opacity-100 transition-opacity focus-within:opacity-100 sm:opacity-0 sm:group-hover:opacity-100">
+                        <TaskActionsMenu
+                            items={[
+                                {
+                                    label: "Add subtask",
+                                    icon: ListTodo,
+                                    onClick: () => {
+                                        setSelectedTask(task);
+                                        setShowSubtaskModal(true);
+                                    },
+                                },
+                                {
+                                    label: "View",
+                                    icon: Eye,
+                                    onClick: () => {
+                                        setSelectedTask(task);
+                                        setShowViewModal(true);
+                                    },
+                                },
+                                {
+                                    label: "Edit",
+                                    icon: Edit,
+                                    onClick: () => {
+                                        setSelectedTask(task);
+                                        setShowEditModal(true);
+                                    },
+                                },
+                                {
+                                    label: "Delete",
+                                    icon: Trash2,
+                                    danger: true,
+                                    onClick: () => handleDeleteTask(task),
+                                },
+                            ]}
+                        />
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Replaces the four inline per-task icon buttons (Add subtask, View, Edit, Delete) on the Tasks page with a single `MoreVertical` (kebab) overflow menu, decluttering each row—especially on mobile. The new `TaskActionsMenu` component reuses the Headless UI `Menu` pattern from `TaskStatusSelect`, portaling its panel via `anchor` so it is never clipped by the `overflow-hidden` Tasks card. On hover-capable pointers the menu opens on hover (with a short close timer bridging the button-to-panel gap); on touch it falls back to Headless UI's native tap-to-open / tap-outside-to-close. The completion checkbox and status dropdown remain inline, and the kebab is keyboard-reachable via `focus-within`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)