### PR TITLE
Add Lists: reusable checklists with items, attachable to tasks

### DIFF
--- a/app/Http/Controllers/ListItemController.php
+++ b/app/Http/Controllers/ListItemController.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ListItem;
+use App\Services\ListItemService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class ListItemController extends Controller
+{
+    public function __construct(
+        private ListItemService $listItemService
+    ) {}
+
+    /**
+     * Redirect back to the originating page, never to a list-item endpoint.
+     *
+     * The list-item routes are POST/PUT/DELETE only — there is no GET
+     * /list-items — so a plain back() that resolves to the request's own URL
+     * leaves Inertia following a 302 into a dead endpoint. Guard against
+     * self-redirects and any list-items path, falling back to the lists index.
+     */
+    private function redirectBack(): RedirectResponse
+    {
+        $previous = url()->previous();
+        $path = ltrim(parse_url($previous, PHP_URL_PATH) ?? '', '/');
+
+        if ($previous === url()->current() || str_starts_with($path, 'list-items')) {
+            return redirect()->route('lists.index');
+        }
+
+        return redirect()->to($previous);
+    }
+
+    /**
+     * Whether the request is a plain background XHR (not an Inertia visit)
+     * expecting a JSON response.
+     */
+    private function wantsJson(Request $request): bool
+    {
+        return ! $request->hasHeader('X-Inertia') && $request->expectsJson();
+    }
+
+    public function store(Request $request): RedirectResponse|JsonResponse
+    {
+        try {
+            $validated = $request->validate([
+                'task_list_id' => 'required|exists:task_lists,id',
+                'content' => 'required|string|max:255',
+            ]);
+
+            $item = $this->listItemService->createItem($validated, Auth::id());
+
+            $payload = $item->only([
+                'id',
+                'content',
+                'is_completed',
+                'completed_at',
+                'position',
+                'task_list_id',
+            ]);
+
+            if ($this->wantsJson($request)) {
+                return response()->json([
+                    'item' => $payload,
+                    'message' => 'Item created successfully',
+                ]);
+            }
+
+            return $this->redirectBack()
+                ->with('message', 'Item created successfully')
+                ->with('item', $payload);
+        } catch (\Illuminate\Validation\ValidationException $e) {
+            throw $e;
+        } catch (\Exception $e) {
+            report($e);
+
+            if ($this->wantsJson($request)) {
+                return response()->json([
+                    'error' => 'Failed to create item: '.$e->getMessage(),
+                ], 500);
+            }
+
+            return $this->redirectBack()->withErrors(['error' => 'Failed to create item: '.$e->getMessage()]);
+        }
+    }
+
+    public function update(Request $request, ListItem $listItem): RedirectResponse|JsonResponse
+    {
+        try {
+            $validated = $request->validate([
+                'content' => 'required|string|max:255',
+                'is_completed' => 'boolean',
+            ]);
+
+            $updatedItem = $this->listItemService->updateItem($listItem, $validated, Auth::id());
+
+            $payload = $updatedItem->only([
+                'id',
+                'content',
+                'is_completed',
+                'completed_at',
+                'position',
+                'task_list_id',
+            ]);
+
+            if ($this->wantsJson($request)) {
+                return response()->json([
+                    'item' => $payload,
+                    'message' => 'Item updated successfully',
+                ]);
+            }
+
+            return $this->redirectBack()->with('message', 'Item updated successfully');
+        } catch (\Illuminate\Validation\ValidationException $e) {
+            throw $e;
+        } catch (\Exception $e) {
+            report($e);
+
+            if ($this->wantsJson($request)) {
+                return response()->json([
+                    'error' => 'Failed to update item: '.$e->getMessage(),
+                ], 500);
+            }
+
+            return $this->redirectBack()->withErrors(['error' => 'Failed to update item: '.$e->getMessage()]);
+        }
+    }
+
+    public function destroy(Request $request, ListItem $listItem): RedirectResponse|JsonResponse
+    {
+        try {
+            $this->listItemService->deleteItem($listItem, Auth::id());
+
+            if ($this->wantsJson($request)) {
+                return response()->json([
+                    'deleted' => true,
+                    'message' => 'Item deleted successfully',
+                ]);
+            }
+
+            return $this->redirectBack()->with('message', 'Item deleted successfully');
+        } catch (\Exception $e) {
+            report($e);
+
+            if ($this->wantsJson($request)) {
+                return response()->json([
+                    'error' => 'Failed to delete item: '.$e->getMessage(),
+                ], 500);
+            }
+
+            return $this->redirectBack()->withErrors(['error' => 'Failed to delete item: '.$e->getMessage()]);
+        }
+    }
+
+    public function toggle(Request $request, ListItem $listItem): RedirectResponse|JsonResponse
+    {
+        try {
+            $updatedItem = $this->listItemService->toggleItem($listItem, Auth::id());
+            $message = $updatedItem->is_completed ? 'Item completed!' : 'Item marked as pending';
+
+            $payload = $updatedItem->only([
+                'id',
+                'content',
+                'is_completed',
+                'completed_at',
+                'position',
+                'task_list_id',
+            ]);
+
+            if ($this->wantsJson($request)) {
+                return response()->json([
+                    'item' => $payload,
+                    'message' => $message,
+                ]);
+            }
+
+            return $this->redirectBack()->with('message', $message);
+        } catch (\Exception $e) {
+            report($e);
+
+            if ($this->wantsJson($request)) {
+                return response()->json([
+                    'error' => 'Failed to toggle item: '.$e->getMessage(),
+                ], 500);
+            }
+
+            return $this->redirectBack()->withErrors(['error' => 'Failed to toggle item: '.$e->getMessage()]);
+        }
+    }
+
+    public function reorder(Request $request): RedirectResponse|JsonResponse
+    {
+        try {
+            $validated = $request->validate([
+                'itemIds' => 'required|array',
+                'itemIds.*' => 'exists:list_items,id',
+            ]);
+
+            $this->listItemService->reorderItems($validated['itemIds'], Auth::id());
+
+            if ($this->wantsJson($request)) {
+                return response()->json([
+                    'message' => 'Items reordered successfully',
+                ]);
+            }
+
+            return $this->redirectBack()->with('message', 'Items reordered successfully');
+        } catch (\Illuminate\Validation\ValidationException $e) {
+            throw $e;
+        } catch (\Exception $e) {
+            report($e);
+
+            if ($this->wantsJson($request)) {
+                return response()->json([
+                    'error' => 'Failed to reorder items: '.$e->getMessage(),
+                ], 500);
+            }
+
+            return $this->redirectBack()->withErrors(['error' => 'Failed to reorder items: '.$e->getMessage()]);
+        }
+    }
+}

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -6,6 +6,7 @@ use App\Models\Task;
 use App\Services\Ai\AiEntitlementService;
 use App\Services\CategoryService;
 use App\Services\TagService;
+use App\Services\TaskListService;
 use App\Services\TaskService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -19,6 +20,7 @@ class TaskController extends Controller
         private TaskService $taskService,
         private CategoryService $categoryService,
         private TagService $tagService,
+        private TaskListService $taskListService,
         private AiEntitlementService $entitlement
     ) {}
 
@@ -43,10 +45,14 @@ class TaskController extends Controller
         // Get all active tags
         $tags = $this->tagService->getAllTags();
 
+        // Get the user's task lists (for attaching tasks to lists)
+        $lists = $this->taskListService->getTaskListsForUser(Auth::id());
+
         return Inertia::render('Tasks/Index', [
             'tasks' => $tasks,
             'categories' => $categories,
             'tags' => $tags,
+            'lists' => $lists,
             'filters' => $request->only(['search', 'status', 'priority', 'category_id', 'tag_id', 'due_date_filter']),
             'canUseTaskCapture' => $this->entitlement->canUse(Auth::user(), 'task_capture'),
         ]);
@@ -106,6 +112,8 @@ class TaskController extends Controller
             'tags.*.name' => 'nullable|string|max:255',
             'tags.*.color' => 'nullable|string|regex:/^#[0-9A-F]{6}$/i',
             'tags.*.is_new' => 'nullable|boolean',
+            'lists' => 'nullable|array',
+            'lists.*' => 'integer|exists:task_lists,id,user_id,'.Auth::id(),
         ]);
 
         // Clear recurring fields for non-recurring tasks
@@ -165,6 +173,8 @@ class TaskController extends Controller
             'tags.*.name' => 'nullable|string|max:255',
             'tags.*.color' => 'nullable|string|regex:/^#[0-9A-F]{6}$/i',
             'tags.*.is_new' => 'nullable|boolean',
+            'lists' => 'nullable|array',
+            'lists.*' => 'integer|exists:task_lists,id,user_id,'.Auth::id(),
         ]);
 
         // Clear recurring fields for non-recurring tasks

--- a/app/Http/Controllers/TaskListController.php
+++ b/app/Http/Controllers/TaskListController.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Task;
+use App\Models\TaskList;
+use App\Services\TaskListService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class TaskListController extends Controller
+{
+    public function __construct(
+        private TaskListService $taskListService
+    ) {}
+
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): Response
+    {
+        $lists = $this->taskListService->getTaskListsWithCounts(Auth::id());
+
+        return Inertia::render('Lists/Index', [
+            'lists' => $lists,
+        ]);
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create(): Response
+    {
+        return Inertia::render('Lists/Create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'color' => 'required|string|regex:/^#[0-9A-F]{6}$/i',
+            'description' => 'nullable|string',
+            'tasks' => 'nullable|array',
+            'tasks.*' => 'integer|exists:tasks,id',
+        ]);
+
+        try {
+            $this->taskListService->createTaskList($validated, Auth::id());
+
+            return redirect()->route('lists.index')->with('message', 'List created successfully');
+        } catch (\InvalidArgumentException $e) {
+            return redirect()->back()->withErrors(['error' => $e->getMessage()])->withInput();
+        } catch (\Exception $e) {
+            return redirect()->back()->withErrors(['error' => 'Failed to create list. Please try again.'])->withInput();
+        }
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(TaskList $list): Response
+    {
+        $listWithContents = $this->taskListService->getTaskListWithContents($list->id, Auth::id());
+
+        if (! $listWithContents) {
+            abort(404);
+        }
+
+        // Tasks the user can still attach to this list (everything they own
+        // that isn't already grouped here) — drives the attach picker.
+        $attachedTaskIds = collect($listWithContents->tasks)->pluck('id');
+        $availableTasks = Task::where('user_id', Auth::id())
+            ->whereNotIn('id', $attachedTaskIds)
+            ->orderByDesc('id')
+            ->get()
+            ->map(fn (Task $task) => ['id' => $task->id, 'title' => $task->title])
+            ->values();
+
+        return Inertia::render('Lists/Show', [
+            'list' => $listWithContents,
+            'availableTasks' => $availableTasks,
+        ]);
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(TaskList $list): Response
+    {
+        $listData = $this->taskListService->findTaskListForUser($list->id, Auth::id());
+
+        if (! $listData) {
+            abort(404);
+        }
+
+        $formattedList = $listData->toArray();
+
+        // Provide the items in the shape the frontend expects.
+        $formattedList['items'] = $listData->items->map(function ($item) {
+            return [
+                'id' => $item->id,
+                'content' => $item->content,
+                'is_completed' => $item->is_completed,
+                'completed_at' => $item->completed_at,
+                'position' => $item->position,
+                'task_list_id' => $item->task_list_id,
+            ];
+        })->toArray();
+
+        return Inertia::render('Lists/Edit', [
+            'list' => $formattedList,
+        ]);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, TaskList $list): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'color' => 'required|string|regex:/^#[0-9A-F]{6}$/i',
+            'description' => 'nullable|string',
+            'tasks' => 'nullable|array',
+            'tasks.*' => 'integer|exists:tasks,id',
+        ]);
+
+        try {
+            $this->taskListService->updateTaskList($list, $validated, Auth::id());
+
+            return redirect()->route('lists.index')->with('message', 'List updated successfully');
+        } catch (\InvalidArgumentException $e) {
+            return redirect()->back()->withErrors(['error' => $e->getMessage()])->withInput();
+        } catch (\Exception $e) {
+            return redirect()->back()->withErrors(['error' => 'Failed to update list. Please try again.'])->withInput();
+        }
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(TaskList $list): RedirectResponse
+    {
+        try {
+            $this->taskListService->deleteTaskList($list, Auth::id());
+
+            return redirect()->route('lists.index')->with('message', 'List deleted successfully');
+        } catch (\Exception $e) {
+            return redirect()->back()->withErrors(['error' => 'Failed to delete list. Please try again.']);
+        }
+    }
+
+    /**
+     * Attach a task to the list (reverse UX from the task side).
+     */
+    public function attachTask(Request $request, TaskList $list): RedirectResponse
+    {
+        $validated = $request->validate([
+            'task_id' => 'required|integer|exists:tasks,id',
+        ]);
+
+        try {
+            $task = Task::findOrFail($validated['task_id']);
+
+            $this->taskListService->attachTask($list, $task, Auth::id());
+
+            return redirect()->back()->with('message', 'Task added to list successfully');
+        } catch (\Symfony\Component\HttpKernel\Exception\HttpException $e) {
+            // Ownership failures surface as a real 403 rather than a soft redirect.
+            abort(403, $e->getMessage());
+        } catch (\Exception $e) {
+            return redirect()->back()->withErrors(['error' => 'Failed to add task to list. Please try again.']);
+        }
+    }
+
+    /**
+     * Detach a task from the list.
+     */
+    public function detachTask(TaskList $list, Task $task): RedirectResponse
+    {
+        try {
+            $this->taskListService->detachTask($list, $task, Auth::id());
+
+            return redirect()->back()->with('message', 'Task removed from list successfully');
+        } catch (\Symfony\Component\HttpKernel\Exception\HttpException $e) {
+            // Ownership failures surface as a real 403 rather than a soft redirect.
+            abort(403, $e->getMessage());
+        } catch (\Exception $e) {
+            return redirect()->back()->withErrors(['error' => 'Failed to remove task from list. Please try again.']);
+        }
+    }
+}

--- a/app/Models/ListItem.php
+++ b/app/Models/ListItem.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ListItem extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'task_list_id',
+        'content',
+        'is_completed',
+        'completed_at',
+        'position',
+    ];
+
+    protected $casts = [
+        'content' => 'encrypted',
+        'is_completed' => 'boolean',
+        'completed_at' => 'datetime',
+    ];
+
+    public function taskList(): BelongsTo
+    {
+        return $this->belongsTo(TaskList::class);
+    }
+}

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -73,6 +73,12 @@ class Task extends Model
         return $this->belongsToMany(Tag::class);
     }
 
