### PR TITLE
Fix inflated account balances from savings transactions

### DIFF
--- a/app/Modules/Finance/Services/FinanceService.php
+++ b/app/Modules/Finance/Services/FinanceService.php
@@ -538,7 +538,7 @@ class FinanceService
 
         $amount = (float) $transaction->amount * $direction;
         $delta = match ($transaction->type) {
-            'expense' => $amount * -1,
+            'expense', 'savings' => $amount * -1,
             default => $amount,
         };
 

--- a/database/migrations/2026_08_04_050000_fix_account_balances_for_savings_transactions.php
+++ b/database/migrations/2026_08_04_050000_fix_account_balances_for_savings_transactions.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Backfill for the savings-transaction balance bug.
+ *
+ * Before this release, a `savings` transaction wrongly ADDED its amount to the
+ * source account's current_balance instead of subtracting it (it fell into the
+ * `default` arm of adjustAccountBalance). Because the reverse-on-delete path used
+ * the same buggy sign, the residual error on any account is exactly +2x the sum
+ * of the amounts of its currently-existing savings transactions.
+ *
+ * This corrects the stored balances by subtracting that error. Credit-card
+ * accounts are skipped: their balance lives in used_credit/available_credit and
+ * savings transactions never target them.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $this->applyCorrection(-2.0);
+    }
+
+    public function down(): void
+    {
+        $this->applyCorrection(2.0);
+    }
+
+    private function applyCorrection(float $factor): void
+    {
+        $sums = DB::table('finance_transactions')
+            ->select('finance_account_id', DB::raw('SUM(amount) as total'))
+            ->where('type', 'savings')
+            ->whereNotNull('finance_account_id')
+            ->groupBy('finance_account_id')
+            ->pluck('total', 'finance_account_id');
+
+        foreach ($sums as $accountId => $total) {
+            $delta = $factor * (float) $total;
+            if ($delta === 0.0) {
+                continue;
+            }
+
+            DB::table('finance_accounts')
+                ->where('id', $accountId)
+                ->where('type', '!=', 'credit-card')
+                ->update([
+                    'current_balance' => DB::raw('current_balance + ('.$delta.')'),
+                ]);
+        }
+    }
+};

--- a/tests/Feature/Modules/Finance/SavingsBalanceBackfillTest.php
+++ b/tests/Feature/Modules/Finance/SavingsBalanceBackfillTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature\Modules\Finance;
+
+use App\Models\User;
+use App\Modules\Finance\Models\FinanceAccount;
+use App\Modules\Finance\Models\FinanceTransaction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SavingsBalanceBackfillTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_backfill_subtracts_double_the_savings_total_from_stored_balance()
+    {
+        $userId = User::factory()->create()->id;
+
+        // Simulate an account whose stored balance was inflated by the old bug:
+        // two savings contributions (250 + 150 = 400) that each swung +amount
+        // instead of -amount, leaving the balance +2 x 400 = 800 too high.
+        $account = FinanceAccount::create([
+            'user_id' => $userId,
+            'name' => 'Unionbank',
+            'type' => 'bank',
+            'currency' => 'PHP',
+            'starting_balance' => 1000,
+            'current_balance' => 1800, // should be 1000 after backfill
+            'is_active' => true,
+        ]);
+
+        foreach ([250, 150] as $amount) {
+            FinanceTransaction::create([
+                'user_id' => $userId,
+                'created_by_user_id' => $userId,
+                'finance_account_id' => $account->id,
+                'type' => 'savings',
+                'amount' => $amount,
+                'currency' => 'PHP',
+                'description' => 'To savings',
+                'occurred_at' => now(),
+            ]);
+        }
+
+        $this->runBackfill();
+
+        $this->assertEqualsWithDelta(1000.0, (float) $account->refresh()->current_balance, 0.001);
+    }
+
+    public function test_backfill_leaves_accounts_without_savings_untouched()
+    {
+        $userId = User::factory()->create()->id;
+
+        $account = FinanceAccount::create([
+            'user_id' => $userId,
+            'name' => 'BPI',
+            'type' => 'bank',
+            'currency' => 'PHP',
+            'starting_balance' => 500,
+            'current_balance' => 500,
+            'is_active' => true,
+        ]);
+
+        $this->runBackfill();
+
+        $this->assertEqualsWithDelta(500.0, (float) $account->refresh()->current_balance, 0.001);
+    }
+
+    private function runBackfill(): void
+    {
+        $migration = require database_path(
+            'migrations/2026_08_04_050000_fix_account_balances_for_savings_transactions.php'
+        );
+        $migration->up();
+    }
+}

