### PR TITLE
Add Web Push notifications and fix the test-notification bell

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,3 +89,10 @@ GEMINI_MODEL=gemini-1.5-flash
 AI_DAILY_SUMMARY_OPEN_BETA=true
 AI_FINANCE_INSIGHTS_OPEN_BETA=true
 AI_TASK_CAPTURE_OPEN_BETA=false
+
+# Web Push (VAPID) — browser/PWA push notifications.
+# Generate a keypair with: php artisan webpush:vapid
+# The public key is safe to expose to the browser; keep the private key secret.
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+VAPID_SUBJECT="${APP_URL}"

--- a/app/Console/Commands/GenerateVapidKeys.php
+++ b/app/Console/Commands/GenerateVapidKeys.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Minishlink\WebPush\VAPID;
+
+class GenerateVapidKeys extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'webpush:vapid';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate a VAPID keypair for Web Push and print the values for your .env';
+
+    /**
+     * Execute the console command.
+     *
+     * VAPID keys authenticate this application server to browser push services.
+     * We only generate and print them — the operator copies the pair into .env
+     * (VAPID_PUBLIC_KEY / VAPID_PRIVATE_KEY) so the private key never touches
+     * version control. Re-running rotates the pair, which invalidates existing
+     * browser subscriptions, so only regenerate deliberately.
+     */
+    public function handle(): int
+    {
+        $keys = VAPID::createVapidKeys();
+
+        $this->info('VAPID keypair generated. Add these to your .env (keep the private key secret):');
+        $this->newLine();
+        $this->line('VAPID_PUBLIC_KEY="'.$keys['publicKey'].'"');
+        $this->line('VAPID_PRIVATE_KEY="'.$keys['privateKey'].'"');
+        $this->newLine();
+        $this->warn('Regenerating rotates the keys and invalidates all existing browser subscriptions.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -40,6 +40,11 @@ class HandleInertiaRequests extends Middleware
                 'message' => fn () => $request->session()->get('message'),
                 'error' => fn () => $request->session()->get('error'),
             ],
+            'webPush' => [
+                // Public VAPID key so the browser can subscribe. Safe to expose;
+                // the private key stays server-side. Null when unconfigured.
+                'vapidPublicKey' => config('services.vapid.public_key'),
+            ],
         ];
     }
 }

--- a/app/Http/Requests/StoreDeviceTokenRequest.php
+++ b/app/Http/Requests/StoreDeviceTokenRequest.php
@@ -26,7 +26,7 @@ class StoreDeviceTokenRequest extends FormRequest
     {
         return [
             'platform' => ['required', 'string', Rule::in(['ios', 'android', 'web'])],
-            'provider' => ['required', 'string', Rule::in(['apns', 'fcm'])],
+            'provider' => ['required', 'string', Rule::in(['apns', 'fcm', 'webpush'])],
             'token' => ['required', 'string', 'max:512'],
             'meta' => ['nullable', 'array'],
         ];

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -109,6 +109,22 @@ class User extends Authenticatable
             ->all();
     }
 
+    /**
+     * Route notifications for the Web Push channel.
+     *
+     * Returns the user's web-push PushToken models (provider = webpush); the
+     * WebPushChannel reads each row's `meta` (endpoint + keys) to build the
+     * browser subscription.
+     *
+     * @return \Illuminate\Database\Eloquent\Collection<int, \App\Models\PushToken>
+     */
+    public function routeNotificationForWebPush()
+    {
+        return $this->pushTokens()
+            ->where('provider', 'webpush')
+            ->get();
+    }
+
     public function categories(): HasMany
     {
         return $this->hasMany(Category::class);

--- a/app/Notifications/Channels/WebPushChannel.php
+++ b/app/Notifications/Channels/WebPushChannel.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Notifications\Channels;
+
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use Minishlink\WebPush\Subscription;
+use Minishlink\WebPush\WebPush;
+
+/**
+ * Custom notification channel that delivers Web Push (VAPID) messages to a
+ * user's registered browser subscriptions.
+ *
+ * Subscriptions live in the shared, provider-agnostic `push_tokens` table
+ * (provider = 'webpush'): the browser's PushSubscription JSON is stored in the
+ * `meta` column and a SHA-256 of the endpoint in `token`. A notification opts in
+ * by implementing `toWebPush($notifiable): array` returning at least
+ * `['title', 'body']` (plus optional `url`, `tag`, `icon`) — the shape the
+ * service worker (`public/push-sw.js`) expects.
+ */
+class WebPushChannel
+{
+    public function send(object $notifiable, Notification $notification): void
+    {
+        if (! method_exists($notification, 'toWebPush')) {
+            return;
+        }
+
+        $tokens = $this->subscriptionsFor($notifiable);
+        if ($tokens->isEmpty()) {
+            return;
+        }
+
+        $config = config('services.vapid');
+        if (empty($config['public_key']) || empty($config['private_key'])) {
+            Log::warning('[webpush] VAPID keys are not configured; skipping web push. Run `php artisan webpush:vapid`.');
+
+            return;
+        }
+
+        $payload = json_encode($notification->toWebPush($notifiable));
+
+        $webPush = $this->makeWebPush([
+            'VAPID' => [
+                'subject' => $config['subject'],
+                'publicKey' => $config['public_key'],
+                'privateKey' => $config['private_key'],
+            ],
+        ]);
+
+        // Map each endpoint back to its PushToken row so dead ones can be pruned.
+        $byEndpoint = [];
+
+        foreach ($tokens as $token) {
+            $meta = $token->meta ?? [];
+            $endpoint = $meta['endpoint'] ?? null;
+            $keys = $meta['keys'] ?? [];
+
+            if (! $endpoint || empty($keys['p256dh']) || empty($keys['auth'])) {
+                continue;
+            }
+
+            $byEndpoint[$endpoint] = $token;
+
+            $webPush->queueNotification(
+                Subscription::create([
+                    'endpoint' => $endpoint,
+                    'keys' => [
+                        'p256dh' => $keys['p256dh'],
+                        'auth' => $keys['auth'],
+                    ],
+                ]),
+                $payload,
+            );
+        }
+
+        foreach ($webPush->flush() as $report) {
+            if ($report->isSuccess()) {
+                continue;
+            }
+
+            $endpoint = $report->getEndpoint();
+
+            // 404/410 mean the browser dropped the subscription — prune it so the
+            // store self-heals and we stop pushing to a dead endpoint.
+            if ($report->isSubscriptionExpired() && isset($byEndpoint[$endpoint])) {
+                $byEndpoint[$endpoint]->delete();
+
+                continue;
+            }
+
+            Log::warning('[webpush] delivery failed', [
+                'endpoint' => $endpoint,
+                'reason' => $report->getReason(),
+            ]);
+        }
+    }
+
+    /**
+     * Build the WebPush client. Extracted so tests can substitute a double.
+     *
+     * @param  array<string, mixed>  $auth
+     */
+    protected function makeWebPush(array $auth): WebPush
+    {
+        return new WebPush($auth);
+    }
+
+    /**
+     * Resolve the notifiable's web-push subscriptions as a collection of
+     * PushToken models.
+     */
+    protected function subscriptionsFor(object $notifiable): Collection
+    {
+        if (method_exists($notifiable, 'routeNotificationForWebPush')) {
+            return collect($notifiable->routeNotificationForWebPush());
+        }
+
+        if (method_exists($notifiable, 'pushTokens')) {
+            return $notifiable->pushTokens()->where('provider', 'webpush')->get();
+        }
+
+        return collect();
+    }
+}

--- a/app/Notifications/CustomReminder.php
+++ b/app/Notifications/CustomReminder.php
@@ -3,6 +3,7 @@
 namespace App\Notifications;
 
 use App\Models\Reminder;
+use App\Notifications\Channels\WebPushChannel;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -46,6 +47,12 @@ class CustomReminder extends Notification implements ShouldQueue
             $channels[] = ApnChannel::class;
         }
 
