### PR TITLE
Remove iOS push capability so the shell signs on a free Apple team

### DIFF
--- a/ios/App/App/App.entitlements
+++ b/ios/App/App/App.entitlements
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>aps-environment</key>
-	<string>development</string>
-</dict>
+<dict/>
 </plist>

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -43,10 +43,6 @@
       </array>
     </dict>
 	</dict>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>remote-notification</string>
-	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
Free/personal Apple teams can't create provisioning profiles with the Push Notifications capability, which broke device signing for the Capacitor iOS shell (three cascading Xcode errors, all rooted in the personal-team push limitation). This drops the `aps-environment` entitlement from `App.entitlements` (leaving an empty `<dict/>`, still referenced, so re-enabling push is a one-line revert) and removes the `remote-notification` background mode from `Info.plist`. No JS or Swift changes are needed — `registerPush.js` is already gated behind `Capacitor.isNativePlatform()` and the `AppDelegate` APNs bridge is now harmless dead code, so both fail safely. The app can now sign and run on a physical device under the personal team; Web Push in the PWA/browser build is unaffected. When a paid Apple Developer Program account is available, restore both entries and re-add the capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)