### PR TITLE
Add per-account transactions view on the Accounts page

### DIFF
--- a/app/Modules/Finance/Controllers/FinanceTransactionController.php
+++ b/app/Modules/Finance/Controllers/FinanceTransactionController.php
@@ -49,6 +49,7 @@ class FinanceTransactionController extends Controller
             'end_date' => $request->string('end_date')->toString(),
             'sort' => $request->string('sort')->toString(),
             'tags' => array_values(array_filter((array) $request->input('tags', []))),
+            'finance_account_id' => $request->integer('finance_account_id') ?: null,
             'wallet_user_id' => $walletUserId,
         ];
 
@@ -100,6 +101,7 @@ class FinanceTransactionController extends Controller
             'end_date' => $request->string('end_date')->toString(),
             'sort' => $request->string('sort')->toString(),
             'tags' => array_values(array_filter((array) $request->input('tags', []))),
+            'finance_account_id' => $request->integer('finance_account_id') ?: null,
             'wallet_user_id' => $walletUserId,
         ];
 
@@ -154,6 +156,15 @@ class FinanceTransactionController extends Controller
             $tagIds = array_map('intval', $filters['tags']);
             $query->whereHas('tags', function ($tagQuery) use ($tagIds) {
                 $tagQuery->whereIn('tags.id', $tagIds);
+            });
+        }
+
+        if (! empty($filters['finance_account_id'])) {
+            $accountId = (int) $filters['finance_account_id'];
+            $query->where(function ($accountQuery) use ($accountId) {
+                $accountQuery->where('finance_account_id', $accountId)
+                    ->orWhere('finance_transfer_account_id', $accountId)
+                    ->orWhere('finance_credit_card_account_id', $accountId);
             });
         }
 

--- a/resources/js/Components/Finance/Accounts/AccountsList.jsx
+++ b/resources/js/Components/Finance/Accounts/AccountsList.jsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
-import { CreditCard, Pencil, Trash2 } from "lucide-react";
+import { Link } from "@inertiajs/react";
+import { CreditCard, Pencil, Receipt, Trash2 } from "lucide-react";
 import EmptyState from "@/Components/Finance/UI/EmptyState";
 import { formatCurrency } from "@/Utils/currency";
 
@@ -16,7 +17,12 @@ const maskAccountNumber = (value) => {
     return `•••• ${digits.slice(-4)}`;
 };
 
