### PR TITLE
Fix mobile UI: precise screen fit + declutter task list

### DIFF
--- a/ios/App/App/capacitor.config.json
+++ b/ios/App/App/capacitor.config.json
@@ -9,5 +9,7 @@
 	"ios": {
 		"contentInset": "automatic"
 	},
-	"packageClassList": []
+	"packageClassList": [
+		"StatusBarPlugin"
+	]
 }

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -11,14 +11,16 @@ let package = Package(
             targets: ["CapApp-SPM"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.5.0")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.5.0"),
+        .package(name: "CapacitorStatusBar", path: "../../../node_modules/@capacitor/status-bar")
     ],
     targets: [
         .target(
             name: "CapApp-SPM",
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
-                .product(name: "Cordova", package: "capacitor-swift-pm")
+                .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "CapacitorStatusBar", package: "CapacitorStatusBar")
             ]
         )
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "tegucigalpa",
+    "name": "washington",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -7,6 +7,7 @@
             "dependencies": {
                 "@capacitor/core": "^8.5.0",
                 "@capacitor/ios": "^8.5.0",
+                "@capacitor/status-bar": "^8.0.3",
                 "@dnd-kit/core": "^6.3.1",
                 "@dnd-kit/sortable": "^10.0.0",
                 "@dnd-kit/utilities": "^3.2.2",
@@ -1743,6 +1744,15 @@
             "license": "MIT",
             "peerDependencies": {
                 "@capacitor/core": "^8.5.0"
+            }
+        },
+        "node_modules/@capacitor/status-bar": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-8.0.3.tgz",
+            "integrity": "sha512-csSpfNeN49Hx9JaQBSJEIiEbOLtXg3kcc2IpScq2fu5L520h3AWEvsxoH8Srk1jxfRKepaJ4S4sqSC3foI4AgA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@capacitor/core": ">=8.0.0"
             }
         },
         "node_modules/@dnd-kit/accessibility": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "dependencies": {
         "@capacitor/core": "^8.5.0",
         "@capacitor/ios": "^8.5.0",
+        "@capacitor/status-bar": "^8.0.3",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",

--- a/resources/js/Components/Finance/Transactions/TransactionCard.jsx
+++ b/resources/js/Components/Finance/Transactions/TransactionCard.jsx
@@ -61,14 +61,14 @@ export default function TransactionCard({ transaction, onEdit, onDelete }) {
 
             <dl className="mt-3 space-y-1 text-xs text-light-muted dark:text-dark-muted">
                 <div className="flex justify-between gap-2">
-                    <dt>Category</dt>
-                    <dd className="truncate text-right text-light-secondary dark:text-dark-secondary">
+                    <dt className="shrink-0">Category</dt>
+                    <dd className="min-w-0 truncate text-right text-light-secondary dark:text-dark-secondary">
                         {transaction.category?.name ?? "Uncategorized"}
                     </dd>
                 </div>
                 <div className="flex justify-between gap-2">
-                    <dt>Account</dt>
-                    <dd className="truncate text-right text-light-secondary dark:text-dark-secondary">
+                    <dt className="shrink-0">Account</dt>
+                    <dd className="min-w-0 truncate text-right text-light-secondary dark:text-dark-secondary">
                         {accountLabel(transaction)}
                     </dd>
                 </div>
@@ -82,8 +82,8 @@ export default function TransactionCard({ transaction, onEdit, onDelete }) {
                 )}
                 {transaction.created_by && transaction.created_by.id !== transaction.user_id && (
                     <div className="flex justify-between gap-2">
-                        <dt>Added by</dt>
-                        <dd className="truncate text-right text-light-secondary dark:text-dark-secondary">
+                        <dt className="shrink-0">Added by</dt>
+                        <dd className="min-w-0 truncate text-right text-light-secondary dark:text-dark-secondary">
                             {transaction.created_by.name}
                         </dd>
                     </div>

--- a/resources/js/Layouts/TodoLayout.jsx
+++ b/resources/js/Layouts/TodoLayout.jsx
@@ -234,7 +234,7 @@ export default function TodoLayout({ header, children }) {
     ];
 
     return (
-        <div className={`min-h-screen bg-light-primary dark:bg-dark-primary lg:flex`}>
+        <div className={`min-h-[100dvh] bg-light-primary dark:bg-dark-primary lg:flex`}>
             {/* Mobile sidebar overlay */}
             {sidebarOpen && (
                 <div className="fixed inset-0 z-50 lg:hidden">
@@ -904,9 +904,9 @@ export default function TodoLayout({ header, children }) {
                 </div>
             </aside>
             {/* Main Content Area */}
-            <div className="flex-1 flex flex-col min-h-screen w-full lg:ml-64">
+            <div className="flex-1 flex flex-col min-h-[100dvh] w-full lg:ml-64">
                 {/* Top Navigation Bar */}
-                <header className="sticky top-0 z-10 bg-light-secondary dark:bg-dark-secondary border-b border-light-border dark:border-dark-border">
+                <header className="sticky top-0 z-10 bg-light-secondary dark:bg-dark-secondary border-b border-light-border dark:border-dark-border pt-[env(safe-area-inset-top)] pl-[env(safe-area-inset-left)] pr-[env(safe-area-inset-right)]">
                     <div className="flex items-center justify-between min-h-14 h-auto py-3 sm:h-16 sm:py-0 px-2 sm:px-6 lg:px-8">
                         <div className="flex items-center">
                             <button
@@ -955,7 +955,7 @@ export default function TodoLayout({ header, children }) {
                     </div>
                 </header>
                 {/* Page Content */}
-                <main className="flex-1 p-6 pb-28 lg:pb-6">
+                <main className="flex-1 overflow-x-hidden p-6 pb-28 lg:pb-6">
                     <div className="mx-auto w-full max-w-7xl">{children}</div>
                 </main>
             </div>

--- a/resources/js/Pages/Tasks/Index.jsx
+++ b/resources/js/Pages/Tasks/Index.jsx
@@ -104,6 +104,49 @@ function SortableTask({
         }
     };
 
+    const actionItems = [
+        {
+            label: "Add subtask",
+            icon: ListTodo,
+            onClick: () => {
+                setSelectedTask(task);
+                setShowSubtaskModal(true);
+            },
+        },
+        {
+            label: "View",
+            icon: Eye,
+            onClick: () => {
+                setSelectedTask(task);
+                setShowViewModal(true);
+            },
+        },
+        {
+            label: "Edit",
+            icon: Edit,
+            onClick: () => {
+                setSelectedTask(task);
+                setShowEditModal(true);
+            },
+        },
+        ...(task.lists && task.lists.length > 0
+            ? [
+                  {
+                      label: "Open list",
+                      icon: List,
+                      onClick: () =>
+                          router.visit(route("lists.show", task.lists[0].id)),
+                  },
+              ]
+            : []),
+        {
+            label: "Delete",
+            icon: Trash2,
+            danger: true,
+            onClick: () => handleDeleteTask(task),
+        },
+    ];
+
     return (
         <div
             ref={setNodeRef}
@@ -164,6 +207,11 @@ function SortableTask({
                             </p>
                         )}
                     </div>
+
+                    {/* Actions (mobile: pinned to the title row so it never wraps) */}
+                    <div className="flex-shrink-0 sm:hidden">
+                        <TaskActionsMenu items={actionItems} />
+                    </div>
                 </div>
 
                 {/* Category */}
@@ -174,8 +222,9 @@ function SortableTask({
                             style={{
                                 backgroundColor: task.category?.color || "#6B7280",
                             }}
+                            title={task.category?.name || "Uncategorized"}
                         />
-                        <span className="text-xs text-light-secondary dark:text-dark-secondary truncate max-w-24">
+                        <span className="hidden sm:inline text-xs text-light-secondary dark:text-dark-secondary truncate max-w-24">
                             {task.category?.name || "Uncategorized"}
                         </span>
                     </div>
@@ -312,57 +361,9 @@ function SortableTask({
                         </div>
                     )}
 
-                    {/* Actions */}
-                    <div className="opacity-100 transition-opacity focus-within:opacity-100 sm:opacity-0 sm:group-hover:opacity-100">
-                        <TaskActionsMenu
-                            items={[
-                                {
-                                    label: "Add subtask",
-                                    icon: ListTodo,
-                                    onClick: () => {
-                                        setSelectedTask(task);
-                                        setShowSubtaskModal(true);
-                                    },
-                                },
-                                {
-                                    label: "View",
-                                    icon: Eye,
-                                    onClick: () => {
-                                        setSelectedTask(task);
-                                        setShowViewModal(true);
-                                    },
-                                },
-                                {
-                                    label: "Edit",
-                                    icon: Edit,
-                                    onClick: () => {
-                                        setSelectedTask(task);
-                                        setShowEditModal(true);
-                                    },
-                                },
-                                ...(task.lists && task.lists.length > 0
-                                    ? [
-                                          {
-                                              label: "Open list",
-                                              icon: List,
-                                              onClick: () =>
-                                                  router.visit(
-                                                      route(
-                                                          "lists.show",
-                                                          task.lists[0].id
-                                                      )
-                                                  ),
-                                          },
-                                      ]
-                                    : []),
-                                {
-                                    label: "Delete",
-                                    icon: Trash2,
-                                    danger: true,
-                                    onClick: () => handleDeleteTask(task),
-                                },
-                            ]}
-                        />
+                    {/* Actions (desktop: hover-reveal at the end of the meta row) */}
+                    <div className="hidden opacity-100 transition-opacity focus-within:opacity-100 sm:block sm:opacity-0 sm:group-hover:opacity-100">
+                        <TaskActionsMenu items={actionItems} />
                     </div>
                 </div>
             </div>

--- a/resources/js/app.jsx
+++ b/resources/js/app.jsx
@@ -7,8 +7,12 @@ import { createRoot } from "react-dom/client";
 import { PomodoroProvider } from "./Components/Pomodoro";
 import NavigationLoader from "./Components/NavigationLoader";
 import { registerSW } from "virtual:pwa-register";
+import { initStatusBar } from "./native/statusBar";
 
 const appName = import.meta.env.VITE_APP_NAME || "Wevie";
+
+// Native shell (iOS/Capacitor): overlay the status bar so the safe-area inset resolves.
+initStatusBar();
 
 createInertiaApp({
     title: (title) => `${title} - ${appName}`,

--- a/resources/js/native/statusBar.js
+++ b/resources/js/native/statusBar.js
@@ -1,0 +1,36 @@
+import { Capacitor } from "@capacitor/core";
+import { StatusBar, Style } from "@capacitor/status-bar";
+
+/**
+ * Configure the native iOS/Android status bar so it overlays the web view.
+ *
+ * The web layout already reserves the notch/status-bar space via
+ * `env(safe-area-inset-top)` (see TodoLayout's header) — for that inset to be
+ * non-zero the status bar must sit *on top of* the web content rather than
+ * pushing it down. We also keep the status-bar text legible by matching its
+ * style to the app's dark-mode class (`<html class="dark">`).
+ *
+ * No-ops on the web (non-native) build, so it is safe to call unconditionally.
+ */
+export function initStatusBar() {
+    if (!Capacitor.isNativePlatform()) {
+        return;
+    }
+
+    const applyStyle = () => {
+        const isDark = document.documentElement.classList.contains("dark");
+        // Style.Dark => dark icons/text for light backgrounds; Style.Light => light text for dark backgrounds.
+        StatusBar.setStyle({ style: isDark ? Style.Light : Style.Dark }).catch(() => {});
+    };
+
+    // Overlay so the web content extends under the status bar and the safe-area inset resolves.
+    StatusBar.setOverlaysWebView({ overlay: true }).catch(() => {});
+    applyStyle();
+
+    // Follow the dark-mode toggle (TodoLayout flips the `dark` class on <html>).
+    const observer = new MutationObserver(applyStyle);
+    observer.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["class"],
+    });
+}

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -2,7 +2,7 @@
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
     <head>
         <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 
         <title inertia>{{ config('app.name', 'Laravel') }}</title>
 


### PR DESCRIPTION
Fixes mobile pages that overflowed the phone screen (extra horizontal and vertical scroll, title hidden under the status bar) and declutters the task list.

- **Fit the screen (all pages):** added `viewport-fit=cover` and header safe-area insets so content clears the notch, switched `min-h-screen` to `min-h-[100dvh]`, and added `overflow-x-hidden` to `<main>` to kill phantom scroll.
- **WevieWallet overflow:** the transaction cards' Category/Account values now truncate instead of pushing the card and amount off-screen (`min-w-0` / `shrink-0`).
- **Task list declutter:** the actions menu is pinned to the title row so nothing wraps, and category shows as a colored dot on mobile (name returns on `sm+`), keeping the inline status dropdown.
- **Native iOS:** wired up `@capacitor/status-bar` to overlay the web view and follow dark mode so the top safe-area inset resolves natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)