+        if (($notifiable->push_notifications_enabled ?? true)
+            && ($notifiable->reminder_notifications_enabled ?? true)
+            && $this->hasWebPushToken($notifiable)) {
+            $channels[] = WebPushChannel::class;
+        }
+
         return $channels;
     }
 
@@ -62,6 +69,21 @@ class CustomReminder extends Notification implements ShouldQueue
         }
 
         return $notifiable->pushTokens()->where('provider', 'apns')->exists();
+    }
+
+    /**
+     * Whether the notifiable has a registered web-push subscription, favouring an
+     * already-loaded relation to avoid a query per notification.
+     */
+    protected function hasWebPushToken(object $notifiable): bool
+    {
+        if (method_exists($notifiable, 'relationLoaded') && $notifiable->relationLoaded('pushTokens')) {
+            return $notifiable->pushTokens
+                ->where('provider', 'webpush')
+                ->isNotEmpty();
+        }
+
+        return $notifiable->pushTokens()->where('provider', 'webpush')->exists();
     }
 
     /**
@@ -94,6 +116,24 @@ class CustomReminder extends Notification implements ShouldQueue
             ->body($body)
             ->custom('task_id', $this->reminder->task_id)
             ->custom('reminder_id', $this->reminder->id);
+    }
+
+    /**
+     * The web-push (browser) representation. `url` deep-links to the task; `tag`
+     * collapses repeated pushes for the same reminder.
+     *
+     * @return array<string, mixed>
+     */
+    public function toWebPush(object $notifiable): array
+    {
+        $task = $this->reminder->task;
+
+        return [
+            'title' => 'Reminder',
+            'body' => $this->reminder->message ?: "Reminder for task '{$task->title}'",
+            'url' => url('/tasks?task='.$this->reminder->task_id),
+            'tag' => 'reminder-'.$this->reminder->id,
+        ];
     }
 
     /**

--- a/app/Notifications/DailyDigest.php
+++ b/app/Notifications/DailyDigest.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications;
 
+use App\Notifications\Channels\WebPushChannel;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -37,7 +38,28 @@ class DailyDigest extends Notification implements ShouldQueue
             $channels[] = 'mail';
         }
 
+        if (($notifiable->push_notifications_enabled ?? true)
+            && ($notifiable->daily_digest_enabled ?? true)
+            && $this->hasWebPushToken($notifiable)) {
+            $channels[] = WebPushChannel::class;
+        }
+
         return $channels;
+    }
+
+    /**
+     * Whether the notifiable has a registered web-push subscription, favouring an
+     * already-loaded relation to avoid a query per notification.
+     */
+    protected function hasWebPushToken(object $notifiable): bool
+    {
+        if (method_exists($notifiable, 'relationLoaded') && $notifiable->relationLoaded('pushTokens')) {
+            return $notifiable->pushTokens
+                ->where('provider', 'webpush')
+                ->isNotEmpty();
+        }
+
+        return $notifiable->pushTokens()->where('provider', 'webpush')->exists();
     }
 
     /**
@@ -52,6 +74,25 @@ class DailyDigest extends Notification implements ShouldQueue
                 'digest' => $this->digestData,
                 'url' => url('/tasks'),
             ]);
+    }
+
+    /**
+     * The web-push (browser) representation. Counts only — the full lists live in
+     * the email and the app.
+     *
+     * @return array<string, mixed>
+     */
+    public function toWebPush(object $notifiable): array
+    {
+        $today = $this->digestData['today_tasks']->count();
+        $overdue = $this->digestData['overdue_tasks']->count();
+
+        return [
+            'title' => 'Daily Task Digest',
+            'body' => "You have {$today} task(s) today and {$overdue} overdue.",
+            'url' => url('/tasks'),
+            'tag' => 'daily-digest',
+        ];
     }
 
     /**

--- a/app/Notifications/TaskDueReminder.php
+++ b/app/Notifications/TaskDueReminder.php
@@ -3,6 +3,7 @@
 namespace App\Notifications;
 
 use App\Models\Task;
+use App\Notifications\Channels\WebPushChannel;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -46,6 +47,12 @@ class TaskDueReminder extends Notification implements ShouldQueue
             $channels[] = ApnChannel::class;
         }
 
+        if (($notifiable->push_notifications_enabled ?? true)
+            && ($notifiable->reminder_notifications_enabled ?? true)
+            && $this->hasWebPushToken($notifiable)) {
+            $channels[] = WebPushChannel::class;
+        }
+
         return $channels;
     }
 
@@ -62,6 +69,21 @@ class TaskDueReminder extends Notification implements ShouldQueue
         }
 
         return $notifiable->pushTokens()->where('provider', 'apns')->exists();
+    }
+
+    /**
+     * Whether the notifiable has a registered web-push subscription, favouring an
+     * already-loaded relation to avoid a query per notification.
+     */
+    protected function hasWebPushToken(object $notifiable): bool
+    {
+        if (method_exists($notifiable, 'relationLoaded') && $notifiable->relationLoaded('pushTokens')) {
+            return $notifiable->pushTokens
+                ->where('provider', 'webpush')
+                ->isNotEmpty();
+        }
+
+        return $notifiable->pushTokens()->where('provider', 'webpush')->exists();
     }
 
     /**
@@ -88,6 +110,22 @@ class TaskDueReminder extends Notification implements ShouldQueue
             ->title('Task Due Reminder')
             ->body("Your task '{$this->task->title}' is due soon.")
             ->custom('task_id', $this->task->id);
+    }
+
+    /**
+     * The web-push (browser) representation. `url` deep-links to the task; `tag`
+     * collapses repeated pushes for the same task.
+     *
+     * @return array<string, mixed>
+     */
+    public function toWebPush(object $notifiable): array
+    {
+        return [
+            'title' => 'Task Due Reminder',
+            'body' => "Your task '{$this->task->title}' is due soon.",
+            'url' => url('/tasks?task='.$this->task->id),
+            'tag' => 'task-'.$this->task->id,
+        ];
     }
 
     /**

--- a/app/Notifications/TaskOverdue.php
+++ b/app/Notifications/TaskOverdue.php
@@ -3,6 +3,7 @@
 namespace App\Notifications;
 
 use App\Models\Task;
+use App\Notifications\Channels\WebPushChannel;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -46,6 +47,12 @@ class TaskOverdue extends Notification implements ShouldQueue
             $channels[] = ApnChannel::class;
         }
 
+        if (($notifiable->push_notifications_enabled ?? true)
+            && ($notifiable->reminder_notifications_enabled ?? true)
+            && $this->hasWebPushToken($notifiable)) {
+            $channels[] = WebPushChannel::class;
+        }
+
         return $channels;
     }
 
@@ -62,6 +69,21 @@ class TaskOverdue extends Notification implements ShouldQueue
         }
 
         return $notifiable->pushTokens()->where('provider', 'apns')->exists();
+    }
+
+    /**
+     * Whether the notifiable has a registered web-push subscription, favouring an
+     * already-loaded relation to avoid a query per notification.
+     */
+    protected function hasWebPushToken(object $notifiable): bool
+    {
+        if (method_exists($notifiable, 'relationLoaded') && $notifiable->relationLoaded('pushTokens')) {
+            return $notifiable->pushTokens
+                ->where('provider', 'webpush')
+                ->isNotEmpty();
+        }
+
+        return $notifiable->pushTokens()->where('provider', 'webpush')->exists();
     }
 
     /**
@@ -88,6 +110,22 @@ class TaskOverdue extends Notification implements ShouldQueue
             ->title('Task Overdue')
             ->body("Your task '{$this->task->title}' is now overdue.")
             ->custom('task_id', $this->task->id);
+    }
+
+    /**
+     * The web-push (browser) representation. `url` deep-links to the task; `tag`
+     * collapses repeated pushes for the same task.
+     *
+     * @return array<string, mixed>
+     */
+    public function toWebPush(object $notifiable): array
+    {
+        return [
+            'title' => 'Task Overdue',
+            'body' => "Your task '{$this->task->title}' is now overdue.",
+            'url' => url('/tasks?task='.$this->task->id),
+            'tag' => 'task-'.$this->task->id,
+        ];
     }
 
     /**

--- a/app/Notifications/TestNotification.php
+++ b/app/Notifications/TestNotification.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications;
 
+use App\Notifications\Channels\WebPushChannel;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
@@ -18,13 +19,45 @@ class TestNotification extends Notification
     }
 
     /**
-     * Delivery channels: email + database (so it appears in the in-app bell).
+     * Delivery channels for the test notification.
+     *
+     * The in-app bell (database) fires first and unconditionally so a hiccup on
+     * another channel can never suppress it. Web push is appended when the user
+     * has opted into push and registered a browser subscription — this is what
+     * makes the admin "Send test notification" button deliver a real device
+     * notification. Mail is last (and, in local/dev, `MAIL_MAILER=log` means it
+     * only lands in the log).
      *
      * @return array<int, string>
      */
     public function via(object $notifiable): array
     {
-        return ['mail', 'database'];
+        $channels = ['database'];
+
+        if (($notifiable->push_notifications_enabled ?? true)
+            && $this->hasWebPushToken($notifiable)) {
+            $channels[] = WebPushChannel::class;
+        }
+
+        $channels[] = 'mail';
+
+        return $channels;
+    }
+
+    /**
+     * Whether the notifiable has a registered web-push subscription, favouring an
+     * already-loaded relation to avoid a query per notification.
+     */
+    protected function hasWebPushToken(object $notifiable): bool
+    {
+        if (method_exists($notifiable, 'relationLoaded') && $notifiable->relationLoaded('pushTokens')) {
+            return $notifiable->pushTokens
+                ->where('provider', 'webpush')
+                ->isNotEmpty();
+        }
+
+        return method_exists($notifiable, 'pushTokens')
+            && $notifiable->pushTokens()->where('provider', 'webpush')->exists();
     }
 
     public function toMail(object $notifiable): MailMessage