+    public function lists(): BelongsToMany
+    {
+        return $this->belongsToMany(TaskList::class, 'list_task', 'task_id', 'task_list_id')
+            ->withTimestamps();
+    }
+
     public function board(): BelongsTo
     {
         return $this->belongsTo(Board::class);

--- a/app/Models/TaskList.php
+++ b/app/Models/TaskList.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class TaskList extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'is_sample',
+        'name',
+        'color',
+        'description',
+        'position',
+    ];
+
+    protected $casts = [
+        'name' => 'encrypted',
+        'description' => 'encrypted',
+        'is_sample' => 'boolean',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function items(): HasMany
+    {
+        return $this->hasMany(ListItem::class)->orderBy('position');
+    }
+
+    public function tasks(): BelongsToMany
+    {
+        return $this->belongsToMany(Task::class, 'list_task', 'task_list_id', 'task_id')
+            ->withTimestamps();
+    }
+
+    public function scopeForUser($query, $userId)
+    {
+        return $query->where('user_id', $userId);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -81,6 +81,11 @@ class User extends Authenticatable
         return $this->hasMany(Category::class);
     }
 
+    public function taskLists(): HasMany
+    {
+        return $this->hasMany(TaskList::class);
+    }
+
     public function financeAccounts(): HasMany
     {
         return $this->hasMany(FinanceAccount::class);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -34,6 +34,11 @@ class AppServiceProvider extends ServiceProvider
         );
 
         $this->app->bind(
+            \App\Repositories\Contracts\TaskListRepositoryInterface::class,
+            \App\Repositories\Eloquent\TaskListRepository::class
+        );
+
+        $this->app->bind(
             \App\Repositories\Contracts\DailySummaryRepositoryInterface::class,
             \App\Repositories\Eloquent\DailySummaryRepository::class
         );
@@ -50,6 +55,7 @@ class AppServiceProvider extends ServiceProvider
         // Register Services (no interfaces needed for services)
         $this->app->singleton(\App\Services\ReminderService::class);
         $this->app->singleton(\App\Services\SubtaskService::class);
+        $this->app->singleton(\App\Services\ListItemService::class);
         $this->app->singleton(\App\Services\GoogleCalendarService::class);
         $this->app->singleton(\App\Services\NotificationService::class);
         $this->app->singleton(\App\Services\SearchService::class);

--- a/app/Repositories/Contracts/TaskListRepositoryInterface.php
+++ b/app/Repositories/Contracts/TaskListRepositoryInterface.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Repositories\Contracts;
+
+use App\Models\Task;
+use App\Models\TaskList;
+use Illuminate\Database\Eloquent\Collection;
+
+interface TaskListRepositoryInterface
+{
+    /**
+     * Get all task lists for a user (sorted by decrypted name in PHP).
+     */
+    public function getTaskListsForUser(int $userId, array $relations = ['items']): Collection;
+
+    /**
+     * Get task lists with item + task counts for a user.
+     */
+    public function getTaskListsWithCounts(int $userId): Collection;
+
+    /**
+     * Create a new task list.
+     */
+    public function create(array $data): TaskList;
+
+    /**
+     * Update a task list.
+     */
+    public function update(TaskList $taskList, array $data): TaskList;
+
+    /**
+     * Delete a task list.
+     */
+    public function delete(TaskList $taskList): bool;
+
+    /**
+     * Find task list by ID for specific user.
+     */
+    public function findForUser(int $id, int $userId, array $relations = []): ?TaskList;
+
+    /**
+     * Get a task list with its items and attached tasks.
+     */
+    public function getTaskListWithContents(int $id, int $userId): ?TaskList;
+
+    /**
+     * Check if a task list name exists for the user (PHP decrypt-compare).
+     */
+    public function nameExistsForUser(string $name, int $userId, ?int $excludeId = null): bool;
+
+    /**
+     * Sync attached tasks for the list.
+     */
+    public function syncTasks(TaskList $taskList, array $taskIds): void;
+
+    /**
+     * Attach a single task to the list.
+     */
+    public function attachTask(TaskList $taskList, Task $task): void;
+
+    /**
+     * Detach a single task from the list.
+     */
+    public function detachTask(TaskList $taskList, Task $task): void;
+}

--- a/app/Repositories/Contracts/TaskRepositoryInterface.php
+++ b/app/Repositories/Contracts/TaskRepositoryInterface.php
@@ -4,16 +4,16 @@ namespace App\Repositories\Contracts;
 
 use App\Models\Task;
 use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Pagination\LengthAwarePaginator;
-use Carbon\Carbon;
 
 interface TaskRepositoryInterface
 {
     /**
      * Get all tasks for a user with optional filters
      */
-    public function getTasksForUser(int $userId, array $filters = [], array $relations = ['category', 'subtasks', 'tags']): Collection;
+    public function getTasksForUser(int $userId, array $filters = [], array $relations = ['category', 'subtasks', 'tags', 'lists']): Collection;
 
     /**
      * Get paginated tasks for a user by category
@@ -89,4 +89,9 @@ interface TaskRepositoryInterface
      * Sync tags for task
      */
     public function syncTags(Task $task, array $tagIds): void;
+
+    /**
+     * Sync attached lists for task
+     */
+    public function syncLists(Task $task, array $listIds): void;
 }

--- a/app/Repositories/Eloquent/TaskListRepository.php
+++ b/app/Repositories/Eloquent/TaskListRepository.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Repositories\Eloquent;
+
+use App\Models\Task;
+use App\Models\TaskList;
+use App\Repositories\Contracts\TaskListRepositoryInterface;
+use Illuminate\Database\Eloquent\Collection;
+
+class TaskListRepository implements TaskListRepositoryInterface
+{
+    /**
+     * Get all task lists for a user (sorted by decrypted name in PHP).
+     */
+    public function getTaskListsForUser(int $userId, array $relations = ['items']): Collection
+    {
+        $taskLists = TaskList::with($relations)
+            ->where('user_id', $userId)
+            ->get();
+
+        return $this->sortByName($taskLists);
+    }
+
+    /**
+     * Get task lists with item + task counts for a user.
+     */
+    public function getTaskListsWithCounts(int $userId): Collection
+    {
+        $taskLists = TaskList::withCount(['items', 'tasks'])
+            ->where('user_id', $userId)
+            ->get();
+
+        return $this->sortByName($taskLists);
+    }
+
+    /**
+     * Create a new task list.
+     */
+    public function create(array $data): TaskList
+    {
+        return TaskList::create($data);
+    }
+
+    /**
+     * Update a task list.
+     */
+    public function update(TaskList $taskList, array $data): TaskList
+    {
+        $taskList->update($data);
+
+        return $taskList->fresh();
+    }
+
+    /**
+     * Delete a task list.
+     */
+    public function delete(TaskList $taskList): bool
+    {
+        return $taskList->delete();
+    }
+
+    /**
+     * Find task list by ID for specific user.
+     */
+    public function findForUser(int $id, int $userId, array $relations = []): ?TaskList
+    {
+        return TaskList::with($relations)
+            ->where('id', $id)
+            ->where('user_id', $userId)
+            ->first();
+    }
+
+    /**
+     * Get a task list with its items and attached tasks.
+     */
+    public function getTaskListWithContents(int $id, int $userId): ?TaskList
+    {
+        return TaskList::with([
+            'items' => function ($query) {
+                $query->orderBy('position');
+            },
+            'tasks' => function ($query) {
+                $query->with(['tags', 'subtasks'])
+                    ->withCount([
+                        'subtasks',
+                        'subtasks as completed_subtasks_count' => function ($query) {
+                            $query->where('is_completed', true);
+                        },
+                    ]);
+            },
+        ])
+            ->where('id', $id)
+            ->where('user_id', $userId)
+            ->first();
+    }
+
+    /**
+     * Check if a task list name exists for the user.
+     *
+     * `task_lists.name` is encrypted, so a SQL equality check would never match.
+     * Compare the decrypted names in PHP instead (case-insensitive, mirroring the
+     * default MySQL collation).
+     */
+    public function nameExistsForUser(string $name, int $userId, ?int $excludeId = null): bool
+    {
+        $needle = mb_strtolower(trim($name));
+
+        return TaskList::where('user_id', $userId)
+            ->when($excludeId, fn ($query) => $query->where('id', '!=', $excludeId))
+            ->get(['id', 'name'])
+            ->contains(fn (TaskList $taskList) => mb_strtolower(trim((string) $taskList->name)) === $needle);
+    }
+
+    /**
+     * Sync attached tasks for the list.
+     */
+    public function syncTasks(TaskList $taskList, array $taskIds): void
+    {
+        $taskList->tasks()->sync($taskIds);
+    }
+
+    /**
+     * Attach a single task to the list.
+     */
+    public function attachTask(TaskList $taskList, Task $task): void
+    {
+        $taskList->tasks()->syncWithoutDetaching([$task->id]);
+    }
+
+    /**
+     * Detach a single task from the list.
+     */
+    public function detachTask(TaskList $taskList, Task $task): void
+    {
+        $taskList->tasks()->detach($task->id);
+    }
+
+    /**
+     * Sort a task-list collection by decrypted name (case-insensitive, ascending).
+     */
+    private function sortByName(Collection $taskLists): Collection
+    {
+        return $taskLists
+            ->sortBy(fn (TaskList $taskList) => mb_strtolower(trim((string) $taskList->name)))
+            ->values();
+    }
+}

--- a/app/Repositories/Eloquent/TaskRepository.php
+++ b/app/Repositories/Eloquent/TaskRepository.php
@@ -16,7 +16,7 @@ class TaskRepository implements TaskRepositoryInterface
     /**
      * Get all tasks for a user with optional filters
      */
-    public function getTasksForUser(int $userId, array $filters = [], array $relations = ['category', 'subtasks', 'tags']): Collection
+    public function getTasksForUser(int $userId, array $filters = [], array $relations = ['category', 'subtasks', 'tags', 'lists']): Collection
     {
         $query = Task::with($relations)
             ->where('user_id', $userId)
@@ -55,7 +55,7 @@ class TaskRepository implements TaskRepositoryInterface
      */
     public function getPaginatedTasksByCategory(int $userId, ?int $categoryId, array $filters = [], int $perPage = 5): LengthAwarePaginator
     {
-        $query = Task::with(['category', 'subtasks', 'tags'])
+        $query = Task::with(['category', 'subtasks', 'tags', 'lists'])
             ->where('user_id', $userId)
             ->withCount([
                 'subtasks',
@@ -79,7 +79,7 @@ class TaskRepository implements TaskRepositoryInterface
      */
     public function getUncategorizedTasks(int $userId, array $filters = [], int $perPage = 5): LengthAwarePaginator
     {
-        $query = Task::with(['category', 'subtasks', 'tags'])
+        $query = Task::with(['category', 'subtasks', 'tags', 'lists'])
             ->where('user_id', $userId)
             ->whereNull('category_id')
             ->withCount([
@@ -248,6 +248,14 @@ class TaskRepository implements TaskRepositoryInterface
     }
 
     /**
+     * Sync attached lists for task
+     */
+    public function syncLists(Task $task, array $listIds): void
+    {
+        $task->lists()->sync($listIds);
+    }
+
+    /**
      * Apply filters to query
      *
      * Note: `search` is intentionally NOT applied here. The `title`/`description`
@@ -276,7 +284,7 @@ class TaskRepository implements TaskRepositoryInterface
         }
 
         // Filter by tag
-        if (!empty($filters['tag_id'])) {
+        if (! empty($filters['tag_id'])) {
             $query->whereHas('tags', function ($q) use ($filters) {
                 $q->where('tags.id', $filters['tag_id']);
             });

--- a/app/Services/ListItemService.php
+++ b/app/Services/ListItemService.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\ListItem;
+use App\Models\TaskList;
+use Illuminate\Support\Facades\DB;
+
+class ListItemService
+{
+    /**
+     * Create a new list item, validating ownership of the parent list.
+     */
+    public function createItem(array $data, int $userId): ListItem
+    {
+        return DB::transaction(function () use ($data, $userId) {
+            // Validate list ownership
+            TaskList::where('id', $data['task_list_id'])
+                ->where('user_id', $userId)
+                ->firstOrFail();
+
+            $data['is_completed'] = $data['is_completed'] ?? false;
+            $data['position'] = $this->getNextPositionForList($data['task_list_id']);
+
+            $item = ListItem::create($data);
+
+            return $item->load('taskList');
+        });
+    }
+
+    /**
+     * Update an existing list item.
+     */
+    public function updateItem(ListItem $item, array $data, int $userId): ListItem
+    {
+        return DB::transaction(function () use ($item, $data, $userId) {
+            if ($item->taskList->user_id !== $userId) {
+                throw new \InvalidArgumentException('You do not have permission to update this item.');
+            }
+
+            // Keep completed_at consistent when is_completed is explicitly set.
+            if (array_key_exists('is_completed', $data)) {
+                $data['completed_at'] = $data['is_completed'] ? ($item->completed_at ?? now()) : null;
+            }
+
+            $item->update($data);
+
+            return $item->fresh(['taskList']);
+        });
+    }
+
+    /**
+     * Delete a list item.
+     */
+    public function deleteItem(ListItem $item, int $userId): bool
+    {
+        if ($item->taskList->user_id !== $userId) {
+            throw new \InvalidArgumentException('You do not have permission to delete this item.');
+        }
+
+        return DB::transaction(function () use ($item) {
+            return $item->delete();
+        });
+    }
+
+    /**
+     * Toggle a list item's completion status.
+     */
+    public function toggleItem(ListItem $item, int $userId): ListItem
+    {
+        if ($item->taskList->user_id !== $userId) {
+            throw new \InvalidArgumentException('You do not have permission to update this item.');
+        }
+
+        return DB::transaction(function () use ($item) {
+            $newStatus = ! $item->is_completed;
+
+            $item->update([
+                'is_completed' => $newStatus,
+                'completed_at' => $newStatus ? now() : null,
+            ]);
+
+            return $item->fresh(['taskList']);
+        });
+    }
+
+    /**
+     * Reorder items within a list.
+     */
+    public function reorderItems(array $itemIds, int $userId): bool
+    {
+        return DB::transaction(function () use ($itemIds, $userId) {
+            // Verify all items belong to the user (via their parent list)
+            $items = ListItem::whereIn('id', $itemIds)
+                ->whereHas('taskList', function ($query) use ($userId) {
+                    $query->where('user_id', $userId);
+                })
+                ->get();
+
+            if ($items->count() !== count($itemIds)) {
+                throw new \InvalidArgumentException('Some items do not belong to the user or do not exist.');
+            }
+
+            foreach ($itemIds as $index => $itemId) {
+                ListItem::where('id', $itemId)->update(['position' => $index + 1]);
+            }
+
+            return true;
+        });
+    }
+
+    /**
+     * Get the next position for an item within a list.
+     */
+    private function getNextPositionForList(int $taskListId): int
+    {
+        $maxPosition = ListItem::where('task_list_id', $taskListId)->max('position');
+
+        return ($maxPosition ?? 0) + 1;
+    }
+}

--- a/app/Services/SampleDataService.php
+++ b/app/Services/SampleDataService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\Category;
 use App\Models\Task;
+use App\Models\TaskList;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -41,8 +42,10 @@ class SampleDataService
     {
         $tasks = Task::where('user_id', $user->id)->where('is_sample', true)->delete();
         $categories = Category::where('user_id', $user->id)->where('is_sample', true)->delete();
+        // Deleting the lists cascades their list_items and list_task pivot rows.
+        $taskLists = TaskList::where('user_id', $user->id)->where('is_sample', true)->delete();
 
-        return $tasks + $categories;
+        return $tasks + $categories + $taskLists;
     }
 
     /** @return array<string, Category> keyed by name */

--- a/app/Services/TaskListService.php
+++ b/app/Services/TaskListService.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Task;
+use App\Models\TaskList;
+use App\Repositories\Contracts\TaskListRepositoryInterface;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+
+class TaskListService
+{
+    public function __construct(
+        private TaskListRepositoryInterface $taskListRepository
+    ) {}
+
+    /**
+     * Get all task lists for a user.
+     */
+    public function getTaskListsForUser(int $userId, array $relations = ['items']): Collection
+    {
+        return $this->taskListRepository->getTaskListsForUser($userId, $relations);
+    }
+
+    /**
+     * Get task lists with item + task counts for a user.
+     */
+    public function getTaskListsWithCounts(int $userId): Collection
+    {
+        return $this->taskListRepository->getTaskListsWithCounts($userId);
+    }
+
+    /**
+     * Find a task list for a user.
+     */
+    public function findTaskListForUser(int $taskListId, int $userId): ?TaskList
+    {
+        return $this->taskListRepository->findForUser($taskListId, $userId, ['items']);
+    }
+
+    /**
+     * Get a task list with its items and attached tasks.
+     */
+    public function getTaskListWithContents(int $taskListId, int $userId): ?TaskList
+    {
+        return $this->taskListRepository->getTaskListWithContents($taskListId, $userId);
+    }
+
+    /**
+     * Create a new task list with validation and business logic.
+     */
+    public function createTaskList(array $data, int $userId): TaskList
+    {
+        return DB::transaction(function () use ($data, $userId) {
+            // Check if the task list name already exists for the user
+            if ($this->taskListRepository->nameExistsForUser($data['name'], $userId)) {
+                throw new \InvalidArgumentException('A list with this name already exists.');
+            }
+
+            // Set user_id and next position
+            $data['user_id'] = $userId;
+            $data['position'] = $this->getNextPositionForUser($userId);
+
+            $taskList = $this->taskListRepository->create($data);
+
+            // Attach tasks (filtered to the user's own tasks)
+            if (array_key_exists('tasks', $data)) {
+                $taskIds = $this->resolveOwnedTaskIds($data['tasks'] ?? [], $userId);
+                $this->taskListRepository->syncTasks($taskList, $taskIds);
+            }
+
+            return $taskList->load(['items', 'tasks']);
+        });
+    }
+
+    /**
+     * Update an existing task list.
+     */
+    public function updateTaskList(TaskList $taskList, array $data, int $userId): TaskList
+    {
+        // Ensure the user owns the list
+        if ($taskList->user_id !== $userId) {
+            throw new UnauthorizedHttpException('', 'You do not have permission to update this list.');
+        }
+
+        return DB::transaction(function () use ($taskList, $data, $userId) {
+            // Check for a duplicate name (excluding this list)
+            if (isset($data['name']) && $this->taskListRepository->nameExistsForUser($data['name'], $userId, $taskList->id)) {
+                throw new \InvalidArgumentException('A list with this name already exists.');
+            }
+
+            $updatedTaskList = $this->taskListRepository->update($taskList, $data);
+
+            // Sync tasks when provided (filtered to the user's own tasks)
+            if (array_key_exists('tasks', $data)) {
+                $taskIds = $this->resolveOwnedTaskIds($data['tasks'] ?? [], $userId);
+                $this->taskListRepository->syncTasks($updatedTaskList, $taskIds);
+            }
+
+            return $updatedTaskList->load(['items', 'tasks']);
+        });
+    }
+
+    /**
+     * Delete a task list. Attached tasks are NOT blocked — the cascade clears the
+     * pivot rows and list items while leaving the tasks themselves intact.
+     */
+    public function deleteTaskList(TaskList $taskList, int $userId): bool
+    {
+        if ($taskList->user_id !== $userId) {
+            throw new UnauthorizedHttpException('', 'You do not have permission to delete this list.');
+        }
+
+        return DB::transaction(function () use ($taskList) {
+            return $this->taskListRepository->delete($taskList);
+        });
+    }
+
+    /**
+     * Attach a task to a list, enforcing ownership of BOTH.
+     */
+    public function attachTask(TaskList $taskList, Task $task, int $userId): void
+    {
+        $this->assertOwnership($taskList, $task, $userId);
+
+        $this->taskListRepository->attachTask($taskList, $task);
+    }
+
+    /**
+     * Detach a task from a list, enforcing ownership of BOTH.
+     */
+    public function detachTask(TaskList $taskList, Task $task, int $userId): void
+    {
+        $this->assertOwnership($taskList, $task, $userId);
+
+        $this->taskListRepository->detachTask($taskList, $task);
+    }
+
+    /**
+     * Ensure the user owns both the list and the task.
+     */
+    private function assertOwnership(TaskList $taskList, Task $task, int $userId): void
+    {
+        if ($taskList->user_id !== $userId || $task->user_id !== $userId) {
+            throw new UnauthorizedHttpException('', 'You do not have permission to modify this list.');
+        }
+    }
+
+    /**
+     * Filter the given task ids down to those owned by the user.
+     *
+     * @return array<int, int>
+     */
+    private function resolveOwnedTaskIds(array $taskIds, int $userId): array
+    {
+        if (empty($taskIds)) {
+            return [];
+        }
+
+        return Task::whereIn('id', $taskIds)
+            ->where('user_id', $userId)
+            ->pluck('id')
+            ->all();
+    }
+
+    /**
+     * Get the next position for the user's lists.
+     */
+    private function getNextPositionForUser(int $userId): int
+    {
+        $maxPosition = TaskList::where('user_id', $userId)->max('position');
+
+        return ($maxPosition ?? 0) + 1;
+    }
+}

--- a/app/Services/TaskService.php
+++ b/app/Services/TaskService.php
@@ -77,7 +77,12 @@ class TaskService
                 $this->taskRepository->syncTags($task, $tagIds);
             }
 
-            return $task->load(['category', 'subtasks', 'tags']);
+            // Handle attached lists
+            if (! empty($data['lists'])) {
+                $this->taskRepository->syncLists($task, $data['lists']);
+            }
+
+            return $task->load(['category', 'subtasks', 'tags', 'lists']);
         });
     }
 
@@ -128,7 +133,12 @@ class TaskService
                 $this->taskRepository->syncTags($updatedTask, $tagIds);
             }
 
-            return $updatedTask->load(['category', 'subtasks', 'tags']);
+            // Handle attached lists
+            if (array_key_exists('lists', $data)) {
+                $this->taskRepository->syncLists($updatedTask, ! empty($data['lists']) ? $data['lists'] : []);
+            }
+
+            return $updatedTask->load(['category', 'subtasks', 'tags', 'lists']);
         });
     }
 