--- a/tests/Feature/Modules/Finance/SavingsBalanceImpactTest.php
+++ b/tests/Feature/Modules/Finance/SavingsBalanceImpactTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Feature\Modules\Finance;
+
+use App\Models\User;
+use App\Modules\Finance\Models\FinanceAccount;
+use App\Modules\Finance\Models\FinanceSavingsGoal;
+use App\Modules\Finance\Services\FinanceService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SavingsBalanceImpactTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private FinanceService $service;
+
+    private int $userId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = app(FinanceService::class);
+        $this->userId = User::factory()->create()->id;
+    }
+
+    private function makeAccount(float $current = 1000.0): FinanceAccount
+    {
+        return FinanceAccount::create([
+            'user_id' => $this->userId,
+            'name' => 'Test Bank',
+            'type' => 'bank',
+            'currency' => 'PHP',
+            'starting_balance' => $current,
+            'current_balance' => $current,
+            'is_active' => true,
+        ]);
+    }
+
+    private function makeGoal(): FinanceSavingsGoal
+    {
+        return $this->service->createSavingsGoal([
+            'name' => 'Emergency Fund',
+            'target_amount' => 5000,
+            'current_amount' => 0,
+            'currency' => 'PHP',
+            'is_active' => true,
+        ], $this->userId);
+    }
+
+    public function test_savings_transaction_decreases_account_and_increases_goal()
+    {
+        $account = $this->makeAccount(1000);
+        $goal = $this->makeGoal();
+
+        $this->service->createTransaction([
+            'finance_account_id' => $account->id,
+            'finance_savings_goal_id' => $goal->id,
+            'type' => 'savings',
+            'amount' => 250,
+            'currency' => 'PHP',
+            'description' => 'Move to savings',
+            'occurred_at' => now(),
+        ], $this->userId, $this->userId);
+
+        $this->assertEqualsWithDelta(750.0, (float) $account->refresh()->current_balance, 0.001);
+        $this->assertEqualsWithDelta(250.0, (float) $goal->refresh()->current_amount, 0.001);
+    }
+
+    public function test_deleting_savings_transaction_restores_account_and_goal()
+    {
+        $account = $this->makeAccount(1000);
+        $goal = $this->makeGoal();
+
+        $transaction = $this->service->createTransaction([
+            'finance_account_id' => $account->id,
+            'finance_savings_goal_id' => $goal->id,
+            'type' => 'savings',
+            'amount' => 250,
+            'currency' => 'PHP',
+            'description' => 'Move to savings',
+            'occurred_at' => now(),
+        ], $this->userId, $this->userId);
+
+        $this->service->deleteTransaction($transaction, $this->userId);
+
+        $this->assertEqualsWithDelta(1000.0, (float) $account->refresh()->current_balance, 0.001);
+        $this->assertEqualsWithDelta(0.0, (float) $goal->refresh()->current_amount, 0.001);
+    }
+
+    public function test_income_and_loan_add_while_expense_subtracts()
+    {
+        $account = $this->makeAccount(1000);
+
+        $this->service->createTransaction([
+            'finance_account_id' => $account->id,
+            'type' => 'income',
+            'amount' => 100,
+            'currency' => 'PHP',
+            'description' => 'Paycheck',
+            'occurred_at' => now(),
+        ], $this->userId, $this->userId);
+        $this->assertEqualsWithDelta(1100.0, (float) $account->refresh()->current_balance, 0.001);
+
+        $this->service->createTransaction([
+            'finance_account_id' => $account->id,
+            'type' => 'expense',
+            'amount' => 300,
+            'currency' => 'PHP',
+            'description' => 'Groceries',
+            'occurred_at' => now(),
+        ], $this->userId, $this->userId);
+        $this->assertEqualsWithDelta(800.0, (float) $account->refresh()->current_balance, 0.001);
+
+        $this->service->createTransaction([
+            'finance_account_id' => $account->id,
+            'type' => 'loan',
+            'amount' => 500,
+            'currency' => 'PHP',
+            'description' => 'Personal loan',
+            'occurred_at' => now(),
+        ], $this->userId, $this->userId);
+        $this->assertEqualsWithDelta(1300.0, (float) $account->refresh()->current_balance, 0.001);
+    }
+}


### PR DESCRIPTION
## Problem
On the WevieWallet accounts page, balances were inflated wherever the user had contributed to a savings goal — e.g. Unionbank showed ₱67,847.02 instead of ₱37,879.62.

## Cause
`current_balance` is a stored column nudged per transaction. In `FinanceService::adjustAccountBalance()` only `expense` was special-cased to subtract, so `savings` fell into the additive `default` arm and *added* the amount to the source account (it should subtract, since the money moves out to a goal) — leaving each account +2× its savings total too high.

## Fix
Special-case `savings` to subtract like `expense`, and add a portable one-time migration that corrects already-stored balances by subtracting 2× each account's savings total (skips credit-card accounts). Added Pest coverage for the balance impact of every transaction type and for the backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)