@@ -34,6 +67,22 @@ class TestNotification extends Notification
             ->greeting('Hello '.($notifiable->name ?? '').'!')
             ->line($this->message)
             ->line('No action is required — this is only a test.');
+    }
+
+    /**
+     * The web-push (browser/device) representation. The service worker reads
+     * `title`, `body`, and `url`; `tag` collapses repeated test pushes.
+     *
+     * @return array<string, mixed>
+     */
+    public function toWebPush(object $notifiable): array
+    {
+        return [
+            'title' => $this->title,
+            'body' => $this->message,
+            'url' => url('/'),
+            'tag' => 'test-notification',
+        ];
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "laravel/framework": "^12.0",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.10.1",
+        "minishlink/web-push": "^11.0",
         "phpoffice/phpspreadsheet": "^5.9",
         "phpoffice/phpword": "^1.4",
         "symfony/console": "~7.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "49d2fd9c7a5309307e57b7519f464175",
+    "content-hash": "7a107c562e0bb154b5024e2ff62dc1b6",
     "packages": [
         {
             "name": "brick/math",
@@ -2781,6 +2781,85 @@
             "time": "2022-12-02T22:17:43+00:00"
         },
         {
+            "name": "minishlink/web-push",
+            "version": "v11.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/web-push-libs/web-push-php.git",
+                "reference": "f8410afb73486ab895bb4792b879bdca62025b47"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/web-push-libs/web-push-php/zipball/f8410afb73486ab895bb4792b879bdca62025b47",
+                "reference": "f8410afb73486ab895bb4792b879bdca62025b47",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-openssl": "*",
+                "php": ">=8.2",
+                "php-http/discovery": "^1.19",
+                "php-http/httplug": "^2.4",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1|^2.0",
+                "psr/log": "^2.0|^3.0",
+                "spomky-labs/base64url": "^2.0.4",
+                "symfony/polyfill-php83": "^1.33",
+                "web-token/jwt-library": "^3.4.9|^4.0.6"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^v3.92.2",
+                "guzzlehttp/guzzle": "^7.9.2",
+                "guzzlehttp/psr7": "^2.7",
+                "php-http/guzzle7-adapter": "^1.1",
+                "phpstan/phpstan": "^2.1.33",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^11.5.46|^12.5.2",
+                "symfony/polyfill-iconv": "^1.33"
+            },
+            "suggest": {
+                "ext-bcmath": "Optional for performance.",
+                "ext-gmp": "Optional for performance.",
+                "php-http/guzzle7-adapter": "Enables concurrent sending via WebPush::flushPooled() if you use Guzzle."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Minishlink\\WebPush\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Louis Lagrange",
+                    "email": "lagrange.louis@gmail.com",
+                    "homepage": "https://github.com/Minishlink"
+                }
+            ],
+            "description": "Web Push library for PHP",
+            "homepage": "https://github.com/web-push-libs/web-push-php",
+            "keywords": [
+                "Push API",
+                "WebPush",
+                "notifications",
+                "push",
+                "web"
+            ],
+            "support": {
+                "issues": "https://github.com/web-push-libs/web-push-php/issues",
+                "source": "https://github.com/web-push-libs/web-push-php/tree/v11.0.0"
+            },
+            "time": "2026-07-23T16:10:05+00:00"
+        },
+        {
             "name": "monolog/monolog",
             "version": "3.10.0",
             "source": {
@@ -3407,6 +3486,194 @@
                 "source": "https://github.com/paragonie/random_compat"
             },
             "time": "2020-10-15T08:29:30+00:00"
+        },
+        {
+            "name": "php-http/discovery",
+            "version": "1.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/discovery.git",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0|^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "nyholm/psr7": "<1.0",
+                "zendframework/zend-diactoros": "*"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "*",
+                "psr/http-factory-implementation": "*",
+                "psr/http-message-implementation": "*"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0.2|^2.0",
+                "graham-campbell/phpspec-skip-example-extension": "^5.0",
+                "php-http/httplug": "^1.0 || ^2.0",
+                "php-http/message-factory": "^1.0",
+                "phpspec/phpspec": "^5.1 || ^6.1 || ^7.3",
+                "sebastian/comparator": "^3.0.5 || ^4.0.8",
+                "symfony/phpunit-bridge": "^6.4.4 || ^7.0.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Http\\Discovery\\Composer\\Plugin",
+                "plugin-optional": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Discovery\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/Composer/Plugin.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Finds and installs PSR-7, PSR-17, PSR-18 and HTTPlug implementations",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "adapter",
+                "client",
+                "discovery",
+                "factory",
+                "http",
+                "message",
+                "psr17",
+                "psr7"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/discovery/issues",
+                "source": "https://github.com/php-http/discovery/tree/1.20.0"
+            },
+            "time": "2024-10-02T11:20:13+00:00"
+        },
+        {
+            "name": "php-http/httplug",
+            "version": "2.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/httplug.git",
+                "reference": "5cad731844891a4c282f3f3e1b582c46839d22f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/httplug/zipball/5cad731844891a4c282f3f3e1b582c46839d22f4",
+                "reference": "5cad731844891a4c282f3f3e1b582c46839d22f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "php-http/promise": "^1.1",
+                "psr/http-client": "^1.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "require-dev": {
+                "friends-of-phpspec/phpspec-code-coverage": "^4.1 || ^5.0 || ^6.0",
+                "phpspec/phpspec": "^5.1 || ^6.0 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eric GELOEN",
+                    "email": "geloen.eric@gmail.com"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "HTTPlug, the HTTP client abstraction for PHP",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "client",
+                "http"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/httplug/issues",
+                "source": "https://github.com/php-http/httplug/tree/2.4.1"
+            },
+            "time": "2024-09-23T11:39:58+00:00"
+        },
+        {
+            "name": "php-http/promise",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/promise.git",
+                "reference": "fc85b1fba37c169a69a07ef0d5a8075770cc1f83"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/promise/zipball/fc85b1fba37c169a69a07ef0d5a8075770cc1f83",
+                "reference": "fc85b1fba37c169a69a07ef0d5a8075770cc1f83",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "friends-of-phpspec/phpspec-code-coverage": "^4.3.2 || ^6.3",
+                "phpspec/phpspec": "^5.1.2 || ^6.2 || ^7.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Http\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joel Wurtz",
+                    "email": "joel.wurtz@gmail.com"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Promise used for asynchronous HTTP requests",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/promise/issues",
+                "source": "https://github.com/php-http/promise/tree/1.3.1"
+            },
+            "time": "2024-03-15T13:55:21+00:00"
         },
         {
             "name": "phpoffice/math",
@@ -4599,6 +4866,71 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.3"
             },
             "time": "2026-06-18T03:57:49+00:00"