--- a/database/migrations/2026_08_04_010000_create_task_lists_table.php
+++ b/database/migrations/2026_08_04_010000_create_task_lists_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('task_lists', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->boolean('is_sample')->default(false);
+            // Encrypted at rest — ciphertext exceeds varchar(255), so use text.
+            $table->text('name');
+            $table->string('color', 7)->default('#3B82F6');
+            // Encrypted at rest.
+            $table->text('description')->nullable();
+            $table->integer('position')->default(0);
+            $table->timestamps();
+
+            $table->index('user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('task_lists');
+    }
+};

--- a/database/migrations/2026_08_04_010001_create_list_items_table.php
+++ b/database/migrations/2026_08_04_010001_create_list_items_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('list_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('task_list_id')->constrained('task_lists')->onDelete('cascade');
+            // Encrypted at rest — ciphertext exceeds varchar(255), so use text.
+            $table->text('content');
+            $table->boolean('is_completed')->default(false);
+            $table->dateTime('completed_at')->nullable();
+            $table->integer('position')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('list_items');
+    }
+};

--- a/database/migrations/2026_08_04_010002_create_list_task_table.php
+++ b/database/migrations/2026_08_04_010002_create_list_task_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Explicitly named `list_task` so it does not depend on Laravel's default
+     * pivot-name guess (which would produce `task_task_list`).
+     */
+    public function up(): void
+    {
+        Schema::create('list_task', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('task_list_id')->constrained('task_lists')->onDelete('cascade');
+            $table->foreignId('task_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+
+            $table->unique(['task_list_id', 'task_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('list_task');
+    }
+};

--- a/database/seeders/TodoSeeder.php
+++ b/database/seeders/TodoSeeder.php
@@ -2,12 +2,13 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
-use Illuminate\Database\Seeder;
 use App\Models\Category;
+use App\Models\ListItem;
 use App\Models\Task;
+use App\Models\TaskList;
 use App\Models\User;
 use Carbon\Carbon;
+use Illuminate\Database\Seeder;
 
 class TodoSeeder extends Seeder
 {
@@ -25,16 +26,19 @@ class TodoSeeder extends Seeder
         if ($demoUser) {
             $this->createCategoriesForUser($demoUser);
             $this->createTasksForUser($demoUser);
+            $this->createTaskListsForUser($demoUser);
         }
 
         if ($testUser) {
             $this->createCategoriesForUser($testUser);
             $this->createTasksForUser($testUser, true); // fewer tasks
+            $this->createTaskListsForUser($testUser);
         }
 
         if ($adminUser) {
             $this->createCategoriesForUser($adminUser);
             $this->createAdminTasks($adminUser);
+            $this->createTaskListsForUser($adminUser);
         }
     }
 
@@ -146,7 +150,7 @@ class TodoSeeder extends Seeder
             ],
         ];
 
-        if (!$minimal) {
+        if (! $minimal) {
             // Add more tasks for full demo
             $tasks = array_merge($tasks, [
                 [
@@ -196,6 +200,59 @@ class TodoSeeder extends Seeder
             $taskData['user_id'] = $user->id;
             $taskData['position'] = Task::where('user_id', $user->id)->max('position') + 1;
             Task::create($taskData);
+        }
+    }
+
+    private function createTaskListsForUser(User $user)
+    {
+        $lists = [
+            [
+                'name' => 'Grocery List',
+                'color' => '#10B981',
+                'description' => 'Weekly groceries to pick up',
+                'items' => ['Milk', 'Eggs', 'Bread', 'Coffee', 'Bananas'],
+            ],
+            [
+                'name' => 'Packing List',
+                'color' => '#3B82F6',
+                'description' => 'Essentials for the next trip',
+                'items' => ['Passport', 'Charger', 'Toothbrush', 'Headphones'],
+            ],
+            [
+                'name' => 'Weekend Errands',
+                'color' => '#F59E0B',
+                'description' => 'Things to get done this weekend',
+                'items' => ['Car wash', 'Post office', 'Return library books'],
+            ],
+        ];
+
+        foreach ($lists as $index => $listData) {
+            $list = TaskList::create([
+                'user_id' => $user->id,
+                'is_sample' => true,
+                'name' => $listData['name'],
+                'color' => $listData['color'],
+                'description' => $listData['description'],
+                'position' => $index + 1,
+            ]);
+
+            foreach ($listData['items'] as $itemIndex => $content) {
+                ListItem::create([
+                    'task_list_id' => $list->id,
+                    'content' => $content,
+                    'is_completed' => false,
+                    'position' => $itemIndex + 1,
+                ]);
+            }
+        }
+
+        // Attach the first list to one of the user's existing sample tasks so the
+        // task <-> list relationship shows something real out of the box.
+        $firstList = TaskList::where('user_id', $user->id)->orderBy('position')->first();
+        $firstTask = Task::where('user_id', $user->id)->orderBy('position')->first();
+
+        if ($firstList && $firstTask) {
+            $firstList->tasks()->attach($firstTask->id);
         }
     }
 

--- a/resources/js/Components/ListItemManager.jsx
+++ b/resources/js/Components/ListItemManager.jsx
@@ -1,0 +1,567 @@
+import { useState, useEffect, useRef } from "react";
+import { toast } from "react-toastify";
+import { Plus, X, Check, Circle, Edit, Trash2, GripVertical } from "lucide-react";
+import {
+    DndContext,
+    closestCenter,
+    KeyboardSensor,
+    PointerSensor,
+    useSensor,
+    useSensors,
+} from "@dnd-kit/core";
+import {
+    arrayMove,
+    SortableContext,
+    sortableKeyboardCoordinates,
+    verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+
+function SortableItem({
+    item,
+    canEdit,
+    editingItem,
+    editContent,
+    onToggle,
+    onStartEdit,
+    onEditContentChange,
+    onSaveEdit,
+    onCancelEdit,
+    onDelete,
+    isLoading = false,
+    isDeleting = false,
+}) {
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+        id: item.id.toString(),
+        disabled: !canEdit || isLoading || isDeleting,
+    });
+
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.5 : 1,
+    };
+
+    return (
+        <div
+            ref={setNodeRef}
+            style={style}
+            className={`flex items-center space-x-3 p-2 rounded-lg transition-colors ${
+                isDragging
+                    ? "bg-light-hover dark:bg-dark-hover"
+                    : isDeleting
+                      ? "bg-red-50 dark:bg-red-900/20 opacity-50"
+                      : "bg-gray-50 dark:bg-gray-700"
+            }`}
+        >
+            {canEdit && (
+                <div {...attributes} {...listeners} className="cursor-move">
+                    <GripVertical className="h-4 w-4 text-gray-400" />
+                </div>
+            )}
+
+            <button
+                type="button"
+                onClick={() => onToggle(item)}
+                disabled={isLoading}
+                className={`flex-shrink-0 transition-transform ${
+                    isLoading ? "cursor-not-allowed opacity-50" : "cursor-pointer hover:scale-110"
+                }`}
+            >
+                {item.is_completed ? (
+                    <Check className="h-4 w-4 text-green-500 bg-green-100 dark:bg-green-900 rounded-full p-0.5" />
+                ) : (
+                    <Circle className="h-4 w-4 text-gray-400" />
+                )}
+            </button>
+
+            <div className="flex-1 min-w-0">
+                {editingItem === item.id ? (
+                    <div className="flex items-center space-x-2">
+                        <input
+                            type="text"
+                            value={editContent}
+                            onChange={(e) => onEditContentChange(e.target.value)}
+                            onKeyPress={(e) => e.key === "Enter" && onSaveEdit(item)}
+                            className="flex-1 px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded focus:ring-wevie-teal/40 focus:border-wevie-teal dark:bg-gray-600 dark:text-white"
+                            autoFocus
+                        />
+                        <button
+                            type="button"
+                            onClick={() => onSaveEdit(item)}
+                            className="p-1 text-green-600 hover:text-green-800 dark:text-green-400 dark:hover:text-green-300"
+                        >
+                            <Check className="h-3 w-3" />
+                        </button>
+                        <button
+                            type="button"
+                            onClick={onCancelEdit}
+                            className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                        >
+                            <X className="h-3 w-3" />
+                        </button>
+                    </div>
+                ) : (
+                    <span
+                        className={`text-sm ${
+                            item.is_completed
+                                ? "line-through text-gray-500 dark:text-gray-400"
+                                : "text-gray-900 dark:text-gray-100"
+                        }`}
+                    >
+                        {item.content}
+                    </span>
+                )}
+            </div>
+
+            {canEdit && editingItem !== item.id && (
+                <div className="flex items-center space-x-1">
+                    <button
+                        type="button"
+                        onClick={() => onStartEdit(item)}
+                        disabled={isLoading || isDeleting}
+                        className={`p-1 ${
+                            isLoading || isDeleting
+                                ? "text-gray-300 cursor-not-allowed"
+                                : "text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                        }`}
+                    >
+                        <Edit className="h-3 w-3" />
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => onDelete(item)}
+                        disabled={isLoading || isDeleting}
+                        className={`p-1 ${
+                            isLoading || isDeleting
+                                ? "text-gray-300 cursor-not-allowed"
+                                : "text-red-400 hover:text-red-600 dark:hover:text-red-300"
+                        }`}
+                    >
+                        <Trash2 className="h-3 w-3" />
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}
+
+export default function ListItemManager({ list, items: initialItems = [], canEdit = true }) {
+    const [items, setItems] = useState(initialItems);
+
+    // A synchronous mirror of the item list. Because several item requests
+    // (toggle/edit/delete/reorder) run as independent background XHRs, their
+    // async callbacks can't rely on the `items` closure (stale) or on a React
+    // state-updater running synchronously. This ref is the single source of
+    // truth each callback reads and writes through `applyItems`.
+    const itemsRef = useRef(initialItems);
+
+    // Sync local state with prop changes
+    useEffect(() => {
+        itemsRef.current = initialItems;
+        setItems(initialItems);
+    }, [initialItems]);
+
+    // Apply a transform to the current list, updating both the ref (synchronously)
+    // and React state, and return the concrete next list.
+    const applyItems = (updater) => {
+        const next = updater(itemsRef.current);
+        itemsRef.current = next;
+        setItems(next);
+        return next;
+    };
+
+    const [newItemContent, setNewItemContent] = useState("");
+    const [isAddingItem, setIsAddingItem] = useState(false);
+    const [editingItem, setEditingItem] = useState(null);
+    const [editContent, setEditContent] = useState("");
+    const [loadingItems, setLoadingItems] = useState(new Set());
+    const [deletingItems, setDeletingItems] = useState(new Set());
+
+    const sensors = useSensors(
+        useSensor(PointerSensor),
+        useSensor(KeyboardSensor, {
+            coordinateGetter: sortableKeyboardCoordinates,
+        })
+    );
+
+    // Display order: incomplete items first (in their existing position order),
+    // then completed ones grouped at the bottom under a "Done" section. Completed
+    // items are sorted so the most recently finished sits at the very bottom.
+    const activeItems = items.filter((s) => !s.is_completed);
+    const doneItems = items
+        .filter((s) => s.is_completed)
+        .sort((a, b) => {
+            if (!a.completed_at && !b.completed_at) return 0;
+            if (!a.completed_at) return 1; // nulls last
+            if (!b.completed_at) return -1;
+            return a.completed_at.localeCompare(b.completed_at);
+        });
+    const orderedItems = [...activeItems, ...doneItems];
+
+    const handleAddItem = () => {
+        if (!newItemContent.trim()) return;
+
+        const tempItem = {
+            id: Date.now(), // Temporary ID
+            content: newItemContent,
+            is_completed: false,
+            completed_at: null,
+            position: items.length,
+            task_list_id: list.id,
+        };
+
+        applyItems((prev) => [...prev, tempItem]);
+        const contentToAdd = newItemContent;
+        setNewItemContent("");
+        setIsAddingItem(false);
+
+        // Save in the background via a plain XHR (no Inertia visit) so the page
+        // never reloads and the optimistic row stays put instantly.
+        window.axios
+            .post(
+                route("list-items.store"),
+                {
+                    task_list_id: list.id,
+                    content: contentToAdd,
+                },
+                { headers: { Accept: "application/json" } }
+            )
+            .then((response) => {
+                // Reconcile the temporary client id with the real database id
+                // returned from the server, otherwise later edit/toggle/delete
+                // requests would target a non-existent item.
+                const created = response?.data?.item;
+
+                applyItems((prev) =>
+                    created?.id
+                        ? prev.map((s) => (s.id === tempItem.id ? { ...s, ...created } : s))
+                        : prev
+                );
+                toast.success("Item saved.");
+            })
+            .catch((error) => {
+                applyItems((prev) => prev.filter((s) => s.id !== tempItem.id));
+                toast.error(
+                    error?.response?.data?.error ||
+                        "We couldn’t save that just now. Try again when you’re ready."
+                );
+            });
+    };
+
+    const handleToggleItem = (item) => {
+        // Prevent multiple simultaneous requests for the same item
+        if (loadingItems.has(item.id)) {
+            return;
+        }
+
+        const newStatus = !item.is_completed;
+
+        setLoadingItems((prev) => new Set(prev).add(item.id));
+
+        // Optimistic flip against the freshest list so concurrent toggles of
+        // different items build on each other rather than clobbering.
+        applyItems((prev) =>
+            prev.map((s) =>
+                s.id === item.id
+                    ? {
+                          ...s,
+                          is_completed: newStatus,
+                          completed_at: newStatus ? new Date().toISOString() : null,
+                      }
+                    : s
+            )
+        );
+
+        const clearLoading = () =>
+            setLoadingItems((prev) => {
+                const newSet = new Set(prev);
+                newSet.delete(item.id);
+                return newSet;
+            });
+
+        // Save via a plain background XHR (no Inertia visit). Inertia runs one
+        // visit at a time and cancels any in-flight one when a new visit
+        // starts, so router.post here would drop earlier toggles when several
+        // items are ticked in quick succession. A bare XHR runs independently
+        // and every toggle persists.
+        window.axios
+            .post(
+                route("list-items.toggle", item.id),
+                {},
+                { headers: { Accept: "application/json" } }
+            )
+            .then((response) => {
+                clearLoading();
+
+                // Reconcile from server truth against the freshest list.
+                const updated = response?.data?.item;
+                applyItems((prev) =>
+                    updated?.id
+                        ? prev.map((s) => (s.id === item.id ? { ...s, ...updated } : s))
+                        : prev
+                );
+                toast.success(newStatus ? "Item set to done." : "Item is back on your list.");
+            })
+            .catch(() => {
+                clearLoading();
+
+                // Revert the optimistic flip against the freshest list.
+                applyItems((prev) =>
+                    prev.map((s) =>
+                        s.id === item.id
+                            ? {
+                                  ...s,
+                                  is_completed: !newStatus,
+                                  completed_at: !newStatus ? new Date().toISOString() : null,
+                              }
+                            : s
+                    )
+                );
+                toast.error("We couldn’t update that just now. Try again when you’re ready.");
+            });
+    };
+
+    const handleEditItem = (item) => {
+        if (!editContent.trim()) return;
+
+        const oldContent = item.content;
+        const newContent = editContent;
+        applyItems((prev) =>
+            prev.map((s) => (s.id === item.id ? { ...s, content: newContent } : s))
+        );
+        setEditingItem(null);
+        setEditContent("");
+
+        // Background XHR (no Inertia visit) so it never cancels an in-flight
+        // toggle/edit of another item. See handleToggleItem.
+        window.axios
+            .put(
+                route("list-items.update", item.id),
+                {
+                    content: newContent,
+                    is_completed: item.is_completed,
+                },
+                { headers: { Accept: "application/json" } }
+            )
+            .then((response) => {
+                const updated = response?.data?.item;
+                applyItems((prev) =>
+                    updated?.id
+                        ? prev.map((s) => (s.id === item.id ? { ...s, ...updated } : s))
+                        : prev
+                );
+                toast.success("Item updated.");
+            })
+            .catch(() => {
+                applyItems((prev) =>
+                    prev.map((s) => (s.id === item.id ? { ...s, content: oldContent } : s))
+                );
+                toast.error("We couldn’t update that just now. Try again when you’re ready.");
+            });
+    };
+
+    const handleDeleteItem = (item) => {
+        if (!confirm("Remove this item? You can add it again later.")) return;
+
+        // Prevent multiple delete requests for the same item
+        if (deletingItems.has(item.id)) {
+            return;
+        }
+
+        setDeletingItems((prev) => new Set(prev).add(item.id));
+
+        const clearDeleting = () =>
+            setDeletingItems((prev) => {
+                const newSet = new Set(prev);
+                newSet.delete(item.id);
+                return newSet;
+            });
+
+        // Background XHR (no Inertia visit) so it never cancels an in-flight
+        // toggle/edit/delete of another item. See handleToggleItem.
+        // Don't update UI optimistically for delete - wait for server confirmation.
+        window.axios
+            .delete(route("list-items.destroy", item.id), {
+                headers: { Accept: "application/json" },
+            })
+            .then(() => {
+                clearDeleting();
+
+                applyItems((prev) => prev.filter((s) => s.id !== item.id));
+                toast.success("Item removed.");
+            })
+            .catch(() => {
+                clearDeleting();
+                toast.error("We couldn’t remove that just now. Please try again.");
+            });
+    };
+
+    const handleDragEnd = (event) => {
+        const { active, over } = event;
+
+        if (!over || active.id === over.id) {
+            return;
+        }
+
+        // Store the original order before making changes
+        const originalItems = Array.from(itemsRef.current);
+
+        // Reorder against the displayed (grouped) order so drops line up with
+        // what the user actually sees.
+        const oldIndex = orderedItems.findIndex((item) => item.id.toString() === active.id);
+        const newIndex = orderedItems.findIndex((item) => item.id.toString() === over.id);
+
+        if (oldIndex === -1 || newIndex === -1) {
+            return;
+        }
+
+        // Don't allow dragging across the active/Done boundary — a completed
+        // item always belongs in the Done section and would just snap back.
+        if (orderedItems[oldIndex].is_completed !== orderedItems[newIndex].is_completed) {
+            return;
+        }
+
+        const newItems = arrayMove(orderedItems, oldIndex, newIndex);
+
+        // Optimistically update the UI (and the ref source of truth).
+        applyItems(() => newItems);
+
+        // Background XHR (no Inertia visit) so it never cancels an in-flight
+        // toggle/edit/delete of another item. See handleToggleItem.
+        window.axios
+            .post(
+                route("list-items.reorder"),
+                {
+                    itemIds: newItems.map((item) => item.id),
+                },
+                { headers: { Accept: "application/json" } }
+            )
+            .then(() => {
+                toast.success("Items reordered.");
+            })
+            .catch(() => {
+                // Revert to the original order on error
+                applyItems(() => originalItems);
+                toast.error("We couldn’t reorder that just now. Please try again.");
+            });
+    };
+
+    const startEdit = (item) => {
+        setEditingItem(item.id);
+        setEditContent(item.content);
+    };
+
+    const cancelEdit = () => {
+        setEditingItem(null);
+        setEditContent("");
+    };
+
+    return (
+        <div>
+            <div className="flex items-center justify-between mb-3">
+                <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                    Items ({items.filter((s) => s.is_completed).length}/{items.length})
+                </h3>
+                {canEdit && (
+                    <button
+                        type="button"
+                        onClick={(e) => {
+                            e.preventDefault();
+                            setIsAddingItem(true);
+                        }}
+                        className="text-sm text-wevie-teal hover:text-wevie-mint dark:text-wevie-mint dark:hover:text-wevie-teal flex items-center"
+                    >
+                        <Plus className="h-4 w-4 mr-1" />
+                        Add Item
+                    </button>
+                )}
+            </div>
+
+            {isAddingItem && (
+                <div className="mb-3 flex items-center space-x-2">
+                    <input
+                        type="text"
+                        placeholder="Item name..."
+                        value={newItemContent}
+                        onChange={(e) => setNewItemContent(e.target.value)}
+                        onKeyPress={(e) => e.key === "Enter" && handleAddItem()}
+                        className="flex-1 px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md focus:ring-wevie-teal/40 focus:border-wevie-teal dark:bg-gray-700 dark:text-white"
+                        autoFocus
+                    />
+                    <button
+                        type="button"
+                        onClick={handleAddItem}
+                        className="p-2 text-green-600 hover:text-green-800 dark:text-green-400 dark:hover:text-green-300"
+                    >
+                        <Check className="h-4 w-4" />
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => {
+                            setIsAddingItem(false);
+                            setNewItemContent("");
+                        }}
+                        className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                    >
+                        <X className="h-4 w-4" />
+                    </button>
+                </div>
+            )}
+
+            {items.length === 0 ? (
+                <div className="py-8 text-center">
+                    <Circle className="mx-auto h-8 w-8 text-gray-300 dark:text-gray-600 mb-2" />
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                        No items yet. Add one to get started.
+                    </p>
+                </div>
+            ) : (
+                <DndContext
+                    sensors={sensors}
+                    collisionDetection={closestCenter}
+                    onDragEnd={handleDragEnd}
+                >
+                    <SortableContext
+                        items={orderedItems.map((s) => s.id.toString())}
+                        strategy={verticalListSortingStrategy}
+                    >
+                        <div className="space-y-2">
+                            {orderedItems.map((item, index) => (
+                                <div key={item.id}>
+                                    {/* Divider before the first completed row */}
+                                    {item.is_completed && index === activeItems.length && (
+                                        <div
+                                            className={`text-xs font-medium text-gray-500 dark:text-gray-400 pt-2 pb-1 ${
+                                                activeItems.length > 0
+                                                    ? "mt-2 border-t border-gray-200 dark:border-gray-600"
+                                                    : ""
+                                            }`}
+                                        >
+                                            Done ({doneItems.length})
+                                        </div>
+                                    )}
+                                    <SortableItem
+                                        item={item}
+                                        canEdit={canEdit}
+                                        editingItem={editingItem}
+                                        editContent={editContent}
+                                        onToggle={handleToggleItem}
+                                        onStartEdit={startEdit}
+                                        onEditContentChange={setEditContent}
+                                        onSaveEdit={handleEditItem}
+                                        onCancelEdit={cancelEdit}
+                                        onDelete={handleDeleteItem}
+                                        isLoading={loadingItems.has(item.id)}
+                                        isDeleting={deletingItems.has(item.id)}
+                                    />
+                                </div>
+                            ))}
+                        </div>
+                    </SortableContext>
+                </DndContext>
+            )}
+        </div>
+    );
+}

--- a/resources/js/Components/TaskEditModal.jsx
+++ b/resources/js/Components/TaskEditModal.jsx
@@ -5,6 +5,7 @@ import PrimaryButton from "./PrimaryButton";
 import SubtaskManager from "./SubtaskManager";
 import TagInput from "./TagInput";
 import CategoryTagSelector from "./CategoryTagSelector";
+import TaskListSelector from "./TaskListSelector";
 import RecurrenceConfigFields from "./RecurrenceConfigFields";
 import { useEffect } from "react";
 
@@ -13,11 +14,12 @@ export default function TaskEditModal({
     onClose,
     task,
     categories,
+    lists = [],
     onTaskUpdate,
     workspace = null,
     board = null,
 }) {
-    const { data, setData, put, processing, errors, reset } = useForm({
+    const { data, setData, put, transform, processing, errors, reset } = useForm({
         title: "",
         description: "",
         category_id: "",
@@ -33,6 +35,7 @@ export default function TaskEditModal({
         recurrence_config: {},
         recurring_until: "",
         tags: [],
+        lists: [],
         assigned_to: "",
     });
 
@@ -75,6 +78,13 @@ export default function TaskEditModal({
                           is_new: false,
                       }))
                     : [],
+                lists: task.lists
+                    ? task.lists.map((l) => ({
+                          id: l.id,
+                          name: l.name,
+                          color: l.color,
+                      }))
+                    : [],
                 assigned_to: task.user_id || "",
             });
         }
@@ -93,6 +103,9 @@ export default function TaskEditModal({
                       task.id,
                   ])
                 : route("tasks.update", task.id);
+
+        // Send attached lists as an array of ids the backend expects.
+        transform((d) => ({ ...d, lists: (d.lists || []).map((l) => l.id) }));
 
         put(updateRoute, {
             onSuccess: () => {
@@ -288,6 +301,12 @@ export default function TaskEditModal({
                                     </div>
                                 )}
                             </div>
+
+                            <TaskListSelector
+                                lists={lists}
+                                selectedLists={data.lists}
+                                onChange={(v) => setData("lists", v)}
+                            />
 
                             <div className="flex items-center">
                                 <input

--- a/resources/js/Components/TaskListSelector.jsx
+++ b/resources/js/Components/TaskListSelector.jsx
@@ -1,0 +1,75 @@
+import { Check } from "lucide-react";
+
+export default function TaskListSelector({
+    lists = [],
+    selectedLists = [],
+    onChange,
+    className = "",
+}) {
+    const isListSelected = (list) => {
+        return selectedLists.some(
+            (selected) => (selected.id && selected.id === list.id) || selected.name === list.name
+        );
+    };
+
+    const toggleList = (list) => {
+        const isSelected = isListSelected(list);
+        let newSelectedLists;
+
+        if (isSelected) {
+            newSelectedLists = selectedLists.filter(
+                (selected) =>
+                    !(selected.id && selected.id === list.id) && selected.name !== list.name
+            );
+        } else {
+            newSelectedLists = [
+                ...selectedLists,
+                {
+                    id: list.id,
+                    name: list.name,
+                    color: list.color,
+                },
+            ];
+        }
+
+        onChange(newSelectedLists);
+    };
+
+    // Nothing to pick from — don't render an empty control.
+    if (!lists || lists.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className={className}>
+            <label className="block text-sm font-medium mb-2 text-light-secondary dark:text-dark-secondary">
+                Attach to lists (optional)
+            </label>
+            <div className="flex flex-wrap gap-2">
+                {lists.map((list) => {
+                    const selected = isListSelected(list);
+                    return (
+                        <button
+                            key={list.id}
+                            type="button"
+                            onClick={() => toggleList(list)}
+                            className={`inline-flex items-center px-3 py-1.5 rounded-full text-sm font-medium transition-all duration-200 ${
+                                selected
+                                    ? "text-white shadow-md transform scale-105"
+                                    : "text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 border border-gray-300 dark:border-gray-600"
+                            }`}
+                            style={selected ? { backgroundColor: list.color } : {}}
+                            aria-pressed={selected}
+                        >
+                            {selected && <Check className="h-3 w-3 mr-1" />}
+                            {list.name}
+                        </button>
+                    );
+                })}
+            </div>
+            <p className="text-xs text-light-muted dark:text-dark-muted mt-1">
+                Click to attach or detach this task from a list
+            </p>
+        </div>
+    );
+}

--- a/resources/js/Components/TaskModal.jsx
+++ b/resources/js/Components/TaskModal.jsx
@@ -8,6 +8,7 @@ import SecondaryButton from "./SecondaryButton";
 import PrimaryButton from "./PrimaryButton";
 import TagInput from "./TagInput";
 import CategoryTagSelector from "./CategoryTagSelector";
+import TaskListSelector from "./TaskListSelector";
 import RecurrenceConfigFields from "./RecurrenceConfigFields";
 import { addTaskFormSteps } from "@/tours";
 
@@ -15,7 +16,7 @@ export default function TaskModal({ show, onClose, onSubmitting, defaultCategory
     // `canUseTaskCapture` is only provided on pages that offer AI capture (the
     // Tasks page). `undefined` → feature not available here (render nothing);
     // `true`/`false` → entitled / locked-upsell states.
-    const { categories, canUseTaskCapture } = usePage().props;
+    const { categories, lists = [], canUseTaskCapture } = usePage().props;
     const captureAvailable = canUseTaskCapture !== undefined;
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [captureInput, setCaptureInput] = useState("");
@@ -36,9 +37,10 @@ export default function TaskModal({ show, onClose, onSubmitting, defaultCategory
         recurrence_config: {},
         recurring_until: "",
         tags: [],
+        lists: [],
     };
 
-    const { data, setData, post, processing, errors, reset, clearErrors } =
+    const { data, setData, post, transform, processing, errors, reset, clearErrors } =
         useForm(initialFormData);
 
     // Force complete form reset when modal opens
@@ -60,6 +62,7 @@ export default function TaskModal({ show, onClose, onSubmitting, defaultCategory
                 recurrence_config: {},
                 recurring_until: "",
                 tags: [],
+                lists: [],
             });
             clearErrors();
             setIsSubmitting(false);
@@ -119,6 +122,9 @@ export default function TaskModal({ show, onClose, onSubmitting, defaultCategory
         e.preventDefault();
         setIsSubmitting(true);
 
+        // Send attached lists as an array of ids the backend expects.
+        transform((d) => ({ ...d, lists: (d.lists || []).map((l) => l.id) }));
+
         post(route("tasks.store"), {
             onSuccess: () => {
                 // Force complete form reset
@@ -135,6 +141,7 @@ export default function TaskModal({ show, onClose, onSubmitting, defaultCategory
                     recurrence_type: "",
                     recurring_until: "",
                     tags: [],
+                    lists: [],
                 });
                 clearErrors();
                 setIsSubmitting(false);
@@ -165,6 +172,7 @@ export default function TaskModal({ show, onClose, onSubmitting, defaultCategory
             recurrence_type: "",
             recurring_until: "",
             tags: [],
+            lists: [],
         });
         clearErrors();
         setIsSubmitting(false);
@@ -341,6 +349,13 @@ export default function TaskModal({ show, onClose, onSubmitting, defaultCategory
                                 <div className="text-red-500 text-xs mt-1">{errors.tags}</div>
                             )}
                         </div>
+
+                        <TaskListSelector
+                            lists={lists}
+                            selectedLists={data.lists}
+                            onChange={(v) => setData("lists", v)}
+                        />
+
                         <div className="flex items-center">
                             <input
                                 type="checkbox"

--- a/resources/js/Components/TaskViewModal.jsx
+++ b/resources/js/Components/TaskViewModal.jsx
@@ -1,7 +1,8 @@
+import { Link } from "@inertiajs/react";
 import Modal from "./Modal";
 import SecondaryButton from "./SecondaryButton";
 import SubtaskManager from "./SubtaskManager";
-import { Calendar, CheckCircle, Clock } from "lucide-react";
+import { Calendar, CheckCircle, Clock, List } from "lucide-react";
 
 export default function TaskViewModal({ show, onClose, task, onTaskUpdate }) {
     if (!task) return null;
@@ -259,6 +260,28 @@ export default function TaskViewModal({ show, onClose, task, onTaskUpdate }) {
                                     >
                                         {tag.name}
                                     </span>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Lists */}
+                    {task.lists && task.lists.length > 0 && (
+                        <div className="mb-6">
+                            <h3 className="text-sm font-medium text-light-muted dark:text-dark-muted mb-2">
+                                Lists
+                            </h3>
+                            <div className="flex flex-wrap gap-2">
+                                {task.lists.map((list) => (
+                                    <Link
+                                        key={list.id}
+                                        href={route("lists.show", list.id)}
+                                        className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium text-white hover:opacity-90 transition-opacity"
+                                        style={{ backgroundColor: list.color }}
+                                    >
+                                        <List className="h-3 w-3" />
+                                        {list.name}
+                                    </Link>
                                 ))}
                             </div>
                         </div>

--- a/resources/js/Layouts/TodoLayout.jsx
+++ b/resources/js/Layouts/TodoLayout.jsx
@@ -34,6 +34,7 @@ import {
     CreditCard,
     BookOpen,
     Tags,
+    ListChecks,
 } from "lucide-react";
 
 export default function TodoLayout({ header, children }) {
@@ -163,6 +164,13 @@ export default function TodoLayout({ header, children }) {
                     icon: FolderOpen,
                     current: route().current("categories.*"),
                     tourKey: "nav-categories",
+                },
+                {
+                    name: "Lists",
+                    href: route("lists.index"),
+                    icon: ListChecks,
+                    current: route().current("lists.*"),
+                    tourKey: "nav-lists",
                 },
             ],
         },

--- a/resources/js/Pages/Lists/Create.jsx
+++ b/resources/js/Pages/Lists/Create.jsx
@@ -1,0 +1,156 @@
+import TodoLayout from "@/Layouts/TodoLayout";
+import { Head, useForm, Link } from "@inertiajs/react";
+import { ArrowLeft, Save, ListPlus } from "lucide-react";
+
+export default function Create() {
+    const { data, setData, post, processing, errors } = useForm({
+        name: "",
+        description: "",
+        color: "#4ACF91", // Default Wevie primary
+    });
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        post(route("lists.store"));
+    };
+
+    const colorOptions = [
+        "#4ACF91", // Wevie green
+        "#5FDDE0", // Wevie cyan
+        "#3B82F6", // Blue
+        "#EF4444", // Red
+        "#F59E0B", // Yellow
+        "#8B5CF6", // Purple
+        "#F97316", // Orange
+        "#84CC16", // Lime
+        "#EC4899", // Pink
+        "#6B7280", // Gray
+    ];
+
+    return (
+        <TodoLayout
+            header={
+                <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+                    <div className="flex items-center gap-3">
+                        <Link
+                            href={route("lists.index")}
+                            className="inline-flex items-center text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 transition-colors"
+                        >
+                            <ArrowLeft className="h-4 w-4" />
+                        </Link>
+                        <h2 className="text-lg sm:text-xl font-semibold text-gray-900 dark:text-gray-100">
+                            Create List
+                        </h2>
+                    </div>
+                </div>
+            }
+        >
+            <Head title="Create List" />
+            <div className="max-w-2xl mx-auto">
+                <div className="card p-4 sm:p-6">
+                    <div className="flex items-center gap-3 mb-6">
+                        <div className="w-10 h-10 sm:w-12 sm:h-12 bg-primary-100 dark:bg-primary-900/40 rounded-lg flex items-center justify-center">
+                            <ListPlus className="w-5 h-5 sm:w-6 sm:h-6 text-wevie-teal dark:text-wevie-mint" />
+                        </div>
+                        <div>
+                            <h3 className="text-base sm:text-lg font-medium text-gray-900 dark:text-gray-100">
+                                New List
+                            </h3>
+                            <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">
+                                Create a list to collect items and group tasks
+                            </p>
+                        </div>
+                    </div>
+
+                    <form onSubmit={handleSubmit} className="space-y-6">
+                        <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                                List Name
+                            </label>
+                            <input
+                                type="text"
+                                className="w-full px-3 py-2 border border-light-border/70 dark:border-white/10 rounded-md focus:ring-wevie-teal/40 focus:border-wevie-teal dark:bg-dark-card dark:text-white text-sm sm:text-base"
+                                value={data.name}
+                                onChange={(e) => setData("name", e.target.value)}
+                                placeholder="e.g. Grocery List"
+                                required
+                            />
+                            {errors.name && (
+                                <div className="text-red-500 text-xs mt-1">{errors.name}</div>
+                            )}
+                        </div>
+
+                        <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                                Description (Optional)
+                            </label>
+                            <textarea
+                                rows={3}
+                                className="w-full px-3 py-2 border border-light-border/70 dark:border-white/10 rounded-md focus:ring-wevie-teal/40 focus:border-wevie-teal dark:bg-dark-card dark:text-white text-sm sm:text-base"
+                                value={data.description}
+                                onChange={(e) => setData("description", e.target.value)}
+                                placeholder="What is this list for?"
+                            />
+                            {errors.description && (
+                                <div className="text-red-500 text-xs mt-1">
+                                    {errors.description}
+                                </div>
+                            )}
+                        </div>
+
+                        <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                                List Color
+                            </label>
+                            <div className="flex flex-wrap gap-2">
+                                {colorOptions.map((color) => (
+                                    <button
+                                        key={color}
+                                        type="button"
+                                        onClick={() => setData("color", color)}
+                                        className={`w-8 h-8 sm:w-10 sm:h-10 rounded-full border-2 transition-all duration-200 ${
+                                            data.color === color
+                                                ? "border-gray-900 dark:border-gray-100 scale-110"
+                                                : "border-gray-300 dark:border-gray-600 hover:scale-105"
+                                        }`}
+                                        style={{ backgroundColor: color }}
+                                        aria-label={`Select color ${color}`}
+                                    />
+                                ))}
+                            </div>
+                            <div className="mt-2 flex items-center gap-2">
+                                <span className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">
+                                    Selected:
+                                </span>
+                                <div
+                                    className="w-4 h-4 rounded-full border border-gray-300 dark:border-gray-600"
+                                    style={{ backgroundColor: data.color }}
+                                />
+                                <span className="text-xs sm:text-sm text-gray-600 dark:text-gray-300 font-mono">
+                                    {data.color}
+                                </span>
+                            </div>
+                        </div>
+
+                        <div className="flex flex-col sm:flex-row gap-3 pt-4">
+                            <button
+                                type="submit"
+                                className="inline-flex items-center justify-center px-4 py-2 bg-gradient-to-r from-wevie-teal to-wevie-mint border border-transparent text-white text-sm font-medium rounded-xl hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-wevie-teal/40 disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-200"
+                                disabled={processing}
+                            >
+                                <Save className="mr-2 h-4 w-4" />
+                                {processing ? "Creating..." : "Create List"}
+                            </button>
+                            <Link
+                                href={route("lists.index")}
+                                className="inline-flex items-center justify-center px-4 py-2 border border-light-border/70 dark:border-dark-border/70 text-light-secondary dark:text-dark-secondary text-sm font-medium rounded-xl hover:bg-light-hover dark:hover:bg-dark-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-wevie-teal/40 transition-colors duration-200"
+                            >
+                                Cancel
+                            </Link>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </TodoLayout>
+    );
+}

--- a/resources/js/Pages/Lists/Edit.jsx
+++ b/resources/js/Pages/Lists/Edit.jsx
@@ -1,0 +1,162 @@
+import TodoLayout from "@/Layouts/TodoLayout";
+import { Head, useForm, Link } from "@inertiajs/react";
+import { ArrowLeft, Save, Edit3 } from "lucide-react";
+
+export default function Edit({ list }) {
+    const { data, setData, put, processing, errors } = useForm({
+        name: list.name || "",
+        description: list.description || "",
+        color: list.color || "#4ACF91",
+    });
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        put(route("lists.update", list.id));
+    };
+
+    const colorOptions = [
+        "#4ACF91", // Wevie green
+        "#5FDDE0", // Wevie cyan
+        "#3B82F6", // Blue
+        "#EF4444", // Red
+        "#F59E0B", // Yellow
+        "#8B5CF6", // Purple
+        "#F97316", // Orange
+        "#84CC16", // Lime
+        "#EC4899", // Pink
+        "#6B7280", // Gray
+    ];
+
+    return (
+        <TodoLayout
+            header={
+                <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+                    <div className="flex items-center gap-3">
+                        <Link
+                            href={route("lists.index")}
+                            className="inline-flex items-center text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 transition-colors"
+                        >
+                            <ArrowLeft className="h-4 w-4" />
+                        </Link>
+                        <h2 className="text-lg sm:text-xl font-semibold text-gray-900 dark:text-gray-100">
+                            Edit List
+                        </h2>
+                    </div>
+                </div>
+            }
+        >
+            <Head title="Edit List" />
+            <div className="max-w-2xl mx-auto">
+                <div className="card p-4 sm:p-6">
+                    <div className="flex items-center gap-3 mb-6">
+                        <div
+                            className="w-10 h-10 sm:w-12 sm:h-12 rounded-lg flex items-center justify-center"
+                            style={{ backgroundColor: `${data.color}20` }}
+                        >
+                            <Edit3
+                                className="w-5 h-5 sm:w-6 sm:h-6"
+                                style={{ color: data.color }}
+                            />
+                        </div>
+                        <div>
+                            <h3 className="text-base sm:text-lg font-medium text-gray-900 dark:text-gray-100">
+                                Edit "{list.name}"
+                            </h3>
+                            <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">
+                                Update list information and settings
+                            </p>
+                        </div>
+                    </div>
+
+                    <form onSubmit={handleSubmit} className="space-y-6">
+                        <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                                List Name
+                            </label>
+                            <input
+                                type="text"
+                                className="w-full px-3 py-2 border border-light-border/70 dark:border-white/10 rounded-md focus:ring-wevie-teal/40 focus:border-wevie-teal dark:bg-dark-card dark:text-white text-sm sm:text-base"
+                                value={data.name}
+                                onChange={(e) => setData("name", e.target.value)}
+                                placeholder="e.g. Grocery List"
+                                required
+                            />
+                            {errors.name && (
+                                <div className="text-red-500 text-xs mt-1">{errors.name}</div>
+                            )}
+                        </div>
+
+                        <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                                Description (Optional)
+                            </label>
+                            <textarea
+                                rows={3}
+                                className="w-full px-3 py-2 border border-light-border/70 dark:border-white/10 rounded-md focus:ring-wevie-teal/40 focus:border-wevie-teal dark:bg-dark-card dark:text-white text-sm sm:text-base"
+                                value={data.description}
+                                onChange={(e) => setData("description", e.target.value)}
+                                placeholder="What is this list for?"
+                            />
+                            {errors.description && (
+                                <div className="text-red-500 text-xs mt-1">
+                                    {errors.description}
+                                </div>
+                            )}
+                        </div>
+
+                        <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                                List Color
+                            </label>
+                            <div className="flex flex-wrap gap-2">
+                                {colorOptions.map((color) => (
+                                    <button
+                                        key={color}
+                                        type="button"
+                                        onClick={() => setData("color", color)}
+                                        className={`w-8 h-8 sm:w-10 sm:h-10 rounded-full border-2 transition-all duration-200 ${
+                                            data.color === color
+                                                ? "border-gray-900 dark:border-gray-100 scale-110"
+                                                : "border-gray-300 dark:border-gray-600 hover:scale-105"
+                                        }`}
+                                        style={{ backgroundColor: color }}
+                                        aria-label={`Select color ${color}`}
+                                    />
+                                ))}
+                            </div>
+                            <div className="mt-2 flex items-center gap-2">
+                                <span className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">
+                                    Selected:
+                                </span>
+                                <div
+                                    className="w-4 h-4 rounded-full border border-gray-300 dark:border-gray-600"
+                                    style={{ backgroundColor: data.color }}
+                                />
+                                <span className="text-xs sm:text-sm text-gray-600 dark:text-gray-300 font-mono">
+                                    {data.color}
+                                </span>
+                            </div>
+                        </div>
+
+                        <div className="flex flex-col sm:flex-row gap-3 pt-4">
+                            <button
+                                type="submit"
+                                className="inline-flex items-center justify-center px-4 py-2 bg-gradient-to-r from-wevie-teal to-wevie-mint border border-transparent text-white text-sm font-medium rounded-xl hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-wevie-teal/40 disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-200"
+                                disabled={processing}
+                            >
+                                <Save className="mr-2 h-4 w-4" />
+                                {processing ? "Updating..." : "Update List"}
+                            </button>
+                            <Link
+                                href={route("lists.index")}
+                                className="inline-flex items-center justify-center px-4 py-2 border border-light-border/70 dark:border-dark-border/70 text-light-secondary dark:text-dark-secondary text-sm font-medium rounded-xl hover:bg-light-hover dark:hover:bg-dark-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-wevie-teal/40 transition-colors duration-200"
+                            >
+                                Cancel
+                            </Link>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </TodoLayout>
+    );
+}

--- a/resources/js/Pages/Lists/Index.jsx
+++ b/resources/js/Pages/Lists/Index.jsx
@@ -1,0 +1,127 @@
+import TodoLayout from "@/Layouts/TodoLayout";
+import { Head, Link, router } from "@inertiajs/react";
+import { Plus, Eye, Edit, ListChecks, Trash2, CheckSquare } from "lucide-react";
+
+export default function Index({ lists = [] }) {
+    const handleDelete = (list) => {
+        if (
+            confirm(
+                `Are you sure you want to delete the list "${list.name}"? This action cannot be undone.`
+            )
+        ) {
+            router.delete(route("lists.destroy", list.id));
+        }
+    };
+
+    return (
+        <TodoLayout
+            header={
+                <div className="flex flex-row items-center justify-between gap-2 md:gap-4">
+                    <h2 className="text-base sm:text-lg md:text-xl font-semibold text-gray-900 dark:text-gray-100 flex-shrink-0">
+                        Lists
+                    </h2>
+                    <Link
+                        href={route("lists.create")}
+                        className="inline-flex items-center justify-center w-auto px-3 py-2 sm:px-2 sm:py-1.5 md:px-4 md:py-2 bg-gradient-to-r from-wevie-teal to-wevie-mint border border-transparent text-white text-xs sm:text-xs md:text-sm font-medium rounded-xl hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-wevie-teal/40 transition-colors duration-200"
+                    >
+                        <Plus className="mr-1 sm:mr-2 h-4 w-4 sm:h-3 sm:w-3 md:h-4 md:w-4" />
+                        <span className="hidden sm:inline">New List</span>
+                        <span className="sm:hidden">Add</span>
+                    </Link>
+                </div>
+            }
+        >
+            <Head title="Lists" />
+            <div className="max-w-4xl mx-auto">
+                <div className="card divide-y divide-gray-200 dark:divide-white/10">
+                    {lists.length === 0 ? (
+                        <div className="p-6 sm:p-8 text-center">
+                            <div className="text-gray-400 dark:text-gray-500 mb-4">
+                                <ListChecks className="mx-auto h-10 w-10 sm:h-12 sm:w-12" />
+                            </div>
+                            <h3 className="text-base sm:text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">
+                                No lists found
+                            </h3>
+                            <p className="text-sm sm:text-base text-gray-500 dark:text-gray-400 mb-4">
+                                Get started by creating your first list to collect items and group
+                                related tasks.
+                            </p>
+                            <Link
+                                href={route("lists.create")}
+                                className="inline-flex items-center justify-center w-full sm:w-auto px-4 py-2.5 sm:px-4 sm:py-2 bg-gradient-to-r from-wevie-teal to-wevie-mint border border-transparent text-white text-sm font-medium rounded-xl hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-wevie-teal/40 transition-colors duration-200"
+                            >
+                                <Plus className="mr-2 h-4 w-4" />
+                                Create List
+                            </Link>
+                        </div>
+                    ) : (
+                        lists.map((list) => (
+                            <div
+                                key={list.id}
+                                className="flex flex-col sm:flex-row sm:items-center justify-between p-4 sm:p-6 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-150"
+                            >
+                                <div className="flex-1 min-w-0">
+                                    <div className="flex items-center gap-3 mb-2">
+                                        <span
+                                            className="inline-block w-4 h-4 sm:w-5 sm:h-5 rounded-full flex-shrink-0"
+                                            style={{
+                                                backgroundColor: list.color,
+                                            }}
+                                        ></span>
+                                        <Link
+                                            href={route("lists.show", list.id)}
+                                            className="font-semibold text-gray-900 dark:text-gray-100 text-sm sm:text-base truncate hover:text-wevie-teal dark:hover:text-wevie-mint transition-colors"
+                                        >
+                                            {list.name}
+                                        </Link>
+                                    </div>
+                                    {list.description && (
+                                        <div className="text-xs sm:text-sm text-gray-500 dark:text-gray-400 ml-7 sm:ml-8">
+                                            {list.description}
+                                        </div>
+                                    )}
+                                    <div className="flex flex-wrap items-center gap-3 text-xs text-gray-400 dark:text-gray-500 ml-7 sm:ml-8 mt-1">
+                                        <span className="inline-flex items-center gap-1">
+                                            <ListChecks className="h-3 w-3" />
+                                            {list.items_count || 0} item
+                                            {(list.items_count || 0) !== 1 ? "s" : ""}
+                                        </span>
+                                        <span className="inline-flex items-center gap-1">
+                                            <CheckSquare className="h-3 w-3" />
+                                            {list.tasks_count || 0} task
+                                            {(list.tasks_count || 0) !== 1 ? "s" : ""}
+                                        </span>
+                                    </div>
+                                </div>
+
+                                <div className="flex items-center space-x-1 sm:space-x-2 mt-3 sm:mt-0 sm:ml-4">
+                                    <Link
+                                        href={route("lists.show", list.id)}
+                                        className="p-1 sm:p-2 text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                                        title="Open list"
+                                    >
+                                        <Eye className="h-4 w-4" />
+                                    </Link>
+                                    <Link
+                                        href={route("lists.edit", list.id)}
+                                        className="p-1 sm:p-2 text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                                        title="Edit list"
+                                    >
+                                        <Edit className="h-4 w-4" />
+                                    </Link>
+                                    <button
+                                        onClick={() => handleDelete(list)}
+                                        className="p-1 sm:p-2 text-gray-400 hover:text-red-600 dark:hover:text-red-400 transition-colors"
+                                        title="Delete list"
+                                    >
+                                        <Trash2 className="h-4 w-4" />
+                                    </button>
+                                </div>
+                            </div>
+                        ))
+                    )}
+                </div>
+            </div>
+        </TodoLayout>
+    );
+}

--- a/resources/js/Pages/Lists/Show.jsx
+++ b/resources/js/Pages/Lists/Show.jsx
@@ -1,0 +1,321 @@
+import TodoLayout from "@/Layouts/TodoLayout";
+import { Head, Link, router } from "@inertiajs/react";
+import { useState, useMemo } from "react";
+import {
+    ArrowLeft,
+    Edit,
+    ListChecks,
+    CheckSquare,
+    Eye,
+    Plus,
+    Search,
+    Link2Off,
+} from "lucide-react";
+import ListItemManager from "@/Components/ListItemManager";
+import TaskViewModal from "@/Components/TaskViewModal";
+import { toast } from "react-toastify";
+
+export default function Show({ list, availableTasks = [] }) {
+    const [showViewModal, setShowViewModal] = useState(false);
+    const [selectedTask, setSelectedTask] = useState(null);
+    const [showAttach, setShowAttach] = useState(false);
+    const [attachSearch, setAttachSearch] = useState("");
+
+    const tasks = list.tasks || [];
+
+    // Candidate tasks to attach = the user's other tasks that aren't already in
+    // this list. `availableTasks` is optionally provided by the backend; if it's
+    // absent we simply hide the picker and point the user at the Tasks page.
+    const attachedIds = useMemo(() => new Set((list.tasks || []).map((t) => t.id)), [list.tasks]);
+
+    const candidateTasks = useMemo(() => {
+        const term = attachSearch.trim().toLowerCase();
+        return (availableTasks || [])
+            .filter((t) => !attachedIds.has(t.id))
+            .filter((t) => (term ? (t.title || "").toLowerCase().includes(term) : true));
+    }, [availableTasks, attachedIds, attachSearch]);
+
+    const handleDetach = (task) => {
+        router.delete(route("lists.tasks.detach", [list.id, task.id]), {
+            preserveScroll: true,
+            onSuccess: () => toast.success("Task removed from this list."),
+            onError: () => toast.error("We couldn’t remove that task just now. Please try again."),
+        });
+    };
+
+    const handleAttach = (task) => {
+        router.post(
+            route("lists.tasks.attach", list.id),
+            { task_id: task.id },
+            {
+                preserveScroll: true,
+                onSuccess: () => {
+                    toast.success("Task added to this list.");
+                    setAttachSearch("");
+                    setShowAttach(false);
+                },
+                onError: () => toast.error("We couldn’t add that task just now. Please try again."),
+            }
+        );
+    };
+
+    const getPriorityColor = (priority) => {
+        switch (priority) {
+            case "urgent":
+                return "text-red-600 bg-red-100 dark:text-red-400 dark:bg-red-900/20";
+            case "high":
+                return "text-orange-600 bg-orange-100 dark:text-orange-400 dark:bg-orange-900/20";
+            case "medium":
+                return "text-yellow-600 bg-yellow-100 dark:text-yellow-400 dark:bg-yellow-900/20";
+            case "low":
+                return "text-green-600 bg-green-100 dark:text-green-400 dark:bg-green-900/20";
+            default:
+                return "text-gray-600 bg-gray-100 dark:text-gray-400 dark:bg-dark-card/70";
+        }
+    };
+
+    return (
+        <TodoLayout
+            header={
+                <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+                    <div className="flex items-center gap-3">
+                        <Link
+                            href={route("lists.index")}
+                            className="inline-flex items-center text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 transition-colors"
+                        >
+                            <ArrowLeft className="h-4 w-4" />
+                        </Link>
+                        <h2 className="text-lg sm:text-xl font-semibold text-gray-900 dark:text-gray-100 truncate">
+                            {list.name}
+                        </h2>
+                    </div>
+                    <Link
+                        href={route("lists.edit", list.id)}
+                        className="inline-flex items-center justify-center px-3 sm:px-4 py-2 bg-gradient-to-r from-wevie-teal to-wevie-mint border border-transparent text-white text-sm font-medium rounded-xl hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-wevie-teal/40 transition-colors duration-200"
+                    >
+                        <Edit className="mr-2 h-4 w-4" />
+                        Edit
+                    </Link>
+                </div>
+            }
+        >
+            <Head title={list.name} />
+            <div className="max-w-5xl mx-auto space-y-4 sm:space-y-6">
+                {/* List Info Card */}
+                <div className="card p-4 sm:p-6">
+                    <div className="flex items-center gap-4">
+                        <div
+                            className="w-12 h-12 sm:w-16 sm:h-16 rounded-lg flex items-center justify-center flex-shrink-0"
+                            style={{ backgroundColor: `${list.color}20` }}
+                        >
+                            <ListChecks
+                                className="w-6 h-6 sm:w-8 sm:h-8"
+                                style={{ color: list.color }}
+                            />
+                        </div>
+                        <div className="flex-1 min-w-0">
+                            <h3 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-gray-100 mb-1">
+                                {list.name}
+                            </h3>
+                            {list.description && (
+                                <p className="text-sm sm:text-base text-gray-600 dark:text-gray-300 mb-2">
+                                    {list.description}
+                                </p>
+                            )}
+                            <div className="flex flex-wrap items-center gap-3 text-xs sm:text-sm text-gray-500 dark:text-gray-400">
+                                <span className="inline-flex items-center gap-1">
+                                    <ListChecks className="h-4 w-4" />
+                                    {(list.items || []).length} item
+                                    {(list.items || []).length !== 1 ? "s" : ""}
+                                </span>
+                                <span className="inline-flex items-center gap-1">
+                                    <CheckSquare className="h-4 w-4" />
+                                    {tasks.length} task
+                                    {tasks.length !== 1 ? "s" : ""}
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                {/* Two-column layout: items + tasks */}
+                <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
+                    {/* Items */}
+                    <div className="card p-4 sm:p-6">
+                        <h3 className="text-base sm:text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
+                            Checklist items
+                        </h3>
+                        <ListItemManager
+                            key={`list-${list.id}`}
+                            list={list}
+                            items={list.items || []}
+                            canEdit={true}
+                        />
+                    </div>
+
+                    {/* Tasks in this list */}
+                    <div className="card p-4 sm:p-6">
+                        <div className="flex items-center justify-between mb-4">
+                            <h3 className="text-base sm:text-lg font-medium text-gray-900 dark:text-gray-100">
+                                Tasks in this list
+                            </h3>
+                            <button
+                                type="button"
+                                onClick={() => setShowAttach((v) => !v)}
+                                className="inline-flex items-center text-sm text-wevie-teal hover:text-wevie-mint dark:text-wevie-mint dark:hover:text-wevie-teal transition-colors"
+                            >
+                                <Plus className="h-4 w-4 mr-1" />
+                                Attach task
+                            </button>
+                        </div>
+
+                        {/* Attach picker */}
+                        {showAttach && (
+                            <div className="mb-4 rounded-lg border border-light-border/70 dark:border-dark-border/70 p-3">
+                                <div className="relative mb-2">
+                                    <Search className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+                                    <input
+                                        type="text"
+                                        value={attachSearch}
+                                        onChange={(e) => setAttachSearch(e.target.value)}
+                                        placeholder="Search your tasks..."
+                                        className="w-full pl-8 pr-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md focus:ring-wevie-teal/40 focus:border-wevie-teal dark:bg-gray-700 dark:text-white"
+                                        autoFocus
+                                    />
+                                </div>
+                                {!availableTasks || availableTasks.length === 0 ? (
+                                    <p className="text-xs text-gray-500 dark:text-gray-400 py-2">
+                                        No tasks available to attach.{" "}
+                                        <Link
+                                            href={route("tasks.index")}
+                                            className="text-wevie-teal dark:text-wevie-mint hover:underline"
+                                        >
+                                            Create a task
+                                        </Link>{" "}
+                                        first.
+                                    </p>
+                                ) : candidateTasks.length === 0 ? (
+                                    <p className="text-xs text-gray-500 dark:text-gray-400 py-2">
+                                        No matching tasks.
+                                    </p>
+                                ) : (
+                                    <ul className="max-h-48 overflow-y-auto divide-y divide-gray-100 dark:divide-gray-700">
+                                        {candidateTasks.map((task) => (
+                                            <li key={task.id}>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => handleAttach(task)}
+                                                    className="flex w-full items-center gap-2 px-1 py-2 text-left text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 rounded"
+                                                >
+                                                    <Plus className="h-4 w-4 flex-shrink-0 text-wevie-teal dark:text-wevie-mint" />
+                                                    <span className="truncate">{task.title}</span>
+                                                </button>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                )}
+                            </div>
+                        )}
+
+                        {tasks.length === 0 ? (
+                            <div className="py-8 text-center">
+                                <CheckSquare className="mx-auto h-8 w-8 text-gray-300 dark:text-gray-600 mb-2" />
+                                <p className="text-sm text-gray-500 dark:text-gray-400">
+                                    No tasks attached yet. Use “Attach task” to add one.
+                                </p>
+                            </div>
+                        ) : (
+                            <div className="space-y-2">
+                                {tasks.map((task) => (
+                                    <div
+                                        key={task.id}
+                                        className="flex items-center gap-2 rounded-lg border border-light-border/60 dark:border-dark-border/60 p-3 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                                    >
+                                        <div className="flex-1 min-w-0">
+                                            <div className="flex items-center gap-2">
+                                                <button
+                                                    type="button"
+                                                    onClick={() => {
+                                                        setSelectedTask(task);
+                                                        setShowViewModal(true);
+                                                    }}
+                                                    className={`text-sm font-medium truncate text-left hover:text-wevie-teal dark:hover:text-wevie-mint transition-colors ${
+                                                        task.status === "completed"
+                                                            ? "text-gray-500 dark:text-gray-400 line-through"
+                                                            : "text-gray-900 dark:text-gray-100"
+                                                    }`}
+                                                    title="Click to view task details"
+                                                >
+                                                    {task.title}
+                                                </button>
+                                                {task.priority && (
+                                                    <span
+                                                        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${getPriorityColor(
+                                                            task.priority
+                                                        )}`}
+                                                    >
+                                                        {task.priority.charAt(0).toUpperCase() +
+                                                            task.priority.slice(1)}
+                                                    </span>
+                                                )}
+                                            </div>
+                                            {task.description && (
+                                                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 truncate">
+                                                    {task.description}
+                                                </p>
+                                            )}
+                                        </div>
+                                        <button
+                                            type="button"
+                                            onClick={() => {
+                                                setSelectedTask(task);
+                                                setShowViewModal(true);
+                                            }}
+                                            className="p-1.5 text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                                            title="View task"
+                                        >
+                                            <Eye className="h-4 w-4" />
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => handleDetach(task)}
+                                            className="p-1.5 text-gray-400 hover:text-red-600 dark:hover:text-red-400 transition-colors"
+                                            title="Remove from list"
+                                        >
+                                            <Link2Off className="h-4 w-4" />
+                                        </button>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                </div>
+
+                {/* Back link */}
+                <div>
+                    <Link
+                        href={route("lists.index")}
+                        className="inline-flex items-center justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 text-sm font-medium rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-200"
+                    >
+                        <ArrowLeft className="mr-2 h-4 w-4" />
+                        Back to Lists
+                    </Link>
+                </div>
+            </div>
+
+            <TaskViewModal
+                show={showViewModal}
+                onClose={() => {
+                    setShowViewModal(false);
+                    setSelectedTask(null);
+                }}
+                task={selectedTask}
+                onTaskUpdate={() => {
+                    // Keep server state authoritative for task edits done in the
+                    // modal by reloading the list's tasks.
+                    router.reload({ only: ["list"] });
+                }}
+            />
+        </TodoLayout>
+    );
+}

--- a/resources/js/Pages/Tasks/Index.jsx
+++ b/resources/js/Pages/Tasks/Index.jsx
@@ -43,6 +43,7 @@ import {
     Square,
     Pause,
     FolderOpen,
+    List,
 } from "lucide-react";
 import TaskModal from "@/Components/TaskModal";
 import TaskViewModal from "@/Components/TaskViewModal";
@@ -287,6 +288,30 @@ function SortableTask({
                         </div>
                     )}
 
+                    {/* Lists */}
+                    {task.lists && task.lists.length > 0 && (
+                        <div className="hidden sm:flex items-center space-x-1">
+                            <List className="h-4 w-4 text-light-muted dark:text-dark-muted" />
+                            <div className="flex space-x-1">
+                                {task.lists.slice(0, 2).map((list) => (
+                                    <span
+                                        key={list.id}
+                                        className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium text-white"
+                                        style={{ backgroundColor: list.color }}
+                                        title={list.name}
+                                    >
+                                        {list.name}
+                                    </span>
+                                ))}
+                                {task.lists.length > 2 && (
+                                    <span className="text-xs text-gray-500 dark:text-gray-400">
+                                        +{task.lists.length - 2}
+                                    </span>
+                                )}
+                            </div>
+                        </div>
+                    )}
+
                     {/* Actions */}
                     <div className="opacity-100 transition-opacity focus-within:opacity-100 sm:opacity-0 sm:group-hover:opacity-100">
                         <TaskActionsMenu
@@ -315,6 +340,21 @@ function SortableTask({
                                         setShowEditModal(true);
                                     },
                                 },
+                                ...(task.lists && task.lists.length > 0
+                                    ? [
+                                          {
+                                              label: "Open list",
+                                              icon: List,
+                                              onClick: () =>
+                                                  router.visit(
+                                                      route(
+                                                          "lists.show",
+                                                          task.lists[0].id
+                                                      )
+                                                  ),
+                                          },
+                                      ]
+                                    : []),
                                 {
                                     label: "Delete",
                                     icon: Trash2,
@@ -330,7 +370,7 @@ function SortableTask({
     );
 }
 
-export default function Index({ tasks = [], categories, tags = [], filters }) {
+export default function Index({ tasks = [], categories, tags = [], lists = [], filters }) {
     const [allTasks, setAllTasks] = useState([]);
     const [search, setSearch] = useState(filters.search || "");
     const [statusFilter, setStatusFilter] = useState(filters.status || "");
@@ -1251,6 +1291,7 @@ export default function Index({ tasks = [], categories, tags = [], filters }) {
                 }}
                 onSubmitting={setIsTaskSubmitting}
                 categories={categories}
+                lists={lists}
                 defaultCategoryId={selectedCategory}
             />
 
@@ -1266,6 +1307,7 @@ export default function Index({ tasks = [], categories, tags = [], filters }) {
                 onClose={() => setShowEditModal(false)}
                 task={selectedTask}
                 categories={categories}
+                lists={lists}
                 onTaskUpdate={handleTaskUpdate}
             />
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\DashboardLayoutController;
 use App\Http\Controllers\GoogleCalendarController;
+use App\Http\Controllers\ListItemController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ReminderController;
 use App\Http\Controllers\SubtaskController;
@@ -15,6 +16,7 @@ use App\Http\Controllers\SwimlaneController;
 use App\Http\Controllers\TagController;
 use App\Http\Controllers\TaskCaptureController;
 use App\Http\Controllers\TaskController;
+use App\Http\Controllers\TaskListController;
 use App\Http\Controllers\WorkspaceController;
 use App\Modules\Finance\Controllers\FinanceAccountController;
 use App\Modules\Finance\Controllers\FinanceBudgetController;
@@ -69,6 +71,11 @@ Route::middleware(['auth', 'verified'])->group(function () {
     // Categories
     Route::resource('categories', CategoryController::class);
 
+    // Lists
+    Route::resource('lists', TaskListController::class);
+    Route::post('lists/{list}/tasks', [TaskListController::class, 'attachTask'])->name('lists.tasks.attach');
+    Route::delete('lists/{list}/tasks/{task}', [TaskListController::class, 'detachTask'])->name('lists.tasks.detach');
+
     // Tags
     Route::resource('tags', TagController::class);
     Route::get('api/tags', [TagController::class, 'getAllTags'])->name('api.tags');
@@ -83,6 +90,13 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::delete('subtasks/{subtask}', [SubtaskController::class, 'destroy'])->name('subtasks.destroy');
     Route::post('subtasks/{subtask}/toggle', [SubtaskController::class, 'toggle'])->name('subtasks.toggle');
     Route::post('subtasks/reorder', [SubtaskController::class, 'reorder'])->name('subtasks.reorder');
+
+    // List Items
+    Route::post('list-items', [ListItemController::class, 'store'])->name('list-items.store');
+    Route::put('list-items/{listItem}', [ListItemController::class, 'update'])->name('list-items.update');
+    Route::delete('list-items/{listItem}', [ListItemController::class, 'destroy'])->name('list-items.destroy');
+    Route::post('list-items/{listItem}/toggle', [ListItemController::class, 'toggle'])->name('list-items.toggle');
+    Route::post('list-items/reorder', [ListItemController::class, 'reorder'])->name('list-items.reorder');
 
     // Reminders
     Route::resource('reminders', ReminderController::class);

--- a/tests/Feature/ListItemTest.php
+++ b/tests/Feature/ListItemTest.php
@@ -1,0 +1,156 @@
+<?php
+
+use App\Models\ListItem;
+use App\Models\TaskList;
+use App\Models\User;
+
+/**
+ * JSON (background XHR) CRUD + toggle + reorder for list items. Ownership is
+ * enforced through the parent list on every mutation.
+ */
+function makeList(User $user): TaskList
+{
+    return TaskList::create([
+        'user_id' => $user->id,
+        'name' => 'List '.uniqid(),
+        'color' => '#3B82F6',
+        'position' => 1,
+    ]);
+}
+
+it('stores an item and returns it as JSON', function () {
+    $user = User::factory()->create();
+    $list = makeList($user);
+
+    $response = $this->actingAs($user)
+        ->postJson(route('list-items.store'), [
+            'task_list_id' => $list->id,
+            'content' => 'Buy milk',
+        ]);
+
+    $response->assertOk()
+        ->assertJsonPath('item.content', 'Buy milk')
+        ->assertJsonPath('item.task_list_id', $list->id)
+        ->assertJsonPath('item.is_completed', false);
+
+    expect(ListItem::where('task_list_id', $list->id)->count())->toBe(1);
+});
+
+it('validates that content is required on store', function () {
+    $user = User::factory()->create();
+    $list = makeList($user);
+
+    $this->actingAs($user)
+        ->postJson(route('list-items.store'), [
+            'task_list_id' => $list->id,
+            'content' => '',
+        ])
+        ->assertJsonValidationErrors(['content']);
+});
+
+it('cannot add an item to another user\'s list', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $list = makeList($other);
+
+    $this->actingAs($user)
+        ->postJson(route('list-items.store'), [
+            'task_list_id' => $list->id,
+            'content' => 'Sneaky',
+        ])
+        ->assertStatus(500);
+
+    expect(ListItem::where('task_list_id', $list->id)->count())->toBe(0);
+});
+
+it('toggles completion and sets/clears completed_at', function () {
+    $user = User::factory()->create();
+    $list = makeList($user);
+    $item = ListItem::create(['task_list_id' => $list->id, 'content' => 'Task', 'position' => 1]);
+
+    $this->actingAs($user)
+        ->postJson(route('list-items.toggle', $item))
+        ->assertOk()
+        ->assertJsonPath('item.is_completed', true);
+
+    $item->refresh();
+    expect($item->is_completed)->toBeTrue()
+        ->and($item->completed_at)->not->toBeNull();
+
+    $this->actingAs($user)
+        ->postJson(route('list-items.toggle', $item))
+        ->assertOk()
+        ->assertJsonPath('item.is_completed', false);
+
+    $item->refresh();
+    expect($item->is_completed)->toBeFalse()
+        ->and($item->completed_at)->toBeNull();
+});
+
+it('updates an item', function () {
+    $user = User::factory()->create();
+    $list = makeList($user);
+    $item = ListItem::create(['task_list_id' => $list->id, 'content' => 'Old', 'position' => 1]);
+
+    $this->actingAs($user)
+        ->putJson(route('list-items.update', $item), [
+            'content' => 'Updated',
+            'is_completed' => true,
+        ])
+        ->assertOk()
+        ->assertJsonPath('item.content', 'Updated')
+        ->assertJsonPath('item.is_completed', true);
+
+    expect($item->fresh()->content)->toBe('Updated');
+});
+
+it('deletes an item', function () {
+    $user = User::factory()->create();
+    $list = makeList($user);
+    $item = ListItem::create(['task_list_id' => $list->id, 'content' => 'Bye', 'position' => 1]);
+
+    $this->actingAs($user)
+        ->deleteJson(route('list-items.destroy', $item))
+        ->assertOk()
+        ->assertJsonPath('deleted', true);
+
+    expect(ListItem::find($item->id))->toBeNull();
+});
+
+it('reorders items within a list', function () {
+    $user = User::factory()->create();
+    $list = makeList($user);
+    $a = ListItem::create(['task_list_id' => $list->id, 'content' => 'A', 'position' => 1]);
+    $b = ListItem::create(['task_list_id' => $list->id, 'content' => 'B', 'position' => 2]);
+
+    $this->actingAs($user)
+        ->postJson(route('list-items.reorder'), ['itemIds' => [$b->id, $a->id]])
+        ->assertOk();
+
+    expect($b->fresh()->position)->toBe(1)
+        ->and($a->fresh()->position)->toBe(2);
+});
+
+it('enforces ownership on update, delete, and toggle', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $list = makeList($other);
+    $item = ListItem::create(['task_list_id' => $list->id, 'content' => 'Theirs', 'position' => 1]);
+
+    $this->actingAs($user)
+        ->putJson(route('list-items.update', $item), ['content' => 'Hacked'])
+        ->assertStatus(500);
+
+    $this->actingAs($user)
+        ->postJson(route('list-items.toggle', $item))
+        ->assertStatus(500);
+
+    $this->actingAs($user)
+        ->deleteJson(route('list-items.destroy', $item))
+        ->assertStatus(500);
+
+    $item->refresh();
+    expect($item->content)->toBe('Theirs')
+        ->and($item->is_completed)->toBeFalse()
+        ->and(ListItem::find($item->id))->not->toBeNull();
+});

--- a/tests/Feature/TaskListAttachmentTest.php
+++ b/tests/Feature/TaskListAttachmentTest.php
@@ -1,0 +1,188 @@
+<?php
+
+use App\Models\Task;
+use App\Models\TaskList;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * The task <-> list many-to-many. Attaching happens both on task save (via the
+ * `lists` payload) and through the dedicated attach/detach endpoints. Both sides
+ * enforce ownership of the list and the task.
+ */
+function ownedList(User $user, string $name = 'List'): TaskList
+{
+    return TaskList::create([
+        'user_id' => $user->id,
+        'name' => $name.' '.uniqid(),
+        'color' => '#3B82F6',
+        'position' => 1,
+    ]);
+}
+
+it('writes pivot rows when a task is created with lists', function () {
+    $user = User::factory()->create();
+    $list = ownedList($user);
+
+    $this->actingAs($user)
+        ->from(route('tasks.index'))
+        ->post(route('tasks.store'), [
+            'title' => 'Task with list',
+            'priority' => 'medium',
+            'lists' => [$list->id],
+        ])
+        ->assertSessionHasNoErrors();
+
+    $task = Task::where('user_id', $user->id)->firstOrFail();
+
+    expect($task->lists)->toHaveCount(1)
+        ->and($task->lists->first()->id)->toBe($list->id);
+});
+
+it('detaches all lists when updating with an empty lists array', function () {
+    $user = User::factory()->create();
+    $list = ownedList($user);
+    $task = Task::create([
+        'user_id' => $user->id,
+        'title' => 'Task',
+        'priority' => 'medium',
+        'status' => 'pending',
+    ]);
+    $task->lists()->attach($list->id);
+
+    $this->actingAs($user)
+        ->from(route('tasks.index'))
+        ->put(route('tasks.update', $task), [
+            'title' => 'Task',
+            'priority' => 'medium',
+            'status' => 'pending',
+            'lists' => [],
+        ])
+        ->assertSessionHasNoErrors();
+
+    expect($task->fresh()->lists)->toHaveCount(0);
+});
+
+it('leaves attachments intact when updating without the lists key', function () {
+    $user = User::factory()->create();
+    $list = ownedList($user);
+    $task = Task::create([
+        'user_id' => $user->id,
+        'title' => 'Task',
+        'priority' => 'medium',
+        'status' => 'pending',
+    ]);
+    $task->lists()->attach($list->id);
+
+    $this->actingAs($user)
+        ->from(route('tasks.index'))
+        ->put(route('tasks.update', $task), [
+            'title' => 'Task renamed',
+            'priority' => 'medium',
+            'status' => 'pending',
+        ])
+        ->assertSessionHasNoErrors();
+
+    expect($task->fresh()->lists)->toHaveCount(1);
+});
+
+it('supports a task in many lists and a list with many tasks', function () {
+    $user = User::factory()->create();
+    $listA = ownedList($user, 'A');
+    $listB = ownedList($user, 'B');
+
+    $task1 = Task::create(['user_id' => $user->id, 'title' => 'T1', 'priority' => 'medium', 'status' => 'pending']);
+    $task2 = Task::create(['user_id' => $user->id, 'title' => 'T2', 'priority' => 'medium', 'status' => 'pending']);
+
+    $task1->lists()->attach([$listA->id, $listB->id]);
+    $listA->tasks()->attach($task2->id);
+
+    expect($task1->fresh()->lists)->toHaveCount(2)
+        ->and($listA->fresh()->tasks)->toHaveCount(2)
+        ->and($listB->fresh()->tasks)->toHaveCount(1);
+});
+
+it('rejects attaching another user\'s list id via the task payload', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $otherList = ownedList($other);
+
+    $this->actingAs($user)
+        ->from(route('tasks.index'))
+        ->post(route('tasks.store'), [
+            'title' => 'Task',
+            'priority' => 'medium',
+            'lists' => [$otherList->id],
+        ])
+        ->assertSessionHasErrors('lists.0');
+
+    expect(Task::where('user_id', $user->id)->count())->toBe(0);
+});
+
+it('attaches a task to a list via the endpoint and is idempotent', function () {
+    $user = User::factory()->create();
+    $list = ownedList($user);
+    $task = Task::create(['user_id' => $user->id, 'title' => 'T', 'priority' => 'medium', 'status' => 'pending']);
+
+    $this->actingAs($user)
+        ->from(route('lists.show', $list))
+        ->post(route('lists.tasks.attach', $list), ['task_id' => $task->id])
+        ->assertSessionHasNoErrors();
+
+    // Attaching again must not create a duplicate pivot row.
+    $this->actingAs($user)
+        ->from(route('lists.show', $list))
+        ->post(route('lists.tasks.attach', $list), ['task_id' => $task->id])
+        ->assertSessionHasNoErrors();
+
+    expect(DB::table('list_task')->where('task_list_id', $list->id)->where('task_id', $task->id)->count())->toBe(1);
+});
+
+it('blocks attaching when the user does not own the list', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $otherList = ownedList($other);
+    $task = Task::create(['user_id' => $user->id, 'title' => 'T', 'priority' => 'medium', 'status' => 'pending']);
+
+    $this->actingAs($user)
+        ->post(route('lists.tasks.attach', $otherList), ['task_id' => $task->id])
+        ->assertForbidden();
+
+    expect(DB::table('list_task')->where('task_list_id', $otherList->id)->count())->toBe(0);
+});
+
+it('blocks attaching another user\'s task to your own list', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $list = ownedList($user);
+    $otherTask = Task::create(['user_id' => $other->id, 'title' => 'T', 'priority' => 'medium', 'status' => 'pending']);
+
+    $this->actingAs($user)
+        ->post(route('lists.tasks.attach', $list), ['task_id' => $otherTask->id])
+        ->assertForbidden();
+
+    expect(DB::table('list_task')->where('task_list_id', $list->id)->count())->toBe(0);
+});
+
+it('detaches a task via the endpoint and enforces ownership', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $list = ownedList($user);
+    $task = Task::create(['user_id' => $user->id, 'title' => 'T', 'priority' => 'medium', 'status' => 'pending']);
+    $list->tasks()->attach($task->id);
+
+    // A different user cannot detach.
+    $this->actingAs($other)
+        ->delete(route('lists.tasks.detach', [$list, $task]))
+        ->assertForbidden();
+
+    expect(DB::table('list_task')->where('task_list_id', $list->id)->count())->toBe(1);
+
+    // The owner can.
+    $this->actingAs($user)
+        ->from(route('lists.show', $list))
+        ->delete(route('lists.tasks.detach', [$list, $task]))
+        ->assertSessionHasNoErrors();
+
+    expect(DB::table('list_task')->where('task_list_id', $list->id)->count())->toBe(0);
+});

--- a/tests/Feature/TaskListTest.php
+++ b/tests/Feature/TaskListTest.php
@@ -1,0 +1,181 @@
+<?php
+
+use App\Models\ListItem;
+use App\Models\Task;
+use App\Models\TaskList;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia;
+
+/**
+ * Web (Inertia/redirect) CRUD for user-owned task lists. Names are encrypted at
+ * rest, uniqueness is enforced per-user in PHP, and deleting a list cascades its
+ * items and pivot rows while leaving attached tasks intact.
+ */
+it('redirects a guest away from the lists index', function () {
+    $this->get(route('lists.index'))->assertRedirect(route('login'));
+});
+
+it('shows only the current user\'s lists on the index', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+
+    TaskList::create(['user_id' => $user->id, 'name' => 'Mine', 'color' => '#3B82F6', 'position' => 1]);
+    TaskList::create(['user_id' => $other->id, 'name' => 'Theirs', 'color' => '#EF4444', 'position' => 1]);
+
+    $this->actingAs($user)
+        ->get(route('lists.index'))
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('Lists/Index')
+            ->has('lists', 1)
+            ->where('lists.0.name', 'Mine'));
+});
+
+it('creates a list and round-trips the encrypted name', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)
+        ->from(route('lists.index'))
+        ->post(route('lists.store'), [
+            'name' => 'Grocery List',
+            'color' => '#10B981',
+            'description' => 'Weekly shop',
+        ]);
+
+    $response->assertRedirect(route('lists.index'));
+    $response->assertSessionHasNoErrors();
+
+    $list = TaskList::where('user_id', $user->id)->firstOrFail();
+
+    expect($list->name)->toBe('Grocery List')
+        ->and($list->description)->toBe('Weekly shop')
+        ->and($list->color)->toBe('#10B981');
+
+    // Stored ciphertext must not equal the plaintext.
+    $raw = \Illuminate\Support\Facades\DB::table('task_lists')->where('id', $list->id)->value('name');
+    expect($raw)->not->toBe('Grocery List');
+});
+
+it('rejects a duplicate list name for the same user', function () {
+    $user = User::factory()->create();
+
+    TaskList::create(['user_id' => $user->id, 'name' => 'Groceries', 'color' => '#10B981', 'position' => 1]);
+
+    $response = $this->actingAs($user)
+        ->from(route('lists.index'))
+        ->post(route('lists.store'), [
+            'name' => 'Groceries',
+            'color' => '#3B82F6',
+        ]);
+
+    $response->assertSessionHasErrors('error');
+    expect(TaskList::where('user_id', $user->id)->count())->toBe(1);
+});
+
+it('allows the same list name across different users', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+
+    TaskList::create(['user_id' => $other->id, 'name' => 'Groceries', 'color' => '#10B981', 'position' => 1]);
+
+    $response = $this->actingAs($user)
+        ->from(route('lists.index'))
+        ->post(route('lists.store'), [
+            'name' => 'Groceries',
+            'color' => '#3B82F6',
+        ]);
+
+    $response->assertSessionHasNoErrors();
+    expect(TaskList::where('user_id', $user->id)->count())->toBe(1);
+});
+
+it('validates a missing name and a bad color on store', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->from(route('lists.index'))
+        ->post(route('lists.store'), ['color' => '#10B981'])
+        ->assertSessionHasErrors('name');
+
+    $this->actingAs($user)
+        ->from(route('lists.index'))
+        ->post(route('lists.store'), ['name' => 'Valid', 'color' => 'blue'])
+        ->assertSessionHasErrors('color');
+});
+
+it('updates an owned list', function () {
+    $user = User::factory()->create();
+    $list = TaskList::create(['user_id' => $user->id, 'name' => 'Old', 'color' => '#10B981', 'position' => 1]);
+
+    $response = $this->actingAs($user)
+        ->from(route('lists.index'))
+        ->put(route('lists.update', $list), [
+            'name' => 'New',
+            'color' => '#3B82F6',
+        ]);
+
+    $response->assertRedirect(route('lists.index'));
+    $response->assertSessionHasNoErrors();
+
+    expect($list->fresh()->name)->toBe('New');
+});
+
+it('blocks updating another user\'s list', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $list = TaskList::create(['user_id' => $other->id, 'name' => 'Theirs', 'color' => '#10B981', 'position' => 1]);
+
+    $this->actingAs($user)
+        ->from(route('lists.index'))
+        ->put(route('lists.update', $list), ['name' => 'Hacked', 'color' => '#3B82F6'])
+        ->assertSessionHasErrors('error');
+
+    expect($list->fresh()->name)->toBe('Theirs');
+});
+
+it('deletes an owned list and cascades its items and pivot rows', function () {
+    $user = User::factory()->create();
+    $list = TaskList::create(['user_id' => $user->id, 'name' => 'Doomed', 'color' => '#10B981', 'position' => 1]);
+    $item = ListItem::create(['task_list_id' => $list->id, 'content' => 'Item', 'position' => 1]);
+
+    $task = Task::create([
+        'user_id' => $user->id,
+        'title' => 'Attached',
+        'priority' => 'medium',
+        'status' => 'pending',
+    ]);
+    $list->tasks()->attach($task->id);
+
+    $this->actingAs($user)
+        ->from(route('lists.index'))
+        ->delete(route('lists.destroy', $list))
+        ->assertRedirect(route('lists.index'));
+
+    expect(TaskList::find($list->id))->toBeNull()
+        ->and(ListItem::find($item->id))->toBeNull()
+        ->and(\Illuminate\Support\Facades\DB::table('list_task')->where('task_list_id', $list->id)->count())->toBe(0)
+        // The task itself survives.
+        ->and(Task::find($task->id))->not->toBeNull();
+});
+
+it('blocks deleting another user\'s list', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $list = TaskList::create(['user_id' => $other->id, 'name' => 'Theirs', 'color' => '#10B981', 'position' => 1]);
+
+    $this->actingAs($user)
+        ->from(route('lists.index'))
+        ->delete(route('lists.destroy', $list))
+        ->assertSessionHasErrors('error');
+
+    expect(TaskList::find($list->id))->not->toBeNull();
+});
+
+it('returns 404 when showing a list that is not owned', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $list = TaskList::create(['user_id' => $other->id, 'name' => 'Theirs', 'color' => '#10B981', 'position' => 1]);
+
+    $this->actingAs($user)
+        ->get(route('lists.show', $list))
+        ->assertNotFound();
+});


### PR DESCRIPTION
Adds a user-owned **List** (model `TaskList`) that holds simple checkable items and groups full tasks, attachable to any task many-to-many via a single `list_task` pivot. Lists are managed on a dedicated Lists page under the Tasks nav (create/edit/show like Categories) and attachable from the task create/edit modals, with list chips and an "Open list" action surfaced on task cards and the view modal. The implementation mirrors existing Category (CRUD), Tag (pivot), and Subtask (`ListItemManager` with optimistic updates) patterns, and spans three migrations, repository/service layers, JSON item endpoints, and seeder demo data. Item content and list names are encrypted at rest, consistent with the rest of the app. Covered by 28 new Pest tests (CRUD, ownership, encrypted-name uniqueness, and attach/detach round-trips), with Pint clean and `npm run build` passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)