-export default function AccountsList({ accounts = [], onEdit, onDelete }) {
+export default function AccountsList({
+    accounts = [],
+    walletUserId,
+    onEdit,
+    onDelete,
+}) {
     const groupedAccounts = useMemo(() => {
         const groups = {
             cash: [],
@@ -164,6 +170,23 @@ export default function AccountsList({ accounts = [], onEdit, onDelete }) {
                                         </div>
                                     </div>
                                     <div className="mt-2 flex justify-end gap-2">
+                                        <Link
+                                            href={route(
+                                                "weviewallet.transactions.index",
+                                                {
+                                                    finance_account_id:
+                                                        account.id,
+                                                    wallet_user_id:
+                                                        walletUserId ||
+                                                        undefined,
+                                                }
+                                            )}
+                                            className="rounded-md p-1 text-light-secondary hover:text-light-primary dark:text-dark-secondary dark:hover:text-dark-primary"
+                                            title="View transactions"
+                                            aria-label="View transactions"
+                                        >
+                                            <Receipt className="h-4 w-4" />
+                                        </Link>
                                         {onEdit && (
                                             <button
                                                 type="button"

--- a/resources/js/Pages/Finance/Accounts.jsx
+++ b/resources/js/Pages/Finance/Accounts.jsx
@@ -128,6 +128,7 @@ export default function Accounts({
                 <div data-tour="accounts-list">
                     <AccountsList
                         accounts={accounts}
+                        walletUserId={walletUserId}
                         onEdit={(account) => setActiveAccount(account)}
                         onDelete={handleDelete}
                     />

--- a/resources/js/Pages/Finance/Transactions.jsx
+++ b/resources/js/Pages/Finance/Transactions.jsx
@@ -57,6 +57,9 @@ export default function Transactions({
     const [startDate, setStartDate] = useState(filters.start_date ?? "");
     const [endDate, setEndDate] = useState(filters.end_date ?? "");
     const [sort, setSort] = useState(filters.sort ?? "date_desc");
+    const [accountId, setAccountId] = useState(
+        filters.finance_account_id ? String(filters.finance_account_id) : ""
+    );
     const [loadedTransactions, setLoadedTransactions] = useState(transactions);
     const [page, setPage] = useState(initialPage);
     const [hasMore, setHasMore] = useState(initialHasMore);
@@ -119,6 +122,7 @@ export default function Transactions({
                         start_date: startDate || undefined,
                         end_date: endDate || undefined,
                         sort: sort || undefined,
+                        finance_account_id: accountId || undefined,
                         wallet_user_id: walletUserId || undefined,
                     },
                 }
@@ -166,6 +170,7 @@ export default function Transactions({
                 start_date: startDate || undefined,
                 end_date: endDate || undefined,
                 sort: sort || undefined,
+                finance_account_id: accountId || undefined,
                 wallet_user_id: walletUserId || undefined,
             },
             { preserveState: true, replace: true, preserveScroll: true }
@@ -178,6 +183,7 @@ export default function Transactions({
         setStartDate("");
         setEndDate("");
         setSort("date_desc");
+        setAccountId("");
         router.get(route("weviewallet.transactions.index"), {
             wallet_user_id: walletUserId || undefined,
         });
@@ -318,6 +324,25 @@ export default function Transactions({
                                 <option value="expense">Expense</option>
                                 <option value="savings">Savings</option>
                                 <option value="transfer">Transfer</option>
+                            </select>
+                        </div>
+                        <div>
+                            <label className="text-xs font-semibold uppercase text-light-muted dark:text-dark-muted">
+                                Account
+                            </label>
+                            <select
+                                className="mt-1 w-full rounded-md border border-light-border/70 px-3 py-2 text-sm text-light-primary focus:border-wevie-teal focus:outline-none focus:ring-1 focus:ring-wevie-teal/30 dark:border-dark-border/70 dark:bg-dark-card dark:text-dark-primary"
+                                value={accountId}
+                                onChange={(event) =>
+                                    setAccountId(event.target.value)
+                                }
+                            >
+                                <option value="">All accounts</option>
+                                {accounts.map((account) => (
+                                    <option key={account.id} value={account.id}>
+                                        {account.label || account.name}
+                                    </option>
+                                ))}
                             </select>
                         </div>
                         <div>

--- a/tests/Feature/Modules/Finance/TransactionsAccountFilterTest.php
+++ b/tests/Feature/Modules/Finance/TransactionsAccountFilterTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use App\Models\User;
+use App\Modules\Finance\Models\FinanceAccount;
+use App\Modules\Finance\Models\FinanceTransaction;
+use Inertia\Testing\AssertableInertia;
+
+function makeFilterAccount(User $user, array $overrides = []): FinanceAccount
+{
+    return FinanceAccount::create(array_merge([
+        'user_id' => $user->id,
+        'name' => 'Filter Bank',
+        'type' => 'bank',
+        'currency' => 'PHP',
+        'starting_balance' => 0,
+        'current_balance' => 0,
+        'is_active' => true,
+        'is_default' => false,
+    ], $overrides));
+}
+
+function makeFilterTransaction(User $user, array $attributes): FinanceTransaction
+{
+    return FinanceTransaction::create(array_merge([
+        'user_id' => $user->id,
+        'type' => 'expense',
+        'amount' => 10,
+        'currency' => 'PHP',
+        'occurred_at' => '2026-07-10 09:00:00',
+    ], $attributes));
+}
+
+it('filters transactions to a single account across all account roles', function () {
+    $user = User::factory()->create();
+    $account = makeFilterAccount($user, ['name' => 'Target']);
+    $other = makeFilterAccount($user, ['name' => 'Other']);
+
+    // Source account.
+    makeFilterTransaction($user, [
+        'finance_account_id' => $account->id,
+        'description' => 'AsSource',
+    ]);
+    // Transfer destination account.
+    makeFilterTransaction($user, [
+        'type' => 'transfer',
+        'finance_account_id' => $other->id,
+        'finance_transfer_account_id' => $account->id,
+        'description' => 'AsTransferDestination',
+    ]);
+    // Credit-card account.
+    makeFilterTransaction($user, [
+        'finance_account_id' => $other->id,
+        'finance_credit_card_account_id' => $account->id,
+        'description' => 'AsCreditCard',
+    ]);
+    // Unrelated transaction on another account.
+    makeFilterTransaction($user, [
+        'finance_account_id' => $other->id,
+        'description' => 'Unrelated',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('weviewallet.transactions.index', [
+            'finance_account_id' => $account->id,
+        ]))
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('Finance/Transactions')
+            ->where('filters.finance_account_id', $account->id)
+            ->has('transactions', 3)
+            ->where('transactions', fn ($transactions) => collect($transactions)
+                ->pluck('description')
+                ->sort()
+                ->values()
+                ->all() === ['AsCreditCard', 'AsSource', 'AsTransferDestination'])
+        );
+});
+
+it('returns all transactions when no account filter is provided', function () {
+    $user = User::factory()->create();
+    $account = makeFilterAccount($user);
+
+    makeFilterTransaction($user, [
+        'finance_account_id' => $account->id,
+        'description' => 'One',
+    ]);
+    makeFilterTransaction($user, [
+        'finance_account_id' => $account->id,
+        'description' => 'Two',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('weviewallet.transactions.index'))
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('Finance/Transactions')
+            ->where('filters.finance_account_id', null)
+            ->has('transactions', 2)
+        );
+});


### PR DESCRIPTION
Adds a "View transactions" button to each account row on the WevieWallet Accounts page that opens the Transactions page pre-filtered to that account. The `finance_account_id` filter is wired end-to-end through `FinanceTransactionController` (both the page and infinite-scroll endpoints) and matches all account roles — source, transfer destination, and credit-card charges — scoped to the wallet's own transactions. The Transactions filter form gains a matching Account dropdown so the filter is visible, adjustable, and clearable via Reset, and the account button is icon-only to match the existing Edit/Delete actions and reflow on mobile. A new Pest test covers the filter across all three account roles and the unfiltered case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)