+        },
+        {
+            "name": "spomky-labs/base64url",
+            "version": "v2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Spomky-Labs/base64url.git",
+                "reference": "7752ce931ec285da4ed1f4c5aa27e45e097be61d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Spomky-Labs/base64url/zipball/7752ce931ec285da4ed1f4c5aa27e45e097be61d",
+                "reference": "7752ce931ec285da4ed1f4c5aa27e45e097be61d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.11|^0.12",
+                "phpstan/phpstan-beberlei-assert": "^0.11|^0.12",
+                "phpstan/phpstan-deprecation-rules": "^0.11|^0.12",
+                "phpstan/phpstan-phpunit": "^0.11|^0.12",
+                "phpstan/phpstan-strict-rules": "^0.11|^0.12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Base64Url\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky-Labs/base64url/contributors"
+                }
+            ],
+            "description": "Base 64 URL Safe Encoding/Decoding PHP Library",
+            "homepage": "https://github.com/Spomky-Labs/base64url",
+            "keywords": [
+                "base64",
+                "rfc4648",
+                "safe",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/base64url/issues",
+                "source": "https://github.com/Spomky-Labs/base64url/tree/v2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2020-11-03T09:10:25+00:00"
         },
         {
             "name": "spomky-labs/pki-framework",

--- a/config/services.php
+++ b/config/services.php
@@ -39,6 +39,20 @@ return [
         'client_id' => env('GOOGLE_CLIENT_ID'),
         'client_secret' => env('GOOGLE_CLIENT_SECRET'),
         'redirect' => env('GOOGLE_REDIRECT_URI'),
-    ]
+    ],
+
+    /*
+    | Web Push (VAPID) credentials for browser/PWA push notifications. Generate a
+    | keypair with `php artisan webpush:vapid` and copy the values here. The
+    | public key is also exposed to the frontend (see HandleInertiaRequests) so
+    | the browser can subscribe; the private key must stay server-side. `subject`
+    | is a contact URL or mailto: identifying the application server to push
+    | services (required by the VAPID spec).
+    */
+    'vapid' => [
+        'public_key' => env('VAPID_PUBLIC_KEY'),
+        'private_key' => env('VAPID_PRIVATE_KEY'),
+        'subject' => env('VAPID_SUBJECT', env('APP_URL', 'https://wevie.app')),
+    ],
 
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "maseru",
+    "name": "vienna-v1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/public/push-sw.js
+++ b/public/push-sw.js
@@ -1,0 +1,58 @@
+/**
+ * Web Push handlers for Wevie.
+ *
+ * This script is layered onto the Workbox-generated service worker via
+ * `workbox.importScripts` in vite.config.js (so the offline/caching config
+ * stays untouched). It handles two events:
+ *   - `push`: renders the notification the WebPushChannel sent
+ *     (payload shape: { title, body, url, tag, icon }).
+ *   - `notificationclick`: focuses an existing app tab (navigating it to the
+ *     payload's `url`) or opens a new one.
+ */
+
+self.addEventListener("push", (event) => {
+    let data = {};
+    try {
+        data = event.data ? event.data.json() : {};
+    } catch {
+        data = { title: "Wevie", body: event.data ? event.data.text() : "" };
+    }
+
+    const title = data.title || "Wevie";
+    const options = {
+        body: data.body || "",
+        icon: data.icon || "/icons/icon-192x192v2.png",
+        badge: "/icons/icon-192x192v2.png",
+        tag: data.tag || undefined,
+        data: { url: data.url || "/" },
+    };
+
+    event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener("notificationclick", (event) => {
+    event.notification.close();
+
+    const targetUrl =
+        (event.notification.data && event.notification.data.url) || "/";
+
+    event.waitUntil(
+        self.clients
+            .matchAll({ type: "window", includeUncontrolled: true })
+            .then((clientList) => {
+                for (const client of clientList) {
+                    if ("focus" in client) {
+                        client.focus();
+                        if ("navigate" in client) {
+                            client.navigate(targetUrl).catch(() => {});
+                        }
+                        return undefined;
+                    }
+                }
+                if (self.clients.openWindow) {
+                    return self.clients.openWindow(targetUrl);
+                }
+                return undefined;
+            })
+    );
+});

--- a/resources/js/Pages/Admin/Tools/Index.jsx
+++ b/resources/js/Pages/Admin/Tools/Index.jsx
@@ -1,5 +1,6 @@
 import TodoLayout from "@/Layouts/TodoLayout";
 import Toast from "@/Components/Toast";
+import { enableWebPush, isWebPushSupported } from "@/native/registerWebPush";
 import { Head, useForm, usePage } from "@inertiajs/react";
 import { useEffect, useMemo, useState } from "react";
 import {
@@ -19,6 +20,7 @@ import {
     ChevronDown,
     Check,
     Wrench,
+    Smartphone,
 } from "lucide-react";
 import { toast } from "react-toastify";
 
@@ -29,9 +31,7 @@ function UserCombobox({ users, value, onChange, id }) {
         if (query === "") return users;
         const q = query.toLowerCase();
         return users.filter(
-            (u) =>
-                u.name.toLowerCase().includes(q) ||
-                u.email.toLowerCase().includes(q)
+            (u) => u.name.toLowerCase().includes(q) || u.email.toLowerCase().includes(q)
         );
     }, [users, query]);
 
@@ -43,9 +43,7 @@ function UserCombobox({ users, value, onChange, id }) {
                         id={id}
                         className="w-full rounded-md border border-light-border/70 dark:border-white/10 bg-white dark:bg-dark-card px-3 py-2 pr-10 text-sm text-gray-900 dark:text-white focus:border-primary-500 focus:ring-primary-500"
                         placeholder="Search by name or email..."
-                        displayValue={(user) =>
-                            user ? `${user.name} (${user.email})` : ""
-                        }
+                        displayValue={(user) => (user ? `${user.name} (${user.email})` : "")}
                         onChange={(e) => setQuery(e.target.value)}
                     />
                     <ComboboxButton className="absolute inset-y-0 right-0 flex items-center pr-2">
@@ -65,9 +63,7 @@ function UserCombobox({ users, value, onChange, id }) {
                                 className="group flex cursor-pointer items-center justify-between px-3 py-2 text-sm text-gray-900 dark:text-gray-100 data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-900/20"
                             >
                                 <span className="truncate">
-                                    <span className="font-medium">
-                                        {user.name}
-                                    </span>{" "}
+                                    <span className="font-medium">{user.name}</span>{" "}
                                     <span className="text-gray-500 dark:text-gray-400">
                                         {user.email}
                                     </span>
@@ -93,9 +89,7 @@ function ToolCard({ icon: Icon, title, description, children }) {
                     <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">
                         {title}
                     </h3>
-                    <p className="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
-                        {description}
-                    </p>
+                    <p className="mt-0.5 text-sm text-gray-500 dark:text-gray-400">{description}</p>
                     <div className="mt-4 space-y-3">{children}</div>
                 </div>
             </div>
@@ -133,6 +127,22 @@ export default function Index({ users }) {
             .post(route("admin.tools.test-notification"), {
                 preserveScroll: true,
             });
+    };
+
+    // Enable web push on this device (must run from a user gesture).
+    const vapidPublicKey = props.webPush?.vapidPublicKey ?? null;
+    const pushSupported = isWebPushSupported();
+    const [enablingPush, setEnablingPush] = useState(false);
+    const handleEnablePush = async () => {
+        setEnablingPush(true);
+        try {
+            await enableWebPush(vapidPublicKey);
+            toast.success("Push enabled on this device. Send yourself a test notification below.");
+        } catch (error) {
+            toast.error(error?.message || "Couldn't enable push on this device.");
+        } finally {
+            setEnablingPush(false);
+        }
     };
 
     // Clear daily summary
@@ -179,8 +189,7 @@ export default function Index({ users }) {
         "inline-flex items-center justify-center gap-2 rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50";
     const inputClass =
         "w-full rounded-md border border-light-border/70 dark:border-white/10 bg-white dark:bg-dark-card px-3 py-2 text-sm text-gray-900 dark:text-white focus:border-primary-500 focus:ring-primary-500";
-    const labelClass =
-        "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1";
+    const labelClass = "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1";
     const errorClass = "mt-1 text-sm text-red-600 dark:text-red-400";
 
     return (
@@ -211,46 +220,36 @@ export default function Index({ users }) {
                                 type="email"
                                 required
                                 value={emailForm.data.email}
-                                onChange={(e) =>
-                                    emailForm.setData("email", e.target.value)
-                                }
+                                onChange={(e) => emailForm.setData("email", e.target.value)}
                                 placeholder="you@example.com"
                                 className={inputClass}
                             />
                             {emailForm.errors.email && (
-                                <p className={errorClass}>
-                                    {emailForm.errors.email}
-                                </p>
+                                <p className={errorClass}>{emailForm.errors.email}</p>
                             )}
                         </div>
                         <div>
                             <label htmlFor="email-subject" className={labelClass}>
-                                Subject{" "}
-                                <span className="text-gray-400">(optional)</span>
+                                Subject <span className="text-gray-400">(optional)</span>
                             </label>
                             <input
                                 id="email-subject"
                                 type="text"
                                 value={emailForm.data.subject}
-                                onChange={(e) =>
-                                    emailForm.setData("subject", e.target.value)
-                                }
+                                onChange={(e) => emailForm.setData("subject", e.target.value)}
                                 placeholder="Wevie test email"
                                 className={inputClass}
                             />
                         </div>
                         <div>
                             <label htmlFor="email-message" className={labelClass}>
-                                Message{" "}
-                                <span className="text-gray-400">(optional)</span>
+                                Message <span className="text-gray-400">(optional)</span>
                             </label>
                             <textarea
                                 id="email-message"
                                 rows={2}
                                 value={emailForm.data.message}
-                                onChange={(e) =>
-                                    emailForm.setData("message", e.target.value)
-                                }
+                                onChange={(e) => emailForm.setData("message", e.target.value)}
                                 placeholder="Custom body text..."
                                 className={inputClass}
                             />
@@ -270,8 +269,38 @@ export default function Index({ users }) {
                 <ToolCard
                     icon={Bell}
                     title="Send test notification"
-                    description="Send a test notification (email + in-app bell) to a user."
+                    description="Send a test notification (in-app bell + web push + email) to a user."
                 >
+                    <div className="rounded-md border border-light-border/70 dark:border-white/10 bg-gray-50 dark:bg-white/5 p-3">
+                        <p className="text-sm font-medium text-gray-700 dark:text-gray-200">
+                            Web push on this device
+                        </p>
+                        <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                            {pushSupported
+                                ? "Enable browser notifications, then send yourself a test below to get a real device push."
+                                : "This browser doesn't support web push (needs a secure context; on iOS, install the app to your home screen first)."}
+                        </p>
+                        <button
+                            type="button"
+                            onClick={handleEnablePush}
+                            disabled={!pushSupported || !vapidPublicKey || enablingPush}
+                            className={`${primaryBtn} mt-3`}
+                            title={
+                                !vapidPublicKey
+                                    ? "Web push isn't configured on the server (missing VAPID key)."
+                                    : undefined
+                            }
+                        >
+                            <Smartphone className="h-4 w-4" />
+                            {enablingPush ? "Enabling…" : "Enable notifications on this device"}
+                        </button>
+                        {!vapidPublicKey && (
+                            <p className={errorClass}>
+                                Server VAPID key missing — run{" "}
+                                <code>php artisan webpush:vapid</code> and set it in .env.
+                            </p>
+                        )}
+                    </div>
                     <form onSubmit={submitNotification} className="space-y-3">
                         <div>
                             <label htmlFor="notify-user" className={labelClass}>
@@ -284,23 +313,18 @@ export default function Index({ users }) {
                                 onChange={setNotifyUser}
                             />
                             {notifyForm.errors.user_id && (
-                                <p className={errorClass}>
-                                    {notifyForm.errors.user_id}
-                                </p>
+                                <p className={errorClass}>{notifyForm.errors.user_id}</p>
                             )}
                         </div>
                         <div>
                             <label htmlFor="notify-message" className={labelClass}>
-                                Message{" "}
-                                <span className="text-gray-400">(optional)</span>
+                                Message <span className="text-gray-400">(optional)</span>
                             </label>
                             <textarea
                                 id="notify-message"
                                 rows={2}
                                 value={notifyForm.data.message}
-                                onChange={(e) =>
-                                    notifyForm.setData("message", e.target.value)
-                                }
+                                onChange={(e) => notifyForm.setData("message", e.target.value)}
                                 placeholder="Custom notification text..."
                                 className={inputClass}
                             />

--- a/resources/js/native/registerWebPush.js
+++ b/resources/js/native/registerWebPush.js
@@ -1,0 +1,124 @@
+/**
+ * Web Push (VAPID) subscription for the Wevie PWA / browser.
+ *
+ * Complements the iOS-only `registerPush.js`: this path targets normal browsers
+ * (desktop Chrome/Edge/Firefox, Android Chrome, and installed iOS 16.4+ PWAs)
+ * and needs no native shell. Because it prompts for notification permission and
+ * subscribes the browser, `enableWebPush()` must be called from a user gesture
+ * (e.g. a button click), not on app mount.
+ *
+ * The subscription is stored server-side in the shared `push_tokens` table via
+ * the existing `device-tokens.store` endpoint, with provider `webpush`: a
+ * SHA-256 of the endpoint as the stable `token` (fits the 512-char column and
+ * powers the idempotent upsert) and the full PushSubscription JSON in `meta`.
+ */
+
+/**
+ * Whether this browser can do Web Push at all.
+ */
+export function isWebPushSupported() {
+    return (
+        typeof window !== "undefined" &&
+        "serviceWorker" in navigator &&
+        "PushManager" in window &&
+        "Notification" in window &&
+        window.isSecureContext === true
+    );
+}
+
+/**
+ * Resolves a Ziggy route by name, falling back to a literal path when the global
+ * `route()` helper isn't available. Mirrors the helper in `registerPush.js`.
+ */
+function routeOr(name, params, fallback) {
+    if (typeof window !== "undefined" && typeof window.route === "function") {
+        try {
+            return window.route(name, params);
+        } catch {
+            // Route not registered in this build — fall through to the literal.
+        }
+    }
+    return fallback;
+}
+
+/**
+ * Converts a base64url VAPID public key into the Uint8Array that
+ * `PushManager.subscribe` expects for `applicationServerKey`.
+ */
+function urlBase64ToUint8Array(base64String) {
+    const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+    const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+    const raw = window.atob(base64);
+    const output = new Uint8Array(raw.length);
+    for (let i = 0; i < raw.length; i += 1) {
+        output[i] = raw.charCodeAt(i);
+    }
+    return output;
+}
+
+/**
+ * SHA-256 hex digest of a string (used as the stable device-token id).
+ */
+async function sha256Hex(input) {
+    const data = new TextEncoder().encode(input);
+    const digest = await crypto.subtle.digest("SHA-256", data);
+    return Array.from(new Uint8Array(digest))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+}
+
+/**
+ * POSTs the browser subscription to the backend using the app's configured
+ * axios (same-origin, so the session cookie + XSRF header ride along).
+ */
+async function sendSubscription(subscription) {
+    const axios = typeof window !== "undefined" ? window.axios : null;
+    if (!axios) {
+        throw new Error("window.axios unavailable — cannot register subscription.");
+    }
+
+    const json = subscription.toJSON();
+    const token = await sha256Hex(json.endpoint);
+
+    await axios.post(routeOr("device-tokens.store", undefined, "/device-tokens"), {
+        platform: "web",
+        provider: "webpush",
+        token,
+        meta: json,
+    });
+}
+
+/**
+ * Requests notification permission, subscribes this browser to push, and
+ * registers the subscription with the backend. Call from a user gesture.
+ *
+ * @param {string} vapidPublicKey  The server's public VAPID key (Inertia prop
+ *                                 `webPush.vapidPublicKey`).
+ * @returns {Promise<PushSubscription>}
+ */
+export async function enableWebPush(vapidPublicKey) {
+    if (!isWebPushSupported()) {
+        throw new Error("Push notifications aren't supported in this browser.");
+    }
+    if (!vapidPublicKey) {
+        throw new Error("Web push isn't configured on the server (missing VAPID key).");
+    }
+
+    const permission = await Notification.requestPermission();
+    if (permission !== "granted") {
+        throw new Error("Notification permission was not granted.");
+    }
+
+    const registration = await navigator.serviceWorker.ready;
+
+    let subscription = await registration.pushManager.getSubscription();
+    if (!subscription) {
+        subscription = await registration.pushManager.subscribe({
+            userVisibleOnly: true,
+            applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
+        });
+    }
+
+    await sendSubscription(subscription);
+    return subscription;
+}

--- a/tests/Feature/WebPushChannelTest.php
+++ b/tests/Feature/WebPushChannelTest.php
@@ -1,0 +1,145 @@
+<?php
+
+use App\Models\PushToken;
+use App\Models\Task;
+use App\Models\User;
+use App\Notifications\Channels\WebPushChannel;
+use App\Notifications\TaskDueReminder;
+use App\Notifications\TestNotification;
+use App\Services\NotificationService;
+use GuzzleHttp\Psr7\Request as GuzzleRequest;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use Illuminate\Support\Facades\Notification;
+use Minishlink\WebPush\MessageSentReport;
+use Minishlink\WebPush\WebPush;
+
+/**
+ * Web Push channel: via() must gate WebPushChannel on push_notifications_enabled
+ * AND the presence of a registered webpush subscription; the channel must prune
+ * a subscription the push service reports as expired (404/410).
+ */
+function makeWebPushTask(User $user): Task
+{
+    return Task::create([
+        'user_id' => $user->id,
+        'title' => 'Ship the release',
+        'priority' => 'high',
+        'status' => 'pending',
+        'due_date' => now()->addDays(2),
+    ]);
+}
+
+function makeWebPushToken(User $user, string $endpoint = 'https://push.example.com/abc'): PushToken
+{
+    return PushToken::factory()->for($user)->create([
+        'provider' => 'webpush',
+        'platform' => 'web',
+        'token' => hash('sha256', $endpoint),
+        'meta' => [
+            'endpoint' => $endpoint,
+            'keys' => ['p256dh' => 'test-p256dh', 'auth' => 'test-auth'],
+        ],
+    ]);
+}
+
+it('includes the web-push channel for the test notification when a subscription exists', function () {
+    Notification::fake();
+
+    $user = User::factory()->create(['push_notifications_enabled' => true]);
+    makeWebPushToken($user);
+
+    $user->notify(new TestNotification);
+
+    Notification::assertSentTo(
+        $user,
+        TestNotification::class,
+        fn ($notification, $channels) => in_array(WebPushChannel::class, $channels, true)
+    );
+});
+
+it('excludes the web-push channel from the test notification when no subscription exists', function () {
+    Notification::fake();
+
+    $user = User::factory()->create(['push_notifications_enabled' => true]);
+
+    $user->notify(new TestNotification);
+
+    Notification::assertSentTo(
+        $user,
+        TestNotification::class,
+        fn ($notification, $channels) => ! in_array(WebPushChannel::class, $channels, true)
+    );
+});
+
+it('includes the web-push channel for reminders when push is enabled and a subscription exists', function () {
+    Notification::fake();
+
+    $user = User::factory()->create(['push_notifications_enabled' => true]);
+    makeWebPushToken($user);
+    $task = makeWebPushTask($user);
+
+    app(NotificationService::class)->sendTaskDueReminder($task);
+
+    Notification::assertSentTo(
+        $user,
+        TaskDueReminder::class,
+        fn ($notification, $channels) => in_array(WebPushChannel::class, $channels, true)
+    );
+});
+
+it('excludes the web-push channel when push notifications are disabled', function () {
+    Notification::fake();
+
+    $user = User::factory()->create(['push_notifications_enabled' => false]);
+    makeWebPushToken($user);
+    $task = makeWebPushTask($user);
+
+    app(NotificationService::class)->sendTaskDueReminder($task);
+
+    Notification::assertSentTo(
+        $user,
+        TaskDueReminder::class,
+        fn ($notification, $channels) => ! in_array(WebPushChannel::class, $channels, true)
+    );
+});
+
+it('prunes a web-push subscription when the push service reports it expired', function () {
+    config()->set('services.vapid', [
+        'public_key' => 'test-public',
+        'private_key' => 'test-private',
+        'subject' => 'mailto:test@example.com',
+    ]);
+
+    $user = User::factory()->create(['push_notifications_enabled' => true]);
+    $endpoint = 'https://push.example.com/gone';
+    $token = makeWebPushToken($user, $endpoint);
+
+    // A 410 Gone report — the push service dropped this subscription.
+    $report = new MessageSentReport(
+        new GuzzleRequest('POST', $endpoint),
+        new GuzzleResponse(410),
+        false,
+        'Gone'
+    );
+
+    $webPush = Mockery::mock(WebPush::class);
+    $webPush->shouldReceive('queueNotification')->once();
+    // flush() is declared to return a Generator, so yield the report.
+    $webPush->shouldReceive('flush')->once()->andReturnUsing(function () use ($report) {
+        yield $report;
+    });
+
+    $channel = new class($webPush) extends WebPushChannel
+    {
+        public function __construct(private WebPush $stub) {}
+
+        protected function makeWebPush(array $auth): WebPush
+        {
+            return $this->stub;
+        }
+    };
+
+    $channel->send($user, new TestNotification);
+
+    expect(PushToken::find($token->id))->toBeNull();
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -62,6 +62,10 @@ export default defineConfig({
             },
             workbox: {
                 cleanupOutdatedCaches: true,
+                // Layer our Web Push handlers (push / notificationclick) onto the
+                // generated SW without touching the caching config below. Served
+                // as a static file from public/push-sw.js.
+                importScripts: ['/push-sw.js'],
                 navigateFallback: '/offline.html',
                 navigateFallbackDenylist: [
                     /^\/api\//,


### PR DESCRIPTION
Fixes the admin "Send test notification" flow, which previously delivered nothing visible: the in-app bell now writes first in `TestNotification::via()` so a mail-channel hiccup can't suppress it, and a new **Web Push (VAPID)** channel lets the button (and the reminder/digest notifications) deliver a real device notification in the browser.

The `WebPushChannel` (built on `minishlink/web-push`, with 404/410 self-healing) reuses the existing provider-agnostic `push_tokens` table and `device-tokens` endpoints rather than adding a new store, and is gated on the user's push preference plus a registered subscription. Server setup adds a `php artisan webpush:vapid` command, `services.vapid` config/env, and the public VAPID key shared via Inertia; the frontend adds `registerWebPush.js`, an "Enable notifications on this device" button on the Admin Tools page, and a service-worker push/notificationclick handler (`public/push-sw.js`) layered into the Workbox config.

Verified by a new `WebPushChannelTest` (channel gating + expired-subscription pruning) plus the related notification/device-token suites, with `npm run build`, Pint, ESLint, and Prettier all clean.

**To enable:** run `php artisan webpush:vapid` and set the keys in `.env`, then build the frontend (the service worker is only emitted by `npm run build` and registered in production). Web push does not touch the existing iOS/APNs path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)