### PR TITLE
Fix & improve mobile UI for the WevieWallet (Finance) module

### DIFF
--- a/ios/App/App/capacitor.config.json
+++ b/ios/App/App/capacitor.config.json
@@ -9,5 +9,7 @@
 	"ios": {
 		"contentInset": "automatic"
 	},
-	"packageClassList": []
+	"packageClassList": [
+		"StatusBarPlugin"
+	]
 }

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -11,14 +11,16 @@ let package = Package(
             targets: ["CapApp-SPM"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.5.0")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.5.0"),
+        .package(name: "CapacitorStatusBar", path: "../../../node_modules/@capacitor/status-bar")
     ],
     targets: [
         .target(
             name: "CapApp-SPM",
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
-                .product(name: "Cordova", package: "capacitor-swift-pm")
+                .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "CapacitorStatusBar", package: "CapacitorStatusBar")
             ]
         )
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "tegucigalpa",
+    "name": "washington",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -7,6 +7,7 @@
             "dependencies": {
                 "@capacitor/core": "^8.5.0",
                 "@capacitor/ios": "^8.5.0",
+                "@capacitor/status-bar": "^8.0.3",
                 "@dnd-kit/core": "^6.3.1",
                 "@dnd-kit/sortable": "^10.0.0",
                 "@dnd-kit/utilities": "^3.2.2",
@@ -1743,6 +1744,15 @@
             "license": "MIT",
             "peerDependencies": {
                 "@capacitor/core": "^8.5.0"
+            }
+        },
+        "node_modules/@capacitor/status-bar": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-8.0.3.tgz",
+            "integrity": "sha512-csSpfNeN49Hx9JaQBSJEIiEbOLtXg3kcc2IpScq2fu5L520h3AWEvsxoH8Srk1jxfRKepaJ4S4sqSC3foI4AgA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@capacitor/core": ">=8.0.0"
             }
         },
         "node_modules/@dnd-kit/accessibility": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "dependencies": {
         "@capacitor/core": "^8.5.0",
         "@capacitor/ios": "^8.5.0",
+        "@capacitor/status-bar": "^8.0.3",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",

--- a/resources/js/Components/Finance/Categories/CategoryList.jsx
+++ b/resources/js/Components/Finance/Categories/CategoryList.jsx
@@ -63,23 +63,23 @@ export default function CategoryList({
 
     return (
         <div className="card p-4">
-            <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-100">
+            <h3 className="text-lg font-semibold text-light-primary dark:text-dark-primary">
                 Finance categories
             </h3>
             <div className="mt-4 space-y-3">
                 {categories.map((category) => (
                     <div
                         key={category.id}
-                        className="rounded-lg border border-light-border/70 px-3 py-2 text-sm text-slate-600 dark:border-white/10 dark:text-slate-300"
+                        className="rounded-lg border border-light-border/70 px-3 py-2 text-sm text-light-secondary dark:border-dark-border/70 dark:text-dark-secondary"
                     >
                         <div className="flex flex-wrap items-center justify-between gap-3">
-                            <div className="flex items-center gap-3">
+                            <div className="flex min-w-0 items-center gap-3">
                                 <span
-                                    className="h-3 w-3 rounded-full"
+                                    className="h-3 w-3 shrink-0 rounded-full"
                                     style={{ backgroundColor: category.color }}
                                 />
                                 {category.icon && (
-                                    <span className="flex h-8 w-8 items-center justify-center rounded-md bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-200">
+                                    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-light-hover text-light-secondary dark:bg-dark-hover dark:text-dark-secondary">
                                         {iconMap[category.icon] ? (
                                             (() => {
                                                 const Icon = iconMap[category.icon];
@@ -92,20 +92,20 @@ export default function CategoryList({
                                         )}
                                     </span>
                                 )}
-                                <div>
-                                    <p className="font-medium text-slate-800 dark:text-slate-100">
+                                <div className="min-w-0">
+                                    <p className="truncate font-medium text-light-primary dark:text-dark-primary">
                                         {category.name}
                                     </p>
-                                    <p className="text-xs text-slate-400">
+                                    <p className="text-xs capitalize text-light-muted dark:text-dark-muted">
                                         {category.type}
                                     </p>
                                 </div>
                             </div>
-                            <div className="flex items-center gap-3">
+                            <div className="flex shrink-0 items-center gap-2">
                                 <button
                                     type="button"
                                     onClick={() => startEdit(category)}
-                                    className="rounded-md p-1 text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
+                                    className="rounded-md p-2 text-wevie-teal hover:text-wevie-teal/80 dark:text-wevie-mint dark:hover:text-wevie-mint/80"
                                     title="Edit"
                                     aria-label="Edit"
                                 >
@@ -114,7 +114,7 @@ export default function CategoryList({
                                 <button
                                     type="button"
                                     onClick={() => onDelete?.(category)}
-                                    className="rounded-md p-1 text-rose-600 hover:text-rose-700 dark:text-rose-400 dark:hover:text-rose-300"
+                                    className="rounded-md p-2 text-rose-600 hover:text-rose-700 dark:text-rose-400 dark:hover:text-rose-300"
                                     title="Delete"
                                     aria-label="Delete"
                                 >
@@ -126,21 +126,21 @@ export default function CategoryList({
                         {editingId === category.id && (
                             <div className="mt-3 grid gap-3 sm:grid-cols-2">
                                 <div>
-                                    <label className="text-xs text-slate-500 dark:text-slate-400">
+                                    <label className="text-xs text-light-muted dark:text-dark-muted">
                                         Name
                                     </label>
                                     <input
-                                        className="mt-1 w-full rounded-md border border-slate-300 px-2 py-1 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-800"
+                                        className="mt-1 w-full rounded-md border border-light-border px-2 py-1 text-sm text-light-primary focus:border-wevie-teal focus:outline-none focus:ring-1 focus:ring-wevie-teal dark:border-dark-border dark:bg-dark-hover dark:text-dark-primary"
                                         value={draft.name}
                                         onChange={updateField("name")}
                                     />
                                 </div>
                                 <div>
-                                    <label className="text-xs text-slate-500 dark:text-slate-400">
+                                    <label className="text-xs text-light-muted dark:text-dark-muted">
                                         Type
                                     </label>
                                     <select
-                                        className="mt-1 w-full rounded-md border border-slate-300 px-2 py-1 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-800"
+                                        className="mt-1 w-full rounded-md border border-light-border px-2 py-1 text-sm text-light-primary focus:border-wevie-teal focus:outline-none focus:ring-1 focus:ring-wevie-teal dark:border-dark-border dark:bg-dark-hover dark:text-dark-primary"
                                         value={draft.type}
                                         onChange={updateField("type")}
                                     >
@@ -151,12 +151,12 @@ export default function CategoryList({
                                     </select>
                                 </div>
                                 <div>
-                                    <label className="text-xs text-slate-500 dark:text-slate-400">
+                                    <label className="text-xs text-light-muted dark:text-dark-muted">
                                         Color
                                     </label>
                                     <input
                                         type="color"
-                                        className="mt-1 h-9 w-full rounded-md border border-slate-300 p-1 dark:border-slate-600 dark:bg-slate-800"
+                                        className="mt-1 h-9 w-full rounded-md border border-light-border p-1 dark:border-dark-border dark:bg-dark-hover"
                                         value={draft.color}
                                         onChange={updateField("color")}
                                     />
@@ -176,14 +176,14 @@ export default function CategoryList({
                                     <button
                                         type="button"
                                         onClick={cancelEdit}
-                                        className="rounded-md border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 hover:border-slate-300 hover:text-slate-700 dark:border-slate-700 dark:text-slate-300 dark:hover:text-slate-100"
+                                        className="rounded-md border border-light-border px-3 py-1 text-xs font-semibold text-light-secondary hover:text-light-primary dark:border-dark-border dark:text-dark-secondary dark:hover:text-dark-primary"
                                     >
                                         Cancel
                                     </button>
                                     <button
                                         type="button"
                                         onClick={() => saveEdit(category)}
-                                        className="rounded-md bg-indigo-600 px-3 py-1 text-xs font-semibold text-white hover:bg-indigo-500"
+                                        className="rounded-md bg-wevie-teal px-3 py-1 text-xs font-semibold text-white hover:bg-wevie-teal/90"
                                     >
                                         Save
                                     </button>
@@ -193,7 +193,7 @@ export default function CategoryList({
                     </div>
                 ))}
                 {(!categories || categories.length === 0) && (
-                    <p className="text-sm text-slate-400 dark:text-slate-500">
+                    <p className="text-sm text-light-muted dark:text-dark-muted">
                         No finance categories yet.
                     </p>
                 )}

--- a/resources/js/Components/Finance/Dashboard/FinanceDashboard.jsx
+++ b/resources/js/Components/Finance/Dashboard/FinanceDashboard.jsx
@@ -223,25 +223,23 @@ export default function FinanceDashboard({
                                     key={budget.id}
                                     className="rounded-xl border border-light-border/70 px-3 py-2 dark:border-dark-border/70"
                                 >
-                                    <div className="flex items-center justify-between">
-                                        <div>
-                                            <p className="font-medium text-light-primary dark:text-dark-primary">
+                                    <div className="flex items-start justify-between gap-3">
+                                        <div className="min-w-0">
+                                            <p className="truncate font-medium text-light-primary dark:text-dark-primary">
                                                 {budget.name}
                                             </p>
-                                            <p className="text-xs text-light-muted dark:text-dark-muted">
-                                                {budget.category?.name ?? "All categories"}
+                                            <p className="truncate text-xs text-light-muted dark:text-dark-muted">
+                                                {[
+                                                    budget.category?.name ?? "All categories",
+                                                    budget.budget_type === "saved" ? "Saved" : null,
+                                                    budget.account?.name
+                                                        ? `Account: ${budget.account.name}`
+                                                        : null,
+                                                ]
+                                                    .filter(Boolean)
+                                                    .join(" · ")}
                                             </p>
-                                            {budget.budget_type === "saved" && (
-                                                <p className="text-xs text-light-muted dark:text-dark-muted">
-                                                    Saved budget
-                                                </p>
-                                            )}
-                                            {budget.account?.name && (
-                                                <p className="text-xs text-light-muted dark:text-dark-muted">
-                                                    Account: {budget.account.name}
-                                                </p>
-                                            )}
-                                            <div className="mt-2 flex items-center gap-2">
+                                            <div className="mt-2 flex items-center gap-1">
                                                 <button
                                                     type="button"
                                                     onClick={() =>
@@ -251,7 +249,7 @@ export default function FinanceDashboard({
                                                             data: budget,
                                                         })
                                                     }
-                                                    className="rounded-md p-1 text-wevie-teal hover:text-wevie-teal/80"
+                                                    className="rounded-md p-2 text-wevie-teal hover:text-wevie-teal/80"
                                                     title="Edit"
                                                     aria-label="Edit"
                                                 >
@@ -261,7 +259,7 @@ export default function FinanceDashboard({
                                                     <button
                                                         type="button"
                                                         onClick={() => onViewBudget?.(budget)}
-                                                        className="rounded-md p-1 text-light-secondary hover:text-light-primary dark:text-dark-secondary dark:hover:text-dark-primary"
+                                                        className="rounded-md p-2 text-light-secondary hover:text-light-primary dark:text-dark-secondary dark:hover:text-dark-primary"
                                                         title="View"
                                                         aria-label="View"
                                                     >
@@ -271,7 +269,7 @@ export default function FinanceDashboard({
                                                 <button
                                                     type="button"
                                                     onClick={() => onDeleteBudget?.(budget)}
-                                                    className="rounded-md p-1 text-rose-600 hover:text-rose-700 dark:text-rose-300 dark:hover:text-rose-200"
+                                                    className="rounded-md p-2 text-rose-600 hover:text-rose-700 dark:text-rose-300 dark:hover:text-rose-200"
                                                     title="Remove"
                                                     aria-label="Remove"
                                                 >
@@ -279,7 +277,7 @@ export default function FinanceDashboard({
                                                 </button>
                                             </div>
                                         </div>
-                                        <div className="text-right text-sm">
+                                        <div className="shrink-0 text-right text-sm">
                                             <p className="font-semibold text-light-primary dark:text-dark-primary">
                                                 {formatCurrency(budget.amount, budget.currency)}
                                             </p>

--- a/resources/js/Components/Finance/Transactions/TransactionCard.jsx
+++ b/resources/js/Components/Finance/Transactions/TransactionCard.jsx
@@ -74,8 +74,8 @@ export default function TransactionCard({ transaction, onEdit, onDelete }) {
                 </div>
                 {transaction.is_recurring && transaction.recurring_frequency && (
                     <div className="flex justify-between gap-2">
-                        <dt>Repeats</dt>
-                        <dd className="text-right capitalize text-violet-500 dark:text-violet-300">
+                        <dt className="shrink-0">Repeats</dt>
+                        <dd className="min-w-0 truncate text-right capitalize text-violet-500 dark:text-violet-300">
                             {formatFrequency(transaction.recurring_frequency)}
                         </dd>
                     </div>

--- a/resources/js/Components/Finance/Transactions/TransactionCard.jsx
+++ b/resources/js/Components/Finance/Transactions/TransactionCard.jsx
@@ -61,14 +61,14 @@ export default function TransactionCard({ transaction, onEdit, onDelete }) {
 
             <dl className="mt-3 space-y-1 text-xs text-light-muted dark:text-dark-muted">
                 <div className="flex justify-between gap-2">
-                    <dt>Category</dt>
-                    <dd className="truncate text-right text-light-secondary dark:text-dark-secondary">
+                    <dt className="shrink-0">Category</dt>
+                    <dd className="min-w-0 truncate text-right text-light-secondary dark:text-dark-secondary">
                         {transaction.category?.name ?? "Uncategorized"}
                     </dd>
                 </div>
                 <div className="flex justify-between gap-2">
-                    <dt>Account</dt>
-                    <dd className="truncate text-right text-light-secondary dark:text-dark-secondary">
+                    <dt className="shrink-0">Account</dt>
+                    <dd className="min-w-0 truncate text-right text-light-secondary dark:text-dark-secondary">
                         {accountLabel(transaction)}
                     </dd>
                 </div>
@@ -82,8 +82,8 @@ export default function TransactionCard({ transaction, onEdit, onDelete }) {
                 )}
                 {transaction.created_by && transaction.created_by.id !== transaction.user_id && (
                     <div className="flex justify-between gap-2">
-                        <dt>Added by</dt>
-                        <dd className="truncate text-right text-light-secondary dark:text-dark-secondary">
+                        <dt className="shrink-0">Added by</dt>
+                        <dd className="min-w-0 truncate text-right text-light-secondary dark:text-dark-secondary">
                             {transaction.created_by.name}
                         </dd>
                     </div>

--- a/resources/js/Components/Finance/Transactions/TransactionsList.jsx
+++ b/resources/js/Components/Finance/Transactions/TransactionsList.jsx
@@ -147,15 +147,15 @@ export default function TransactionsList({
 
     return (
         <div className="card p-4">
-            <div className="mb-4 flex items-center justify-between">
-                <h3 className="text-lg font-semibold text-light-primary dark:text-dark-primary">
+            <div className="mb-4 flex items-center justify-between gap-2">
+                <h3 className="min-w-0 truncate text-lg font-semibold text-light-primary dark:text-dark-primary">
                     Recent activity
                 </h3>
                 <button
                     type="button"
                     onClick={onViewAll}
                     disabled={isLoading}
-                    className="rounded-xl bg-gradient-to-r from-wevie-teal to-wevie-mint px-3 py-1.5 text-sm text-white shadow-soft hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-70"
+                    className="shrink-0 rounded-xl bg-gradient-to-r from-wevie-teal to-wevie-mint px-3 py-1.5 text-sm text-white shadow-soft hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-70"
                 >
                     {isLoading ? "Loading..." : "See all"}
                 </button>

--- a/resources/js/Layouts/TodoLayout.jsx
+++ b/resources/js/Layouts/TodoLayout.jsx
@@ -234,7 +234,7 @@ export default function TodoLayout({ header, children }) {
     ];
 
     return (
-        <div className={`min-h-screen bg-light-primary dark:bg-dark-primary lg:flex`}>
+        <div className={`min-h-[100dvh] bg-light-primary dark:bg-dark-primary lg:flex`}>
             {/* Mobile sidebar overlay */}
             {sidebarOpen && (
                 <div className="fixed inset-0 z-50 lg:hidden">
@@ -904,9 +904,9 @@ export default function TodoLayout({ header, children }) {
                 </div>
             </aside>
             {/* Main Content Area */}
-            <div className="flex-1 flex flex-col min-h-screen w-full lg:ml-64">
+            <div className="flex-1 flex flex-col min-h-[100dvh] w-full lg:ml-64">
                 {/* Top Navigation Bar */}
-                <header className="sticky top-0 z-10 bg-light-secondary dark:bg-dark-secondary border-b border-light-border dark:border-dark-border">
+                <header className="sticky top-0 z-10 bg-light-secondary dark:bg-dark-secondary border-b border-light-border dark:border-dark-border pt-[env(safe-area-inset-top)] pl-[env(safe-area-inset-left)] pr-[env(safe-area-inset-right)]">
                     <div className="flex items-center justify-between min-h-14 h-auto py-3 sm:h-16 sm:py-0 px-2 sm:px-6 lg:px-8">
                         <div className="flex items-center">
                             <button
@@ -955,7 +955,7 @@ export default function TodoLayout({ header, children }) {
                     </div>
                 </header>
                 {/* Page Content */}
-                <main className="flex-1 p-6 pb-28 lg:pb-6">
+                <main className="flex-1 overflow-x-hidden p-6 pb-28 lg:pb-6">
                     <div className="mx-auto w-full max-w-7xl">{children}</div>
                 </main>
             </div>

--- a/resources/js/Pages/Finance/Accounts.jsx
+++ b/resources/js/Pages/Finance/Accounts.jsx
@@ -92,7 +92,7 @@ export default function Accounts({
     return (
         <TodoLayout header="Accounts">
             <Head title="Accounts" />
-            <div className="mx-auto max-w-5xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
+            <div className="mx-auto max-w-5xl space-y-6">
                 <div className="card p-4">
                     <div className="flex flex-wrap items-center justify-between gap-3">
                         <div>

--- a/resources/js/Pages/Finance/Budgets.jsx
+++ b/resources/js/Pages/Finance/Budgets.jsx
@@ -4,6 +4,7 @@ import TodoLayout from "@/Layouts/TodoLayout";
 import OnboardingTour from "@/Components/OnboardingTour";
 import Badge from "@/Components/Finance/UI/Badge";
 import EmptyState from "@/Components/Finance/UI/EmptyState";
+import ResponsiveTable from "@/Components/Finance/UI/ResponsiveTable";
 import useWalletMutation from "@/Hooks/useWalletMutation";
 import { formatWholeCurrency, formatCurrency } from "@/Utils/currency";
 import { walletBudgetsSteps } from "@/tours";
@@ -279,10 +280,240 @@ export default function Budgets({
         setClosingBudget(null);
     }, [closeForm, closingBudget, mutate]);
 
+    const budgetMetrics = (budget) => {
+        const spent = Number(budget.current_spent ?? 0);
+        const total = Number(budget.amount ?? 0);
+        const remaining = Math.max(0, total - spent);
+        const progress =
+            total > 0
+                ? Math.min(100, Math.round((spent / total) * 100))
+                : 0;
+        const statusLabel = budget.is_active
+            ? "Active"
+            : remaining === 0
+              ? "Completed"
+              : "Closed";
+        const statusTone = budget.is_active
+            ? "success"
+            : remaining === 0
+              ? "neutral"
+              : "danger";
+        return { spent, total, remaining, progress, statusLabel, statusTone };
+    };
+
+    const rowActions = (budget) => (
+        <>
+            <button
+                type="button"
+                onClick={() => setActiveBudget(budget)}
+                className="rounded-md p-2 text-wevie-teal hover:text-wevie-teal/80 dark:text-wevie-mint"
+                title="Edit budget"
+                aria-label="Edit budget"
+            >
+                <Pencil className="h-4 w-4" />
+            </button>
+            <button
+                type="button"
+                onClick={() => handleViewTransactions(budget)}
+                className="rounded-md p-2 text-light-secondary hover:text-light-primary dark:text-dark-secondary dark:hover:text-dark-primary"
+                title="View transactions"
+                aria-label="View transactions"
+            >
+                <Eye className="h-4 w-4" />
+            </button>
+            <button
+                type="button"
+                onClick={() => handleOpenClose(budget)}
+                disabled={!budget.is_active}
+                className="rounded-md p-2 text-amber-600 hover:text-amber-700 disabled:cursor-not-allowed disabled:text-light-muted dark:text-amber-400 dark:hover:text-amber-300 dark:disabled:text-dark-muted"
+                title="Close budget"
+                aria-label="Close budget"
+            >
+                <Lock className="h-4 w-4" />
+            </button>
+            <button
+                type="button"
+                onClick={() => handleDelete(budget)}
+                className="rounded-md p-2 text-rose-600 hover:text-rose-700 dark:text-rose-300"
+                title="Delete budget"
+                aria-label="Delete budget"
+            >
+                <Trash2 className="h-4 w-4" />
+            </button>
+        </>
+    );
+
+    const columns = [
+        {
+            key: "name",
+            header: "Budget",
+            render: (budget) => (
+                <p className="font-medium text-light-primary dark:text-dark-primary">
+                    {budget.name}
+                </p>
+            ),
+        },
+        {
+            key: "budget_type",
+            header: "Type",
+            render: (budget) => (
+                <span className="text-xs capitalize text-light-muted dark:text-dark-muted">
+                    {budget.budget_type ?? "spending"}
+                </span>
+            ),
+        },
+        {
+            key: "category",
+            header: "Category",
+            render: (budget) => (
+                <span className="text-xs text-light-muted dark:text-dark-muted">
+                    {budget.category?.name ?? "All categories"}
+                </span>
+            ),
+        },
+        {
+            key: "account",
+            header: "Account",
+            render: (budget) => (
+                <span className="text-xs text-light-muted dark:text-dark-muted">
+                    {budget.account?.name ?? "—"}
+                </span>
+            ),
+        },
+        {
+            key: "status",
+            header: "Status",
+            className: "hidden md:table-cell",
+            cellClassName: "hidden md:table-cell",
+            render: (budget) => {
+                const { statusLabel, statusTone } = budgetMetrics(budget);
+                return <Badge label={statusLabel} tone={statusTone} />;
+            },
+        },
+        {
+            key: "progress",
+            header: "Progress",
+            className: "hidden md:table-cell",
+            cellClassName: "hidden min-w-[160px] md:table-cell",
+            render: (budget) => {
+                const { progress } = budgetMetrics(budget);
+                return (
+                    <div className="flex items-center gap-2">
+                        <span className="text-xs text-light-muted dark:text-dark-muted">
+                            {progress}%
+                        </span>
+                        <div className="h-2 w-full rounded-full bg-light-hover dark:bg-dark-hover">
+                            <div
+                                className="h-2 rounded-full bg-rose-500 dark:bg-rose-500/80"
+                                style={{ width: `${progress}%` }}
+                            />
+                        </div>
+                    </div>
+                );
+            },
+        },
+        {
+            key: "amount",
+            header: "Amount",
+            align: "right",
+            render: (budget) => (
+                <span className="font-semibold text-light-primary dark:text-dark-primary">
+                    {formatWholeCurrency(budget.amount, budget.currency)}
+                </span>
+            ),
+        },
+        {
+            key: "remaining",
+            header: "Remaining",
+            align: "right",
+            render: (budget) => {
+                const { remaining } = budgetMetrics(budget);
+                return (
+                    <span className="text-xs text-light-muted dark:text-dark-muted">
+                        {formatWholeCurrency(remaining, budget.currency)}
+                    </span>
+                );
+            },
+        },
+        {
+            key: "actions",
+            header: "Actions",
+            align: "right",
+            render: (budget) => (
+                <div className="flex flex-wrap items-center justify-end gap-2">
+                    {rowActions(budget)}
+                </div>
+            ),
+        },
+    ];
+
+    const renderCard = (budget) => {
+        const { remaining, progress, statusLabel, statusTone } =
+            budgetMetrics(budget);
+        return (
+            <div className="rounded-xl border border-light-border/70 p-4 dark:border-dark-border/70">
+                <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                        <p className="truncate font-medium text-light-primary dark:text-dark-primary">
+                            {budget.name}
+                        </p>
+                        <div className="mt-1 flex flex-wrap items-center gap-2">
+                            <Badge label={statusLabel} tone={statusTone} />
+                            <span className="text-xs capitalize text-light-muted dark:text-dark-muted">
+                                {budget.budget_type ?? "spending"}
+                            </span>
+                        </div>
+                    </div>
+                    <p className="shrink-0 text-right font-semibold text-light-primary dark:text-dark-primary">
+                        {formatWholeCurrency(budget.amount, budget.currency)}
+                    </p>
+                </div>
+
+                <dl className="mt-3 space-y-1 text-xs text-light-muted dark:text-dark-muted">
+                    <div className="flex justify-between gap-2">
+                        <dt className="shrink-0">Category</dt>
+                        <dd className="min-w-0 truncate text-right text-light-secondary dark:text-dark-secondary">
+                            {budget.category?.name ?? "All categories"}
+                        </dd>
+                    </div>
+                    <div className="flex justify-between gap-2">
+                        <dt className="shrink-0">Account</dt>
+                        <dd className="min-w-0 truncate text-right text-light-secondary dark:text-dark-secondary">
+                            {budget.account?.name ?? "—"}
+                        </dd>
+                    </div>
+                    <div className="flex justify-between gap-2">
+                        <dt className="shrink-0">Remaining</dt>
+                        <dd className="min-w-0 truncate text-right text-light-secondary dark:text-dark-secondary">
+                            {formatWholeCurrency(remaining, budget.currency)}
+                        </dd>
+                    </div>
+                </dl>
+
+                <div className="mt-3">
+                    <div className="mb-1 flex items-center justify-between gap-2 text-xs text-light-muted dark:text-dark-muted">
+                        <span>Progress</span>
+                        <span>{progress}%</span>
+                    </div>
+                    <div className="h-2 w-full rounded-full bg-light-hover dark:bg-dark-hover">
+                        <div
+                            className="h-2 rounded-full bg-rose-500 dark:bg-rose-500/80"
+                            style={{ width: `${progress}%` }}
+                        />
+                    </div>
+                </div>
+
+                <div className="mt-3 flex items-center justify-end gap-1 border-t border-light-border/50 pt-3 dark:border-dark-border/50">
+                    {rowActions(budget)}
+                </div>
+            </div>
+        );
+    };
+
     return (
         <TodoLayout header="Budgets">
             <Head title="Budgets" />
-            <div className="mx-auto max-w-5xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
+            <div className="mx-auto max-w-5xl space-y-6">
                 <div className="card p-4">
                     <div className="flex flex-wrap items-center justify-between gap-3">
                         <div>
@@ -368,183 +599,20 @@ export default function Budgets({
                     <h3 className="text-lg font-semibold text-light-primary dark:text-dark-primary">
                         All budgets
                     </h3>
-                    <div className="mt-4 overflow-x-auto">
-                        <table className="min-w-[980px] w-full text-left text-sm text-light-secondary dark:text-dark-secondary">
-                            <thead className="text-xs uppercase text-light-muted dark:text-dark-muted">
-                                <tr>
-                                    <th className="py-2 pr-4">Budget</th>
-                                    <th className="py-2 pr-4">Type</th>
-                                    <th className="py-2 pr-4">Category</th>
-                                    <th className="py-2 pr-4">Account</th>
-                                    <th className="py-2 hidden md:table-cell">
-                                        Status
-                                    </th>
-                                    <th className="py-2 hidden md:table-cell">
-                                        Progress
-                                    </th>
-                                    <th className="py-2 text-right whitespace-nowrap">
-                                        Amount
-                                    </th>
-                                    <th className="py-2 text-right whitespace-nowrap">
-                                        Remaining
-                                    </th>
-                                    <th className="py-2 text-right whitespace-nowrap">
-                                        Actions
-                                    </th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {pagedBudgets.map((budget) => {
-                                    const spent = Number(budget.current_spent ?? 0);
-                                    const total = Number(budget.amount ?? 0);
-                                    const remaining = Math.max(0, total - spent);
-                                    const progress =
-                                        total > 0
-                                            ? Math.min(
-                                                  100,
-                                                  Math.round(
-                                                      (spent / total) * 100
-                                                  )
-                                              )
-                                            : 0;
-                                    const statusLabel = budget.is_active
-                                        ? "Active"
-                                        : remaining === 0
-                                          ? "Completed"
-                                          : "Closed";
-                                    const statusTone = budget.is_active
-                                        ? "success"
-                                        : remaining === 0
-                                          ? "neutral"
-                                          : "danger";
-
-                                    return (
-                                        <tr
-                                            key={budget.id}
-                                            className="border-t border-light-border/70 dark:border-dark-border/70"
-                                        >
-                                            <td className="py-3 pr-4">
-                                                <p className="font-medium text-light-primary dark:text-dark-primary">
-                                                    {budget.name}
-                                                </p>
-                                            </td>
-                                            <td className="py-3 pr-4 capitalize text-xs text-light-muted dark:text-dark-muted">
-                                                {budget.budget_type ?? "spending"}
-                                            </td>
-                                            <td className="py-3 pr-4 text-xs text-light-muted dark:text-dark-muted">
-                                                {budget.category?.name ??
-                                                    "All categories"}
-                                            </td>
-                                            <td className="py-3 pr-4 text-xs text-light-muted dark:text-dark-muted">
-                                                {budget.account?.name ?? "—"}
-                                            </td>
-                                            <td className="py-3 hidden md:table-cell">
-                                                <Badge
-                                                    label={statusLabel}
-                                                    tone={statusTone}
-                                                />
-                                            </td>
-                                            <td className="py-3 min-w-[160px] hidden md:table-cell">
-                                                <div className="flex items-center gap-2">
-                                                    <span className="text-xs text-light-muted dark:text-dark-muted">
-                                                        {progress}%
-                                                    </span>
-                                                    <div className="h-2 w-full rounded-full bg-light-hover dark:bg-dark-hover">
-                                                        <div
-                                                            className="h-2 rounded-full bg-rose-500 dark:bg-rose-500/80"
-                                                            style={{
-                                                                width: `${progress}%`,
-                                                            }}
-                                                        />
-                                                    </div>
-                                                </div>
-                                            </td>
-                                            <td className="py-3 text-right font-semibold text-light-primary dark:text-dark-primary">
-                                                {formatWholeCurrency(
-                                                    budget.amount,
-                                                    budget.currency
-                                                )}
-                                            </td>
-                                            <td className="py-3 text-right text-xs text-light-muted dark:text-dark-muted">
-                                                {formatWholeCurrency(
-                                                    remaining,
-                                                    budget.currency
-                                                )}
-                                            </td>
-                                            <td className="py-3 text-right">
-                                                <div className="flex flex-wrap items-center justify-end gap-2">
-                                                    <button
-                                                        type="button"
-                                                        onClick={() =>
-                                                            setActiveBudget(
-                                                                budget
-                                                            )
-                                                        }
-                                                        className="rounded-md p-1 text-wevie-teal hover:text-wevie-teal/80 dark:text-wevie-mint"
-                                                        title="Edit budget"
-                                                        aria-label="Edit budget"
-                                                    >
-                                                        <Pencil className="h-4 w-4" />
-                                                    </button>
-                                                    <button
-                                                        type="button"
-                                                        onClick={() =>
-                                                            handleViewTransactions(
-                                                                budget
-                                                            )
-                                                        }
-                                                        className="rounded-md p-1 text-light-secondary hover:text-light-primary dark:text-dark-secondary dark:hover:text-dark-primary"
-                                                        title="View transactions"
-                                                        aria-label="View transactions"
-                                                    >
-                                                        <Eye className="h-4 w-4" />
-                                                    </button>
-                                                    <button
-                                                        type="button"
-                                                        onClick={() =>
-                                                            handleOpenClose(
-                                                                budget
-                                                            )
-                                                        }
-                                                        disabled={
-                                                            !budget.is_active
-                                                        }
-                                                        className="rounded-md p-1 text-amber-600 hover:text-amber-700 disabled:cursor-not-allowed disabled:text-light-muted dark:text-amber-400 dark:hover:text-amber-300 dark:disabled:text-dark-muted"
-                                                        title="Close budget"
-                                                        aria-label="Close budget"
-                                                    >
-                                                        <Lock className="h-4 w-4" />
-                                                    </button>
-                                                    <button
-                                                        type="button"
-                                                        onClick={() =>
-                                                            handleDelete(budget)
-                                                        }
-                                                        className="rounded-md p-1 text-rose-600 hover:text-rose-700 dark:text-rose-300"
-                                                        title="Delete budget"
-                                                        aria-label="Delete budget"
-                                                    >
-                                                        <Trash2 className="h-4 w-4" />
-                                                    </button>
-                                                </div>
-                                            </td>
-                                        </tr>
-                                    );
-                                })}
-                                {(!pagedBudgets ||
-                                    pagedBudgets.length === 0) && (
-                                    <tr>
-                                        <td colSpan={9} className="py-6">
-                                            <EmptyState
-                                                icon={PiggyBank}
-                                                title="No budgets yet"
-                                                description="No budgets match your filters. Use the New budget button to start tracking your spending."
-                                            />
-                                        </td>
-                                    </tr>
-                                )}
-                            </tbody>
-                        </table>
+                    <div className="mt-4">
+                        <ResponsiveTable
+                            columns={columns}
+                            rows={pagedBudgets}
+                            keyField="id"
+                            renderCard={renderCard}
+                            emptyState={
+                                <EmptyState
+                                    icon={PiggyBank}
+                                    title="No budgets yet"
+                                    description="No budgets match your filters. Use the New budget button to start tracking your spending."
+                                />
+                            }
+                        />
                     </div>
                     {visibleBudgets.length > perPage && (
                         <div className="mt-4 flex flex-wrap items-center justify-between gap-3 text-sm text-light-secondary dark:text-dark-secondary">

--- a/resources/js/Pages/Finance/Dashboard.jsx
+++ b/resources/js/Pages/Finance/Dashboard.jsx
@@ -651,7 +651,7 @@ export default function Dashboard(props) {
             }
         >
             <Head title="WevieWallet" />
-            <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
+            <div className="mx-auto max-w-7xl space-y-6">
                 {props.isWalletOwner && (
                     <FinanceInsightCard
                         insight={props.financeInsight ?? null}

--- a/resources/js/Pages/Finance/Loans.jsx
+++ b/resources/js/Pages/Finance/Loans.jsx
@@ -4,6 +4,7 @@ import TodoLayout from "@/Layouts/TodoLayout";
 import OnboardingTour from "@/Components/OnboardingTour";
 import Badge from "@/Components/Finance/UI/Badge";
 import EmptyState from "@/Components/Finance/UI/EmptyState";
+import ResponsiveTable from "@/Components/Finance/UI/ResponsiveTable";
 import useWalletMutation from "@/Hooks/useWalletMutation";
 import { formatWholeCurrency, formatCurrency } from "@/Utils/currency";
 import { walletLoansSteps } from "@/tours";
@@ -173,10 +174,199 @@ export default function Loans({ loans = [], walletUserId, filters = {} }) {
         [mutate]
     );
 
+    const loanMetrics = (loan) => {
+        const total = Number(loan.total_amount ?? 0);
+        const remaining = Number(loan.remaining_amount ?? 0);
+        const progress =
+            total > 0
+                ? Math.min(
+                      100,
+                      Math.round(((total - remaining) / total) * 100)
+                  )
+                : 0;
+        return { total, remaining, progress };
+    };
+
+    const rowActions = (loan) => (
+        <>
+            <button
+                type="button"
+                onClick={() => setActiveLoan(loan)}
+                className="rounded-md p-2 text-wevie-teal hover:text-wevie-teal/80 dark:text-wevie-mint"
+                title="Edit loan"
+                aria-label="Edit loan"
+            >
+                <Pencil className="h-4 w-4" />
+            </button>
+            <button
+                type="button"
+                onClick={() => handleViewTransactions(loan)}
+                className="rounded-md p-2 text-light-secondary hover:text-light-primary dark:text-dark-secondary dark:hover:text-dark-primary"
+                title="View transactions"
+                aria-label="View transactions"
+            >
+                <Eye className="h-4 w-4" />
+            </button>
+            <button
+                type="button"
+                onClick={() => handleDelete(loan)}
+                className="rounded-md p-2 text-rose-600 hover:text-rose-700 dark:text-rose-300"
+                title="Delete loan"
+                aria-label="Delete loan"
+            >
+                <Trash2 className="h-4 w-4" />
+            </button>
+        </>
+    );
+
+    const columns = [
+        {
+            key: "name",
+            header: "Loan",
+            render: (loan) => (
+                <p className="font-medium text-light-primary dark:text-dark-primary">
+                    {loan.name}
+                </p>
+            ),
+        },
+        {
+            key: "target_date",
+            header: "Due date",
+            render: (loan) => (
+                <span className="text-xs text-light-muted dark:text-dark-muted">
+                    {formatDate(loan.target_date)}
+                </span>
+            ),
+        },
+        {
+            key: "status",
+            header: "Status",
+            className: "hidden md:table-cell",
+            cellClassName: "hidden md:table-cell",
+            render: (loan) => (
+                <Badge
+                    label={loan.is_active ? "Active" : "Closed"}
+                    tone={loan.is_active ? "success" : "neutral"}
+                />
+            ),
+        },
+        {
+            key: "progress",
+            header: "Progress",
+            className: "hidden md:table-cell",
+            cellClassName: "hidden min-w-[160px] md:table-cell",
+            render: (loan) => {
+                const { progress } = loanMetrics(loan);
+                return (
+                    <div className="flex items-center gap-2">
+                        <span className="text-xs text-light-muted dark:text-dark-muted">
+                            {progress}%
+                        </span>
+                        <div className="h-2 w-full rounded-full bg-light-hover dark:bg-dark-hover">
+                            <div
+                                className="h-2 rounded-full bg-amber-500 dark:bg-amber-500/80"
+                                style={{ width: `${progress}%` }}
+                            />
+                        </div>
+                    </div>
+                );
+            },
+        },
+        {
+            key: "remaining",
+            header: "Remaining",
+            align: "right",
+            render: (loan) => {
+                const { remaining } = loanMetrics(loan);
+                return (
+                    <span className="font-semibold text-light-primary dark:text-dark-primary">
+                        {formatWholeCurrency(remaining, loan.currency)}
+                    </span>
+                );
+            },
+        },
+        {
+            key: "total",
+            header: "Total",
+            align: "right",
+            render: (loan) => {
+                const { total } = loanMetrics(loan);
+                return (
+                    <span className="text-xs text-light-muted dark:text-dark-muted">
+                        {formatWholeCurrency(total, loan.currency)}
+                    </span>
+                );
+            },
+        },
+        {
+            key: "actions",
+            header: "Actions",
+            align: "right",
+            render: (loan) => (
+                <div className="flex flex-wrap items-center justify-end gap-2">
+                    {rowActions(loan)}
+                </div>
+            ),
+        },
+    ];
+
+    const renderCard = (loan) => {
+        const { total, remaining, progress } = loanMetrics(loan);
+        return (
+            <div className="rounded-xl border border-light-border/70 p-4 dark:border-dark-border/70">
+                <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                        <p className="truncate font-medium text-light-primary dark:text-dark-primary">
+                            {loan.name}
+                        </p>
+                        <div className="mt-1 flex flex-wrap items-center gap-2">
+                            <Badge
+                                label={loan.is_active ? "Active" : "Closed"}
+                                tone={loan.is_active ? "success" : "neutral"}
+                            />
+                            <span className="text-xs text-light-muted dark:text-dark-muted">
+                                {formatDate(loan.target_date)}
+                            </span>
+                        </div>
+                    </div>
+                    <p className="shrink-0 text-right font-semibold text-light-primary dark:text-dark-primary">
+                        {formatWholeCurrency(remaining, loan.currency)}
+                    </p>
+                </div>
+
+                <dl className="mt-3 space-y-1 text-xs text-light-muted dark:text-dark-muted">
+                    <div className="flex justify-between gap-2">
+                        <dt className="shrink-0">Total</dt>
+                        <dd className="min-w-0 truncate text-right text-light-secondary dark:text-dark-secondary">
+                            {formatWholeCurrency(total, loan.currency)}
+                        </dd>
+                    </div>
+                </dl>
+
+                <div className="mt-3">
+                    <div className="mb-1 flex items-center justify-between gap-2 text-xs text-light-muted dark:text-dark-muted">
+                        <span>Progress</span>
+                        <span>{progress}%</span>
+                    </div>
+                    <div className="h-2 w-full rounded-full bg-light-hover dark:bg-dark-hover">
+                        <div
+                            className="h-2 rounded-full bg-amber-500 dark:bg-amber-500/80"
+                            style={{ width: `${progress}%` }}
+                        />
+                    </div>
+                </div>
+
+                <div className="mt-3 flex items-center justify-end gap-1 border-t border-light-border/50 pt-3 dark:border-dark-border/50">
+                    {rowActions(loan)}
+                </div>
+            </div>
+        );
+    };
+
     return (
         <TodoLayout header="Loans">
             <Head title="Loans" />
-            <div className="mx-auto max-w-5xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
+            <div className="mx-auto max-w-5xl space-y-6">
                 <div className="card p-4">
                     <div className="flex flex-wrap items-center justify-between gap-3">
                         <div>
@@ -261,158 +451,20 @@ export default function Loans({ loans = [], walletUserId, filters = {} }) {
                     <h3 className="text-lg font-semibold text-light-primary dark:text-dark-primary">
                         All loans
                     </h3>
-                    <div className="mt-4 overflow-x-auto">
-                        <table className="min-w-[880px] w-full text-left text-sm text-light-secondary dark:text-dark-secondary">
-                            <thead className="text-xs uppercase text-light-muted dark:text-dark-muted">
-                                <tr>
-                                    <th className="py-2 pr-4">Loan</th>
-                                    <th className="py-2 pr-4">Due date</th>
-                                    <th className="py-2 hidden md:table-cell">
-                                        Status
-                                    </th>
-                                    <th className="py-2 hidden md:table-cell">
-                                        Progress
-                                    </th>
-                                    <th className="py-2 text-right whitespace-nowrap">
-                                        Remaining
-                                    </th>
-                                    <th className="py-2 text-right whitespace-nowrap">
-                                        Total
-                                    </th>
-                                    <th className="py-2 text-right whitespace-nowrap">
-                                        Actions
-                                    </th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {pagedLoans.map((loan) => {
-                                    const total = Number(loan.total_amount ?? 0);
-                                    const remaining = Number(
-                                        loan.remaining_amount ?? 0
-                                    );
-                                    const progress =
-                                        total > 0
-                                            ? Math.min(
-                                                  100,
-                                                  Math.round(
-                                                      ((total - remaining) /
-                                                          total) *
-                                                          100
-                                                  )
-                                              )
-                                            : 0;
-
-                                    return (
-                                        <tr
-                                            key={loan.id}
-                                            className="border-t border-light-border/70 dark:border-dark-border/70"
-                                        >
-                                            <td className="py-3 pr-4">
-                                                <p className="font-medium text-light-primary dark:text-dark-primary">
-                                                    {loan.name}
-                                                </p>
-                                            </td>
-                                            <td className="py-3 pr-4 text-xs text-light-muted dark:text-dark-muted">
-                                                {formatDate(loan.target_date)}
-                                            </td>
-                                            <td className="py-3 hidden md:table-cell">
-                                                <Badge
-                                                    label={
-                                                        loan.is_active
-                                                            ? "Active"
-                                                            : "Closed"
-                                                    }
-                                                    tone={
-                                                        loan.is_active
-                                                            ? "success"
-                                                            : "neutral"
-                                                    }
-                                                />
-                                            </td>
-                                            <td className="py-3 min-w-[160px] hidden md:table-cell">
-                                                <div className="flex items-center gap-2">
-                                                    <span className="text-xs text-light-muted dark:text-dark-muted">
-                                                        {progress}%
-                                                    </span>
-                                                    <div className="h-2 w-full rounded-full bg-light-hover dark:bg-dark-hover">
-                                                        <div
-                                                            className="h-2 rounded-full bg-amber-500 dark:bg-amber-500/80"
-                                                            style={{
-                                                                width: `${progress}%`,
-                                                            }}
-                                                        />
-                                                    </div>
-                                                </div>
-                                            </td>
-                                            <td className="py-3 text-right font-semibold text-light-primary dark:text-dark-primary">
-                                                {formatWholeCurrency(
-                                                    remaining,
-                                                    loan.currency
-                                                )}
-                                            </td>
-                                            <td className="py-3 text-right text-xs text-light-muted dark:text-dark-muted">
-                                                {formatWholeCurrency(
-                                                    total,
-                                                    loan.currency
-                                                )}
-                                            </td>
-                                            <td className="py-3 text-right">
-                                                <div className="flex flex-wrap items-center justify-end gap-2">
-                                                    <button
-                                                        type="button"
-                                                        onClick={() =>
-                                                            setActiveLoan(
-                                                                loan
-                                                            )
-                                                        }
-                                                        className="rounded-md p-1 text-wevie-teal hover:text-wevie-teal/80 dark:text-wevie-mint"
-                                                        title="Edit loan"
-                                                        aria-label="Edit loan"
-                                                    >
-                                                        <Pencil className="h-4 w-4" />
-                                                    </button>
-                                                    <button
-                                                        type="button"
-                                                        onClick={() =>
-                                                            handleViewTransactions(
-                                                                loan
-                                                            )
-                                                        }
-                                                        className="rounded-md p-1 text-light-secondary hover:text-light-primary dark:text-dark-secondary dark:hover:text-dark-primary"
-                                                        title="View transactions"
-                                                        aria-label="View transactions"
-                                                    >
-                                                        <Eye className="h-4 w-4" />
-                                                    </button>
-                                                    <button
-                                                        type="button"
-                                                        onClick={() =>
-                                                            handleDelete(loan)
-                                                        }
-                                                        className="rounded-md p-1 text-rose-600 hover:text-rose-700 dark:text-rose-300"
-                                                        title="Delete loan"
-                                                        aria-label="Delete loan"
-                                                    >
-                                                        <Trash2 className="h-4 w-4" />
-                                                    </button>
-                                                </div>
-                                            </td>
-                                        </tr>
-                                    );
-                                })}
-                                {(!pagedLoans || pagedLoans.length === 0) && (
-                                    <tr>
-                                        <td colSpan={7} className="py-6">
-                                            <EmptyState
-                                                icon={Landmark}
-                                                title="No loans yet"
-                                                description="No loans match your filters. Use the New loan button to start tracking what you owe."
-                                            />
-                                        </td>
-                                    </tr>
-                                )}
-                            </tbody>
-                        </table>
+                    <div className="mt-4">
+                        <ResponsiveTable
+                            columns={columns}
+                            rows={pagedLoans}
+                            keyField="id"
+                            renderCard={renderCard}
+                            emptyState={
+                                <EmptyState
+                                    icon={Landmark}
+                                    title="No loans yet"
+                                    description="No loans match your filters. Use the New loan button to start tracking what you owe."
+                                />
+                            }
+                        />
                     </div>
                 </div>
                 {loans.length > perPage && (

--- a/resources/js/Pages/Finance/SavingsGoals.jsx
+++ b/resources/js/Pages/Finance/SavingsGoals.jsx
@@ -4,6 +4,7 @@ import TodoLayout from "@/Layouts/TodoLayout";
 import OnboardingTour from "@/Components/OnboardingTour";
 import Badge from "@/Components/Finance/UI/Badge";
 import EmptyState from "@/Components/Finance/UI/EmptyState";
+import ResponsiveTable from "@/Components/Finance/UI/ResponsiveTable";
 import useWalletMutation from "@/Hooks/useWalletMutation";
 import { formatWholeCurrency, formatCurrency } from "@/Utils/currency";
 import { walletSavingsGoalsSteps } from "@/tours";
@@ -195,10 +196,232 @@ export default function SavingsGoals({
         [mutate]
     );
 
+    const goalMetrics = (goal) => {
+        const current = Number(goal.current_amount ?? 0);
+        const target = Number(goal.target_amount ?? 0);
+        const progress =
+            target > 0
+                ? Math.min(100, Math.round((current / target) * 100))
+                : 0;
+        const statusLabel = goal.is_active
+            ? "Active"
+            : goal.converted_finance_budget_id
+              ? "Converted"
+              : current >= target
+                ? "Completed"
+                : "Closed";
+        return { current, target, progress, statusLabel };
+    };
+
+    const rowActions = (goal) => (
+        <>
+            <button
+                type="button"
+                onClick={() => setActiveGoal(goal)}
+                className="rounded-md p-2 text-wevie-teal hover:text-wevie-teal/80 dark:text-wevie-mint"
+                title="Edit goal"
+                aria-label="Edit goal"
+            >
+                <Pencil className="h-4 w-4" />
+            </button>
+            <button
+                type="button"
+                onClick={() => handleViewTransactions(goal)}
+                className="rounded-md p-2 text-light-secondary hover:text-light-primary dark:text-dark-secondary dark:hover:text-dark-primary"
+                title="View transactions"
+                aria-label="View transactions"
+            >
+                <Eye className="h-4 w-4" />
+            </button>
+            {!goal.converted_finance_budget_id && (
+                <button
+                    type="button"
+                    onClick={() => handleConvert(goal)}
+                    className="rounded-md p-2 text-emerald-600 hover:text-emerald-700 dark:text-emerald-300"
+                    title="Convert to budget"
+                    aria-label="Convert to budget"
+                >
+                    <Repeat2 className="h-4 w-4" />
+                </button>
+            )}
+            <button
+                type="button"
+                onClick={() => handleDelete(goal)}
+                className="rounded-md p-2 text-rose-600 hover:text-rose-700 dark:text-rose-300"
+                title="Delete goal"
+                aria-label="Delete goal"
+            >
+                <Trash2 className="h-4 w-4" />
+            </button>
+        </>
+    );
+
+    const columns = [
+        {
+            key: "name",
+            header: "Goal",
+            render: (goal) => (
+                <p className="font-medium text-light-primary dark:text-dark-primary">
+                    {goal.name}
+                </p>
+            ),
+        },
+        {
+            key: "account",
+            header: "Account",
+            render: (goal) => (
+                <span className="text-xs text-light-muted dark:text-dark-muted">
+                    {goal.account?.name ?? "—"}
+                </span>
+            ),
+        },
+        {
+            key: "target_date",
+            header: "Target date",
+            render: (goal) => (
+                <span className="text-xs text-light-muted dark:text-dark-muted">
+                    {formatDate(goal.target_date)}
+                </span>
+            ),
+        },
+        {
+            key: "status",
+            header: "Status",
+            className: "hidden md:table-cell",
+            cellClassName: "hidden md:table-cell",
+            render: (goal) => {
+                const { statusLabel } = goalMetrics(goal);
+                return (
+                    <Badge
+                        label={statusLabel}
+                        tone={STATUS_TONE[statusLabel] ?? "neutral"}
+                    />
+                );
+            },
+        },
+        {
+            key: "progress",
+            header: "Progress",
+            className: "hidden md:table-cell",
+            cellClassName: "hidden min-w-[160px] md:table-cell",
+            render: (goal) => {
+                const { progress } = goalMetrics(goal);
+                return (
+                    <div className="flex items-center gap-2">
+                        <span className="text-xs text-light-muted dark:text-dark-muted">
+                            {progress}%
+                        </span>
+                        <div className="h-2 w-full rounded-full bg-light-hover dark:bg-dark-hover">
+                            <div
+                                className="h-2 rounded-full bg-emerald-500 dark:bg-emerald-500/80"
+                                style={{ width: `${progress}%` }}
+                            />
+                        </div>
+                    </div>
+                );
+            },
+        },
+        {
+            key: "saved",
+            header: "Saved",
+            align: "right",
+            render: (goal) => {
+                const { current } = goalMetrics(goal);
+                return (
+                    <span className="font-semibold text-light-primary dark:text-dark-primary">
+                        {formatWholeCurrency(current, goal.currency)}
+                    </span>
+                );
+            },
+        },
+        {
+            key: "target",
+            header: "Target",
+            align: "right",
+            render: (goal) => {
+                const { target } = goalMetrics(goal);
+                return (
+                    <span className="text-xs text-light-muted dark:text-dark-muted">
+                        {formatWholeCurrency(target, goal.currency)}
+                    </span>
+                );
+            },
+        },
+        {
+            key: "actions",
+            header: "Actions",
+            align: "right",
+            render: (goal) => (
+                <div className="flex flex-wrap items-center justify-end gap-2">
+                    {rowActions(goal)}
+                </div>
+            ),
+        },
+    ];
+
+    const renderCard = (goal) => {
+        const { current, target, progress, statusLabel } = goalMetrics(goal);
+        return (
+            <div className="rounded-xl border border-light-border/70 p-4 dark:border-dark-border/70">
+                <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                        <p className="truncate font-medium text-light-primary dark:text-dark-primary">
+                            {goal.name}
+                        </p>
+                        <div className="mt-1 flex flex-wrap items-center gap-2">
+                            <Badge
+                                label={statusLabel}
+                                tone={STATUS_TONE[statusLabel] ?? "neutral"}
+                            />
+                            <span className="text-xs text-light-muted dark:text-dark-muted">
+                                {formatDate(goal.target_date)}
+                            </span>
+                        </div>
+                    </div>
+                    <p className="shrink-0 text-right font-semibold text-light-primary dark:text-dark-primary">
+                        {formatWholeCurrency(current, goal.currency)}
+                    </p>
+                </div>
+
+                <dl className="mt-3 space-y-1 text-xs text-light-muted dark:text-dark-muted">
+                    <div className="flex justify-between gap-2">
+                        <dt className="shrink-0">Account</dt>
+                        <dd className="min-w-0 truncate text-right text-light-secondary dark:text-dark-secondary">
+                            {goal.account?.name ?? "—"}
+                        </dd>
+                    </div>
+                    <div className="flex justify-between gap-2">
+                        <dt className="shrink-0">Target</dt>
+                        <dd className="min-w-0 truncate text-right text-light-secondary dark:text-dark-secondary">
+                            {formatWholeCurrency(target, goal.currency)}
+                        </dd>
+                    </div>
+                </dl>
+
+                <div className="mt-3">
+                    <div className="mb-1 flex items-center justify-between gap-2 text-xs text-light-muted dark:text-dark-muted">
+                        <span>Progress</span>
+                        <span>{progress}%</span>
+                    </div>
+                    <div className="h-2 w-full rounded-full bg-light-hover dark:bg-dark-hover">
+                        <div
+                            className="h-2 rounded-full bg-emerald-500 dark:bg-emerald-500/80"
+                            style={{ width: `${progress}%` }}
+                        />
+                    </div>
+                </div>
+
+                <div className="mt-3 flex items-center justify-end gap-1 border-t border-light-border/50 pt-3 dark:border-dark-border/50">
+                    {rowActions(goal)}
+                </div>
+            </div>
+        );
+    };
+
     return (
         <TodoLayout header="Savings goals">
             <Head title="Savings goals" />
-            <div className="mx-auto max-w-5xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
+            <div className="mx-auto max-w-5xl space-y-6">
                 <div className="card p-4">
                     <div className="flex flex-wrap items-center justify-between gap-3">
                         <div>
@@ -285,178 +508,20 @@ export default function SavingsGoals({
                     <h3 className="text-lg font-semibold text-light-primary dark:text-dark-primary">
                         All savings goals
                     </h3>
-                    <div className="mt-4 overflow-x-auto">
-                        <table className="min-w-[920px] w-full text-left text-sm text-light-secondary dark:text-dark-secondary">
-                            <thead className="text-xs uppercase text-light-muted dark:text-dark-muted">
-                                <tr>
-                                    <th className="py-2 pr-4">Goal</th>
-                                    <th className="py-2 pr-4">Account</th>
-                                    <th className="py-2 pr-4">Target date</th>
-                                    <th className="py-2 hidden md:table-cell">
-                                        Status
-                                    </th>
-                                    <th className="py-2 hidden md:table-cell">
-                                        Progress
-                                    </th>
-                                    <th className="py-2 text-right whitespace-nowrap">
-                                        Saved
-                                    </th>
-                                    <th className="py-2 text-right whitespace-nowrap">
-                                        Target
-                                    </th>
-                                    <th className="py-2 text-right whitespace-nowrap">
-                                        Actions
-                                    </th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {pagedGoals.map((goal) => {
-                                    const current = Number(
-                                        goal.current_amount ?? 0
-                                    );
-                                    const target = Number(
-                                        goal.target_amount ?? 0
-                                    );
-                                    const progress =
-                                        target > 0
-                                            ? Math.min(
-                                                  100,
-                                                  Math.round(
-                                                      (current / target) * 100
-                                                  )
-                                              )
-                                            : 0;
-                                    const statusLabel = goal.is_active
-                                        ? "Active"
-                                        : goal.converted_finance_budget_id
-                                          ? "Converted"
-                                          : current >= target
-                                            ? "Completed"
-                                            : "Closed";
-
-                                    return (
-                                        <tr
-                                            key={goal.id}
-                                            className="border-t border-light-border/70 dark:border-dark-border/70"
-                                        >
-                                            <td className="py-3 pr-4">
-                                                <p className="font-medium text-light-primary dark:text-dark-primary">
-                                                    {goal.name}
-                                                </p>
-                                            </td>
-                                            <td className="py-3 pr-4 text-xs text-light-muted dark:text-dark-muted">
-                                                {goal.account?.name ?? "—"}
-                                            </td>
-                                            <td className="py-3 pr-4 text-xs text-light-muted dark:text-dark-muted">
-                                                {formatDate(goal.target_date)}
-                                            </td>
-                                            <td className="py-3 hidden md:table-cell">
-                                                <Badge
-                                                    label={statusLabel}
-                                                    tone={
-                                                        STATUS_TONE[
-                                                            statusLabel
-                                                        ] ?? "neutral"
-                                                    }
-                                                />
-                                            </td>
-                                            <td className="py-3 min-w-[160px] hidden md:table-cell">
-                                                <div className="flex items-center gap-2">
-                                                    <span className="text-xs text-light-muted dark:text-dark-muted">
-                                                        {progress}%
-                                                    </span>
-                                                    <div className="h-2 w-full rounded-full bg-light-hover dark:bg-dark-hover">
-                                                        <div
-                                                            className="h-2 rounded-full bg-emerald-500 dark:bg-emerald-500/80"
-                                                            style={{
-                                                                width: `${progress}%`,
-                                                            }}
-                                                        />
-                                                    </div>
-                                                </div>
-                                            </td>
-                                            <td className="py-3 text-right font-semibold text-light-primary dark:text-dark-primary">
-                                                {formatWholeCurrency(
-                                                    current,
-                                                    goal.currency
-                                                )}
-                                            </td>
-                                            <td className="py-3 text-right text-xs text-light-muted dark:text-dark-muted">
-                                                {formatWholeCurrency(
-                                                    target,
-                                                    goal.currency
-                                                )}
-                                            </td>
-                                            <td className="py-3 text-right">
-                                                <div className="flex flex-wrap items-center justify-end gap-2">
-                                                    <button
-                                                        type="button"
-                                                        onClick={() =>
-                                                            setActiveGoal(goal)
-                                                        }
-                                                        className="rounded-md p-1 text-wevie-teal hover:text-wevie-teal/80 dark:text-wevie-mint"
-                                                        title="Edit goal"
-                                                        aria-label="Edit goal"
-                                                    >
-                                                        <Pencil className="h-4 w-4" />
-                                                    </button>
-                                                    <button
-                                                        type="button"
-                                                        onClick={() =>
-                                                            handleViewTransactions(
-                                                                goal
-                                                            )
-                                                        }
-                                                        className="rounded-md p-1 text-light-secondary hover:text-light-primary dark:text-dark-secondary dark:hover:text-dark-primary"
-                                                        title="View transactions"
-                                                        aria-label="View transactions"
-                                                    >
-                                                        <Eye className="h-4 w-4" />
-                                                    </button>
-                                                    {!goal.converted_finance_budget_id && (
-                                                        <button
-                                                            type="button"
-                                                            onClick={() =>
-                                                                handleConvert(
-                                                                    goal
-                                                                )
-                                                            }
-                                                            className="rounded-md p-1 text-emerald-600 hover:text-emerald-700 dark:text-emerald-300"
-                                                            title="Convert to budget"
-                                                            aria-label="Convert to budget"
-                                                        >
-                                                            <Repeat2 className="h-4 w-4" />
-                                                        </button>
-                                                    )}
-                                                    <button
-                                                        type="button"
-                                                        onClick={() =>
-                                                            handleDelete(goal)
-                                                        }
-                                                        className="rounded-md p-1 text-rose-600 hover:text-rose-700 dark:text-rose-300"
-                                                        title="Delete goal"
-                                                        aria-label="Delete goal"
-                                                    >
-                                                        <Trash2 className="h-4 w-4" />
-                                                    </button>
-                                                </div>
-                                            </td>
-                                        </tr>
-                                    );
-                                })}
-                                {(!pagedGoals || pagedGoals.length === 0) && (
-                                    <tr>
-                                        <td colSpan={8} className="py-6">
-                                            <EmptyState
-                                                icon={Target}
-                                                title="No savings goals yet"
-                                                description="No savings goals match your filters. Use the New savings goal button to start saving toward something."
-                                            />
-                                        </td>
-                                    </tr>
-                                )}
-                            </tbody>
-                        </table>
+                    <div className="mt-4">
+                        <ResponsiveTable
+                            columns={columns}
+                            rows={pagedGoals}
+                            keyField="id"
+                            renderCard={renderCard}
+                            emptyState={
+                                <EmptyState
+                                    icon={Target}
+                                    title="No savings goals yet"
+                                    description="No savings goals match your filters. Use the New savings goal button to start saving toward something."
+                                />
+                            }
+                        />
                     </div>
                 </div>
                 {savingsGoals.length > perPage && (

--- a/resources/js/Pages/Finance/Transactions.jsx
+++ b/resources/js/Pages/Finance/Transactions.jsx
@@ -238,7 +238,7 @@ export default function Transactions({
     return (
         <TodoLayout header="All Transactions">
             <Head title="All Transactions" />
-            <div className="mx-auto max-w-6xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
+            <div className="mx-auto max-w-6xl space-y-6">
                 <div className="card p-4" data-tour="transactions-filters">
                     <div className="flex flex-wrap items-center justify-between gap-3">
                         <div>
@@ -449,8 +449,8 @@ export default function Transactions({
                                                                     className="rounded-lg border border-light-border/70 p-3 dark:border-dark-border/70"
                                                                 >
                                                                     <div className="flex flex-wrap items-center justify-between gap-2">
-                                                                        <div>
-                                                                            <p className="font-medium text-light-primary dark:text-dark-primary">
+                                                                        <div className="min-w-0">
+                                                                            <p className="break-words font-medium text-light-primary dark:text-dark-primary">
                                                                                 {
                                                                                     transaction.description
                                                                                 }

--- a/resources/js/Pages/Profile/FinanceCategories.jsx
+++ b/resources/js/Pages/Profile/FinanceCategories.jsx
@@ -60,14 +60,14 @@ export default function FinanceCategories({ categories = [], walletUserId }) {
     return (
         <TodoLayout header="WevieWallet Categories">
             <Head title="WevieWallet Categories" />
-            <div className="mx-auto max-w-5xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
+            <div className="mx-auto max-w-5xl space-y-6">
                 <div className="card p-4">
                     <div className="flex flex-wrap items-center justify-between gap-3">
-                        <div>
-                            <h2 className="text-xl font-semibold text-slate-900 dark:text-white">
+                        <div className="min-w-0">
+                            <h2 className="text-xl font-semibold text-light-primary dark:text-dark-primary">
                                 Finance categories
                             </h2>
-                            <p className="text-sm text-slate-500 dark:text-slate-400">
+                            <p className="text-sm text-light-muted dark:text-dark-muted">
                                 Manage income, expense, and savings categories.
                             </p>
                         </div>
@@ -75,7 +75,7 @@ export default function FinanceCategories({ categories = [], walletUserId }) {
                             href={route("weviewallet.dashboard", {
                                 wallet_user_id: walletUserId || undefined,
                             })}
-                            className="text-sm font-semibold text-indigo-600 hover:text-indigo-700 dark:text-indigo-300 dark:hover:text-indigo-200"
+                            className="shrink-0 text-sm font-semibold text-wevie-teal hover:text-wevie-teal/80 dark:text-wevie-mint dark:hover:text-wevie-mint/80"
                         >
                             Back to WevieWallet
                         </Link>

--- a/resources/js/Pages/Tasks/Index.jsx
+++ b/resources/js/Pages/Tasks/Index.jsx
@@ -104,6 +104,49 @@ function SortableTask({
         }
     };
 
+    const actionItems = [
+        {
+            label: "Add subtask",
+            icon: ListTodo,
+            onClick: () => {
+                setSelectedTask(task);
+                setShowSubtaskModal(true);
+            },
+        },
+        {
+            label: "View",
+            icon: Eye,
+            onClick: () => {
+                setSelectedTask(task);
+                setShowViewModal(true);
+            },
+        },
+        {
+            label: "Edit",
+            icon: Edit,
+            onClick: () => {
+                setSelectedTask(task);
+                setShowEditModal(true);
+            },
+        },
+        ...(task.lists && task.lists.length > 0
+            ? [
+                  {
+                      label: "Open list",
+                      icon: List,
+                      onClick: () =>
+                          router.visit(route("lists.show", task.lists[0].id)),
+                  },
+              ]
+            : []),
+        {
+            label: "Delete",
+            icon: Trash2,
+            danger: true,
+            onClick: () => handleDeleteTask(task),
+        },
+    ];
+
     return (
         <div
             ref={setNodeRef}
@@ -164,6 +207,11 @@ function SortableTask({
                             </p>
                         )}
                     </div>
+
+                    {/* Actions (mobile: pinned to the title row so it never wraps) */}
+                    <div className="flex-shrink-0 sm:hidden">
+                        <TaskActionsMenu items={actionItems} />
+                    </div>
                 </div>
 
                 {/* Category */}
@@ -174,8 +222,9 @@ function SortableTask({
                             style={{
                                 backgroundColor: task.category?.color || "#6B7280",
                             }}
+                            title={task.category?.name || "Uncategorized"}
                         />
-                        <span className="text-xs text-light-secondary dark:text-dark-secondary truncate max-w-24">
+                        <span className="hidden sm:inline text-xs text-light-secondary dark:text-dark-secondary truncate max-w-24">
                             {task.category?.name || "Uncategorized"}
                         </span>
                     </div>
@@ -312,57 +361,9 @@ function SortableTask({
                         </div>
                     )}
 
-                    {/* Actions */}
-                    <div className="opacity-100 transition-opacity focus-within:opacity-100 sm:opacity-0 sm:group-hover:opacity-100">
-                        <TaskActionsMenu
-                            items={[
-                                {
-                                    label: "Add subtask",
-                                    icon: ListTodo,
-                                    onClick: () => {
-                                        setSelectedTask(task);
-                                        setShowSubtaskModal(true);
-                                    },
-                                },
-                                {
-                                    label: "View",
-                                    icon: Eye,
-                                    onClick: () => {
-                                        setSelectedTask(task);
-                                        setShowViewModal(true);
-                                    },
-                                },
-                                {
-                                    label: "Edit",
-                                    icon: Edit,
-                                    onClick: () => {
-                                        setSelectedTask(task);
-                                        setShowEditModal(true);
-                                    },
-                                },
-                                ...(task.lists && task.lists.length > 0
-                                    ? [
-                                          {
-                                              label: "Open list",
-                                              icon: List,
-                                              onClick: () =>
-                                                  router.visit(
-                                                      route(
-                                                          "lists.show",
-                                                          task.lists[0].id
-                                                      )
-                                                  ),
-                                          },
-                                      ]
-                                    : []),
-                                {
-                                    label: "Delete",
-                                    icon: Trash2,
-                                    danger: true,
-                                    onClick: () => handleDeleteTask(task),
-                                },
-                            ]}
-                        />
+                    {/* Actions (desktop: hover-reveal at the end of the meta row) */}
+                    <div className="hidden opacity-100 transition-opacity focus-within:opacity-100 sm:block sm:opacity-0 sm:group-hover:opacity-100">
+                        <TaskActionsMenu items={actionItems} />
                     </div>
                 </div>
             </div>

--- a/resources/js/app.jsx
+++ b/resources/js/app.jsx
@@ -7,8 +7,12 @@ import { createRoot } from "react-dom/client";
 import { PomodoroProvider } from "./Components/Pomodoro";
 import NavigationLoader from "./Components/NavigationLoader";
 import { registerSW } from "virtual:pwa-register";
+import { initStatusBar } from "./native/statusBar";
 
 const appName = import.meta.env.VITE_APP_NAME || "Wevie";
+
+// Native shell (iOS/Capacitor): overlay the status bar so the safe-area inset resolves.
+initStatusBar();
 
 createInertiaApp({
     title: (title) => `${title} - ${appName}`,

--- a/resources/js/native/statusBar.js
+++ b/resources/js/native/statusBar.js
@@ -1,0 +1,36 @@
+import { Capacitor } from "@capacitor/core";
+import { StatusBar, Style } from "@capacitor/status-bar";
+
+/**
+ * Configure the native iOS/Android status bar so it overlays the web view.
+ *
+ * The web layout already reserves the notch/status-bar space via
+ * `env(safe-area-inset-top)` (see TodoLayout's header) — for that inset to be
+ * non-zero the status bar must sit *on top of* the web content rather than
+ * pushing it down. We also keep the status-bar text legible by matching its
+ * style to the app's dark-mode class (`<html class="dark">`).
+ *
+ * No-ops on the web (non-native) build, so it is safe to call unconditionally.
+ */
+export function initStatusBar() {
+    if (!Capacitor.isNativePlatform()) {
+        return;
+    }
+
+    const applyStyle = () => {
+        const isDark = document.documentElement.classList.contains("dark");
+        // Style.Dark => dark icons/text for light backgrounds; Style.Light => light text for dark backgrounds.
+        StatusBar.setStyle({ style: isDark ? Style.Light : Style.Dark }).catch(() => {});
+    };
+
+    // Overlay so the web content extends under the status bar and the safe-area inset resolves.
+    StatusBar.setOverlaysWebView({ overlay: true }).catch(() => {});
+    applyStyle();
+
+    // Follow the dark-mode toggle (TodoLayout flips the `dark` class on <html>).
+    const observer = new MutationObserver(applyStyle);
+    observer.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["class"],
+    });
+}

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -2,7 +2,7 @@
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
     <head>
         <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 
         <title inertia>{{ config('app.name', 'Laravel') }}</title>
 


### PR DESCRIPTION
## Context
On mobile, the WevieWallet dashboard and Finance list pages didn't fit the screen — content clipped at the right edge (transaction amounts, category/account values, the "See all" button) and the budgets/loans/savings index pages forced a wide horizontal scroll. This finishes the mobile work started in `29e77a0` across the **whole Finance module**.

## Root causes fixed
1. **Double padding** — every Finance page re-added `px-4 py-8 sm:px-6 lg:px-8` on top of the layout's `<main class="p-6">` + `max-w-7xl` centering, squeezing usable width to ~295px on a 375px screen. Removed the redundant padding on all 7 pages (kept each page's intentional `max-w-Nxl` desktop reading width).
2. **Wide tables with no mobile fallback** — Budgets (`min-w-[980px]`), Loans (`min-w-[880px]`), Savings goals (`min-w-[920px]`) forced horizontal scroll. Converted all three to the shared `ResponsiveTable` pattern: desktop table unchanged at `lg`+, stacked mobile cards (mirroring `TransactionCard`) below `lg`.
3. **Unguarded flex rows** — added the standard `min-w-0 truncate` (flexible child) + `shrink-0` (fixed sibling) idiom to the Active budgets card, `TransactionCard` "Repeats" row, Recent-activity header, Transactions row, and Categories name block.

## Polish
- Icon action buttons `p-1` → `p-2` for comfortable (~40px) tap targets.
- Decluttered the Active budgets card meta into a single truncating line.
- Tokenized `CategoryList` + `FinanceCategories` header (off-palette `slate-*`/`indigo-*` → Wevie `light-*`/`dark-*`/`wevie-*` tokens with `dark:` variants), per CLAUDE.md rule #3.

## Verification
- `npm run build` — ✓ clean.
- ESLint on all 11 touched files — **0 errors** (37 warnings, all pre-existing).
- Desktop (≥`lg`) tables keep identical columns, order, formatting, `md:`-band hiding, and row actions — only the mobile experience changed.
- Manual check at 375px / 414px: no horizontal scroll, nothing clipped, wide tables render as stacked cards.

## Files changed (11)
`Pages/Finance/{Dashboard,Transactions,Budgets,Loans,SavingsGoals,Accounts}.jsx`, `Pages/Profile/FinanceCategories.jsx`, `Components/Finance/{Dashboard/FinanceDashboard,Transactions/TransactionCard,Transactions/TransactionsList,Categories/CategoryList}.jsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)