### PR TITLE
Wallet: net worth info tooltip, grouped account dropdowns, real card charges

### DIFF
--- a/resources/js/Components/Finance/SummaryCards.jsx
+++ b/resources/js/Components/Finance/SummaryCards.jsx
@@ -30,6 +30,7 @@ export default function SummaryCards({
             icon: Coins,
             iconClassName: "bg-wevie-teal/10 text-wevie-teal",
             accent: "text-light-primary dark:text-dark-primary",
+            info: "Net worth = your cash, bank and e-wallet balances, minus credit-card debt and outstanding loan balances.",
         },
         {
             label: "Income",
@@ -101,6 +102,7 @@ export default function SummaryCards({
                     icon={card.icon}
                     iconClassName={card.iconClassName}
                     accent={card.accent}
+                    info={card.info}
                     onClick={card.onClick}
                 />
             ))}

--- a/resources/js/Components/Finance/Transactions/TransactionForm.jsx
+++ b/resources/js/Components/Finance/Transactions/TransactionForm.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import TagInput from "@/Components/TagInput";
+import { groupAccountsByType } from "@/Utils/finance";
 
 const buildInitialState = (initialValues) => ({
     id: initialValues?.id,
@@ -47,6 +48,8 @@ export default function TransactionForm({
     const transferTargets = accounts.filter(
         (account) => String(account.id) !== String(form.finance_account_id)
     );
+    const accountGroups = groupAccountsByType(accounts);
+    const transferTargetGroups = groupAccountsByType(transferTargets);
 
     useEffect(() => {
         setForm(buildInitialState(initialValues));
@@ -321,10 +324,14 @@ export default function TransactionForm({
                                 ? "Select account"
                                 : "No account linked"}
                         </option>
-                        {accounts.map((account) => (
-                            <option key={account.id} value={account.id}>
-                                {account.label} - {account.name}
-                            </option>
+                        {accountGroups.map((group) => (
+                            <optgroup key={group.type} label={group.label}>
+                                {group.accounts.map((account) => (
+                                    <option key={account.id} value={account.id}>
+                                        {account.label} - {account.name}
+                                    </option>
+                                ))}
+                            </optgroup>
                         ))}
                     </select>
                 </div>
@@ -370,10 +377,14 @@ export default function TransactionForm({
                             required
                         >
                             <option value="">Select account</option>
-                            {transferTargets.map((account) => (
-                                <option key={account.id} value={account.id}>
-                                    {account.label} - {account.name}
-                                </option>
+                            {transferTargetGroups.map((group) => (
+                                <optgroup key={group.type} label={group.label}>
+                                    {group.accounts.map((account) => (
+                                        <option key={account.id} value={account.id}>
+                                            {account.label} - {account.name}
+                                        </option>
+                                    ))}
+                                </optgroup>
                             ))}
                         </select>
                     </div>

--- a/resources/js/Components/Finance/UI/StatCard.jsx
+++ b/resources/js/Components/Finance/UI/StatCard.jsx
@@ -1,4 +1,5 @@
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, Info } from "lucide-react";
+import Tooltip from "@/Components/Journal/Tooltip";
 
 /**
  * KPI tile used across WevieWallet. Interactive tiles (onClick provided) get a
@@ -12,6 +13,7 @@ export default function StatCard({
     iconClassName = "bg-wevie-teal/10 text-wevie-teal",
     accent = "text-light-primary dark:text-dark-primary",
     hint,
+    info,
     onClick,
     loading = false,
 }) {
@@ -45,6 +47,18 @@ export default function StatCard({
                     )}
                 </div>
                 <div className="flex flex-shrink-0 items-center gap-1">
+                    {info && (
+                        <Tooltip label={info} multiline>
+                            <button
+                                type="button"
+                                aria-label={info}
+                                onClick={(event) => event.stopPropagation()}
+                                className="inline-flex rounded-full text-light-muted outline-none focus-visible:ring-2 focus-visible:ring-wevie-teal/40 dark:text-dark-muted"
+                            >
+                                <Info className="h-4 w-4" aria-hidden="true" />
+                            </button>
+                        </Tooltip>
+                    )}
                     {Icon && (
                         <div className={`rounded-full p-2 ${iconClassName}`} aria-hidden="true">
                             <Icon className="h-5 w-5" />

--- a/resources/js/Components/Journal/Tooltip.jsx
+++ b/resources/js/Components/Journal/Tooltip.jsx
@@ -18,7 +18,7 @@ const FLIP_THRESHOLD = 44;
  * It renders above the trigger, centered, and flips below when there is not
  * enough room at the top of the viewport.
  */
-export default function Tooltip({ label, children, className = "" }) {
+export default function Tooltip({ label, children, className = "", multiline = false }) {
     const triggerRef = useRef(null);
     const timerRef = useRef(null);
     const [coords, setCoords] = useState(null);
@@ -89,7 +89,11 @@ export default function Tooltip({ label, children, className = "" }) {
                 createPortal(
                     <span
                         role="tooltip"
-                        className="journal-tooltip pointer-events-none fixed z-50 whitespace-nowrap rounded-md bg-neutral-800 px-2 py-1 text-xs font-medium text-white shadow-soft dark:bg-neutral-700 dark:text-dark-primary"
+                        className={`journal-tooltip pointer-events-none fixed z-50 rounded-md bg-neutral-800 px-2 py-1 text-xs font-medium text-white shadow-soft dark:bg-neutral-700 dark:text-dark-primary ${
+                            multiline
+                                ? "max-w-xs whitespace-normal"
+                                : "whitespace-nowrap"
+                        }`}
                         style={{
                             top: coords.top,
                             left: coords.left,

--- a/resources/js/Pages/Finance/Dashboard.jsx
+++ b/resources/js/Pages/Finance/Dashboard.jsx
@@ -107,13 +107,42 @@ export default function Dashboard(props) {
         () => accounts.filter((account) => account.type === "credit-card"),
         [accounts]
     );
+    const isCurrentMonth = useCallback((transaction) => {
+        const raw = transaction.occurred_at ?? transaction.created_at;
+        if (!raw) return false;
+        const date = new Date(raw);
+        if (Number.isNaN(date.getTime())) return false;
+        const now = new Date();
+        return (
+            date.getFullYear() === now.getFullYear() &&
+            date.getMonth() === now.getMonth()
+        );
+    }, []);
+    const creditCardIds = useMemo(
+        () => new Set(creditCardAccounts.map((account) => account.id)),
+        [creditCardAccounts]
+    );
+    // Real charges: expenses whose *source* account is a credit card, this month.
     const creditCardCharges = useMemo(
         () =>
             transactions.filter(
                 (transaction) =>
-                    transaction.finance_credit_card_account_id && transaction.type === "expense"
+                    transaction.type === "expense" &&
+                    creditCardIds.has(transaction.finance_account_id) &&
+                    isCurrentMonth(transaction)
             ),
-        [transactions]
+        [transactions, creditCardIds, isCurrentMonth]
+    );
+    // Paydowns: expenses from another account that restore a card's credit, this month.
+    const creditCardPayments = useMemo(
+        () =>
+            transactions.filter(
+                (transaction) =>
+                    transaction.type === "expense" &&
+                    creditCardIds.has(transaction.finance_credit_card_account_id) &&
+                    isCurrentMonth(transaction)
+            ),
+        [transactions, creditCardIds, isCurrentMonth]
     );
     const activeWallet = props.activeWallet ?? null;
 
@@ -861,6 +890,10 @@ export default function Dashboard(props) {
                             creditCardAccounts.map((account) => {
                                 const charges = creditCardCharges.filter(
                                     (transaction) =>
+                                        transaction.finance_account_id === account.id
+                                );
+                                const payments = creditCardPayments.filter(
+                                    (transaction) =>
                                         transaction.finance_credit_card_account_id === account.id
                                 );
 
@@ -891,11 +924,11 @@ export default function Dashboard(props) {
                                         </div>
                                         <div className="mt-3 space-y-2 text-xs text-light-muted dark:text-dark-muted">
                                             <p className="font-semibold uppercase text-light-muted dark:text-dark-muted">
-                                                Charges
+                                                Charges this month
                                             </p>
                                             {charges.length === 0 ? (
                                                 <p className="text-light-muted dark:text-dark-muted">
-                                                    No charges yet.
+                                                    No charges this month.
                                                 </p>
                                             ) : (
                                                 charges.map((transaction) => (
@@ -916,6 +949,44 @@ export default function Dashboard(props) {
                                                             </p>
                                                         </div>
                                                         <p className="text-sm font-semibold text-rose-600 dark:text-rose-300">
+                                                            {formatCurrency(
+                                                                transaction.amount ?? 0,
+                                                                transaction.currency ??
+                                                                    account.currency ??
+                                                                    "PHP"
+                                                            )}
+                                                        </p>
+                                                    </div>
+                                                ))
+                                            )}
+                                        </div>
+                                        <div className="mt-3 space-y-2 text-xs text-light-muted dark:text-dark-muted">
+                                            <p className="font-semibold uppercase text-light-muted dark:text-dark-muted">
+                                                Payments this month
+                                            </p>
+                                            {payments.length === 0 ? (
+                                                <p className="text-light-muted dark:text-dark-muted">
+                                                    No payments this month.
+                                                </p>
+                                            ) : (
+                                                payments.map((transaction) => (
+                                                    <div
+                                                        key={transaction.id}
+                                                        className="flex flex-wrap items-center justify-between gap-2 border-t border-light-border/70 pt-2 dark:border-dark-border/70"
+                                                    >
+                                                        <div>
+                                                            <p className="text-sm text-light-secondary dark:text-dark-secondary">
+                                                                {transaction.description}
+                                                            </p>
+                                                            <p className="text-xs text-light-muted dark:text-dark-muted">
+                                                                {new Date(
+                                                                    transaction.occurred_at ??
+                                                                        transaction.created_at ??
+                                                                        Date.now()
+                                                                ).toLocaleDateString()}
+                                                            </p>
+                                                        </div>
+                                                        <p className="text-sm font-semibold text-emerald-600 dark:text-emerald-300">
                                                             {formatCurrency(
                                                                 transaction.amount ?? 0,
                                                                 transaction.currency ??

--- a/resources/js/Utils/finance.js
+++ b/resources/js/Utils/finance.js
@@ -65,6 +65,50 @@ export const computeNetWorth = (accounts = [], loans = []) => {
 };
 
 /**
+ * Human-friendly label per account `type` (the category chosen at setup).
+ */
+export const ACCOUNT_TYPE_LABELS = {
+    cash: "Cash",
+    bank: "Bank",
+    "e-wallet": "E-wallet",
+    "credit-card": "Credit card",
+};
+
+// Order account groups follow in the dropdowns.
+const ACCOUNT_TYPE_ORDER = ["cash", "bank", "e-wallet", "credit-card"];
+
+/**
+ * Group accounts by their setup `type` for use as <optgroup>s. Returns the
+ * groups in a fixed order (cash → bank → e-wallet → credit-card), with any
+ * unknown type collected into a trailing "Other" group so nothing is dropped.
+ * Empty groups are omitted.
+ */
+export const groupAccountsByType = (accounts = []) => {
+    const buckets = new Map();
+    (accounts || []).forEach((account) => {
+        const type = account?.type ?? "other";
+        if (!buckets.has(type)) buckets.set(type, []);
+        buckets.get(type).push(account);
+    });
+
+    const groups = [];
+    ACCOUNT_TYPE_ORDER.forEach((type) => {
+        if (buckets.has(type)) {
+            groups.push({ type, label: ACCOUNT_TYPE_LABELS[type], accounts: buckets.get(type) });
+            buckets.delete(type);
+        }
+    });
+    // Any remaining (unknown) types go under "Other".
+    const leftovers = [];
+    buckets.forEach((list) => leftovers.push(...list));
+    if (leftovers.length > 0) {
+        groups.push({ type: "other", label: "Other", accounts: leftovers });
+    }
+
+    return groups;
+};
+
+/**
  * Budget progress (0-100, capped) from spent vs. total.
  */
 export const budgetProgress = (spent, total) => {


### PR DESCRIPTION
Three frontend-only improvements to the WevieWallet dashboard.

- **Net worth**: adds an info icon with a hover/focus tooltip explaining the figure (cash + bank + e-wallet balances, minus credit-card debt and outstanding loans); the existing computation was verified correct and unchanged.
- **Account dropdowns**: the create/update transaction account selects (source and transfer "To account") are now grouped by the category chosen at account setup — Cash / Bank / E-wallet / Credit card — via a new `groupAccountsByType` helper.
- **Credit-card charges**: fixes the credit panel, which previously listed paydown *payments* mislabeled as charges and hid real spending; it now shows actual charges (card as source account) and adds a separate current-month **Payments** section for paydowns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)