### PR TITLE
Add points system, point store, and customizable avatars (Phase 1)

### DIFF
--- a/app/Console/Commands/PointsBackfillCommand.php
+++ b/app/Console/Commands/PointsBackfillCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use App\Modules\Points\Repositories\Contracts\StoreItemRepositoryInterface;
+use App\Modules\Points\Repositories\Contracts\UserAvatarRepositoryInterface;
+use App\Modules\Points\Repositories\Contracts\UserStoreItemRepositoryInterface;
+use App\Modules\Points\Services\PointsWalletService;
+use Illuminate\Console\Command;
+
+class PointsBackfillCommand extends Command
+{
+    protected $signature = 'points:backfill';
+
+    protected $description = 'Ensure every user has a point wallet, avatar row, and the default base avatar.';
+
+    public function handle(
+        PointsWalletService $walletService,
+        UserAvatarRepositoryInterface $avatars,
+        UserStoreItemRepositoryInterface $inventory,
+        StoreItemRepositoryInterface $storeItems,
+    ): int {
+        $defaultBase = $storeItems->defaultBase();
+        $count = 0;
+
+        User::query()->chunkById(200, function ($users) use ($walletService, $avatars, $inventory, $defaultBase, &$count) {
+            foreach ($users as $user) {
+                $walletService->ensureWallet($user->id);
+                $avatar = $avatars->ensureForUser($user->id);
+
+                if ($defaultBase) {
+                    if (! $inventory->existsForUser($user->id, $defaultBase->id)) {
+                        $inventory->create([
+                            'user_id' => $user->id,
+                            'store_item_id' => $defaultBase->id,
+                            'acquired_via' => 'default',
+                            'acquired_at' => now(),
+                        ]);
+                    }
+
+                    if ($avatar->base_item_id === null) {
+                        $avatar->base_item_id = $defaultBase->id;
+                        $avatar->save();
+                    }
+                }
+
+                $count++;
+            }
+        });
+
+        $this->info("Points backfill complete for {$count} user(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/ResetRecurringTasks.php
+++ b/app/Console/Commands/ResetRecurringTasks.php
@@ -2,10 +2,10 @@
 
 namespace App\Console\Commands;
 
-use Illuminate\Console\Command;
 use App\Models\Task;
 use App\Models\User;
 use Carbon\Carbon;
+use Illuminate\Console\Command;
 
 class ResetRecurringTasks extends Command
 {
@@ -70,7 +70,7 @@ class ResetRecurringTasks extends Command
      */
     private function shouldResetTask(Task $task, Carbon $userToday): bool
     {
-        if (!$task->completed_at) {
+        if (! $task->completed_at) {
             return false;
         }
 
@@ -84,7 +84,7 @@ class ResetRecurringTasks extends Command
             $nextOccurrenceDate = $nextOccurrenceDate->setTimezone($userToday->timezone)->startOfDay();
         }
 
-        if (!$nextOccurrenceDate) {
+        if (! $nextOccurrenceDate) {
             return false;
         }
 
@@ -128,11 +128,15 @@ class ResetRecurringTasks extends Command
             'due_date' => $newDueDate,
         ]);
 
-        // Reset all subtasks to incomplete
-        $task->subtasks()->update([
-            'is_completed' => false,
-            'completed_at' => null,
-        ]);
+        // Reset all subtasks to incomplete. Update each model individually
+        // (not a bulk relationship query) so `updated` events fire and points
+        // observers can reverse the completion awards for the next occurrence.
+        foreach ($task->subtasks as $subtask) {
+            $subtask->update([
+                'is_completed' => false,
+                'completed_at' => null,
+            ]);
+        }
     }
 
     /**
@@ -148,7 +152,7 @@ class ResetRecurringTasks extends Command
 
             case 'weekly':
                 $days = $config['days_of_week'] ?? null;
-                if (!empty($days)) {
+                if (! empty($days)) {
                     $days = array_map('intval', $days);
                     // Next selected weekday strictly after $fromDate
                     for ($i = 1; $i <= 7; $i++) {

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Middleware;
 
+use App\Modules\Points\Services\AvatarService;
+use App\Modules\Points\Services\PointsWalletService;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 
@@ -29,11 +31,18 @@ class HandleInertiaRequests extends Middleware
      */
     public function share(Request $request): array
     {
+        $user = $request->user();
+
         return [
             ...parent::share($request),
             'auth' => [
-                'user' => $request->user(),
-                'unreadNotifications' => $request->user() ? $request->user()->unreadNotifications()->count() : 0,
+                'user' => $user,
+                'unreadNotifications' => $user ? $user->unreadNotifications()->count() : 0,
+                // Points balance + streak, exposed on every authenticated page.
+                'points' => $user ? $this->pointsProps($user->id) : null,
+                // Avatar kept alongside (not nested in the user) so the user
+                // serialization is untouched. Phase 1: base layer + initials.
+                'avatar' => $user ? app(AvatarService::class)->presentFor($user->id) : null,
             ],
             'flash' => [
                 'subtask' => fn () => $request->session()->get('subtask'),
@@ -45,6 +54,19 @@ class HandleInertiaRequests extends Middleware
                 // the private key stays server-side. Null when unconfigured.
                 'vapidPublicKey' => config('services.vapid.public_key'),
             ],
+        ];
+    }
+
+    /**
+     * @return array{balance: int, streak: int}
+     */
+    private function pointsProps(int $userId): array
+    {
+        $wallet = app(PointsWalletService::class)->ensureWallet($userId);
+
+        return [
+            'balance' => (int) $wallet->balance,
+            'streak' => (int) $wallet->current_streak_days,
         ];
     }
 }

--- a/app/Modules/Points/Controllers/PomodoroSessionController.php
+++ b/app/Modules/Points/Controllers/PomodoroSessionController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Modules\Points\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Modules\Points\Requests\StorePomodoroSessionRequest;
+use App\Modules\Points\Services\PomodoroSessionService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+
+class PomodoroSessionController extends Controller
+{
+    public function __construct(
+        private PomodoroSessionService $pomodoroService,
+    ) {}
+
+    public function store(StorePomodoroSessionRequest $request): RedirectResponse
+    {
+        $this->pomodoroService->record(Auth::user(), $request->validated());
+
+        return back();
+    }
+}

--- a/app/Modules/Points/Controllers/StoreController.php
+++ b/app/Modules/Points/Controllers/StoreController.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Modules\Points\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Modules\Points\Exceptions\InsufficientBalanceException;
+use App\Modules\Points\Repositories\Contracts\StoreItemRepositoryInterface;
+use App\Modules\Points\Requests\EquipAvatarRequest;
+use App\Modules\Points\Requests\PurchaseStoreItemRequest;
+use App\Modules\Points\Services\PointsWalletService;
+use App\Modules\Points\Services\StoreService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class StoreController extends Controller
+{
+    public function __construct(
+        private StoreService $storeService,
+        private PointsWalletService $walletService,
+        private StoreItemRepositoryInterface $storeItems,
+    ) {}
+
+    public function index(): Response
+    {
+        $user = Auth::user();
+        $wallet = $this->walletService->ensureWallet($user->id);
+
+        return Inertia::render('Store/Index', [
+            'items' => $this->storeService->listCatalogFor($user),
+            'balance' => (int) $wallet->balance,
+        ]);
+    }
+
+    public function purchase(PurchaseStoreItemRequest $request): RedirectResponse
+    {
+        $user = Auth::user();
+        $storeItem = $this->storeItems->findById((int) $request->validated('store_item_id'));
+
+        if (! $storeItem) {
+            return back()->with('error', 'This item is not available.');
+        }
+
+        try {
+            $this->storeService->purchase(
+                $user,
+                $storeItem,
+                (string) $request->validated('client_request_id'),
+            );
+        } catch (InsufficientBalanceException $e) {
+            return back()->with('error', 'You do not have enough points for this item.');
+        }
+
+        return back()->with('message', 'Purchase complete!');
+    }
+
+    public function equip(EquipAvatarRequest $request): RedirectResponse
+    {
+        $user = Auth::user();
+        $storeItem = $this->storeItems->findById((int) $request->validated('store_item_id'));
+
+        if (! $storeItem) {
+            return back()->with('error', 'This item is not available.');
+        }
+
+        $this->storeService->equip($user, $storeItem);
+
+        return back()->with('message', 'Avatar updated.');
+    }
+}

--- a/app/Modules/Points/Enums/PointLedgerType.php
+++ b/app/Modules/Points/Enums/PointLedgerType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Modules\Points\Enums;
+
+enum PointLedgerType: string
+{
+    case Earn = 'earn';
+    case Spend = 'spend';
+    case Adjust = 'adjust';
+    case Refund = 'refund';
+}

--- a/app/Modules/Points/Enums/PointSource.php
+++ b/app/Modules/Points/Enums/PointSource.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\Points\Enums;
+
+enum PointSource: string
+{
+    case TaskCompletion = 'task_completion';
+    case SubtaskCompletion = 'subtask_completion';
+    case DailyStreak = 'daily_streak';
+    case PomodoroSession = 'pomodoro_session';
+    case StorePurchase = 'store_purchase';
+    case PurchaseRefund = 'purchase_refund';
+    case AdminAdjust = 'admin_adjust';
+}

--- a/app/Modules/Points/Enums/StoreItemSlot.php
+++ b/app/Modules/Points/Enums/StoreItemSlot.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Modules\Points\Enums;
+
+enum StoreItemSlot: string
+{
+    case Base = 'base';
+    case Hat = 'hat';
+    case Background = 'background';
+    case Frame = 'frame';
+}

--- a/app/Modules/Points/Enums/StoreItemType.php
+++ b/app/Modules/Points/Enums/StoreItemType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Modules\Points\Enums;
+
+enum StoreItemType: string
+{
+    case AvatarBase = 'avatar_base';
+    case Accessory = 'accessory';
+}

--- a/app/Modules/Points/Exceptions/InsufficientBalanceException.php
+++ b/app/Modules/Points/Exceptions/InsufficientBalanceException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Modules\Points\Exceptions;
+
+use RuntimeException;
+
+class InsufficientBalanceException extends RuntimeException
+{
+    public static function forPurchase(int $balance, int $cost): self
+    {
+        return new self("Insufficient point balance: have {$balance}, need {$cost}.");
+    }
+}

--- a/app/Modules/Points/Models/PointLedgerEntry.php
+++ b/app/Modules/Points/Models/PointLedgerEntry.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Modules\Points\Models;
+
+use App\Models\User;
+use App\Modules\Points\Enums\PointLedgerType;
+use App\Modules\Points\Enums\PointSource;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class PointLedgerEntry extends Model
+{
+    protected $table = 'point_ledger_entries';
+
+    protected $fillable = [
+        'user_id',
+        'type',
+        'source',
+        'amount',
+        'balance_after',
+        'sourceable_type',
+        'sourceable_id',
+        'client_request_id',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'type' => PointLedgerType::class,
+        'source' => PointSource::class,
+        'amount' => 'integer',
+        'balance_after' => 'integer',
+        'metadata' => 'array',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function sourceable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/app/Modules/Points/Models/PointWallet.php
+++ b/app/Modules/Points/Models/PointWallet.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Modules\Points\Models;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PointWallet extends Model
+{
+    protected $table = 'point_wallets';
+
+    protected $fillable = [
+        'user_id',
+        'balance',
+        'lifetime_earned',
+        'lifetime_spent',
+        'current_streak_days',
+        'longest_streak_days',
+        'last_earned_on',
+        'last_streak_awarded_on',
+    ];
+
+    protected $casts = [
+        'balance' => 'integer',
+        'lifetime_earned' => 'integer',
+        'lifetime_spent' => 'integer',
+        'current_streak_days' => 'integer',
+        'longest_streak_days' => 'integer',
+        'last_earned_on' => 'date',
+        'last_streak_awarded_on' => 'date',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Modules/Points/Models/PomodoroSession.php
+++ b/app/Modules/Points/Models/PomodoroSession.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Modules\Points\Models;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PomodoroSession extends Model
+{
+    protected $table = 'pomodoro_sessions';
+
+    protected $fillable = [
+        'user_id',
+        'client_request_id',
+        'type',
+        'duration_seconds',
+        'started_at',
+        'completed_at',
+        'awarded_points',
+        'point_ledger_entry_id',
+    ];
+
+    protected $casts = [
+        'duration_seconds' => 'integer',
+        'started_at' => 'datetime',
+        'completed_at' => 'datetime',
+        'awarded_points' => 'integer',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function ledgerEntry(): BelongsTo
+    {
+        return $this->belongsTo(PointLedgerEntry::class, 'point_ledger_entry_id');
+    }
+}

--- a/app/Modules/Points/Models/StoreItem.php
+++ b/app/Modules/Points/Models/StoreItem.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Modules\Points\Models;
+
+use App\Modules\Points\Enums\StoreItemSlot;
+use App\Modules\Points\Enums\StoreItemType;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class StoreItem extends Model
+{
+    protected $table = 'store_items';
+
+    protected $fillable = [
+        'key',
+        'name',
+        'description',
+        'type',
+        'slot',
+        'cost',
+        'asset',
+        'preview_asset',
+        'metadata',
+        'sort_order',
+        'is_active',
+        'is_default',
+        'is_premium',
+        'available_from',
+        'available_until',
+    ];
+
+    protected $casts = [
+        'type' => StoreItemType::class,
+        'slot' => StoreItemSlot::class,
+        'cost' => 'integer',
+        'metadata' => 'array',
+        'sort_order' => 'integer',
+        'is_active' => 'boolean',
+        'is_default' => 'boolean',
+        'is_premium' => 'boolean',
+        'available_from' => 'datetime',
+        'available_until' => 'datetime',
+    ];
+
+    public function userStoreItems(): HasMany
+    {
+        return $this->hasMany(UserStoreItem::class);
+    }
+}

--- a/app/Modules/Points/Models/UserAvatar.php
+++ b/app/Modules/Points/Models/UserAvatar.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Modules\Points\Models;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class UserAvatar extends Model
+{
+    protected $table = 'user_avatars';
+
+    protected $fillable = [
+        'user_id',
+        'base_item_id',
+        'equipped',
+    ];
+
+    protected $casts = [
+        'equipped' => 'array',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function baseItem(): BelongsTo
+    {
+        return $this->belongsTo(StoreItem::class, 'base_item_id');
+    }
+}

--- a/app/Modules/Points/Models/UserStoreItem.php
+++ b/app/Modules/Points/Models/UserStoreItem.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Modules\Points\Models;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class UserStoreItem extends Model
+{
+    protected $table = 'user_store_items';
+
+    protected $fillable = [
+        'user_id',
+        'store_item_id',
+        'acquired_via',
+        'point_ledger_entry_id',
+        'acquired_at',
+    ];
+
+    protected $casts = [
+        'acquired_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function storeItem(): BelongsTo
+    {
+        return $this->belongsTo(StoreItem::class);
+    }
+
+    public function ledgerEntry(): BelongsTo
+    {
+        return $this->belongsTo(PointLedgerEntry::class, 'point_ledger_entry_id');
+    }
+}

--- a/app/Modules/Points/Observers/PointsSubtaskObserver.php
+++ b/app/Modules/Points/Observers/PointsSubtaskObserver.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Modules\Points\Observers;
+
+use App\Models\Subtask;
+use App\Modules\Points\Services\PointsAwardService;
+
+/**
+ * Awards / reverses subtask-completion points off the `is_completed`
+ * transition. When the last subtask completes the parent task auto-completes
+ * too — awarding both subtask and task points is intended.
+ */
+class PointsSubtaskObserver
+{
+    public function __construct(
+        private PointsAwardService $awardService,
+    ) {}
+
+    public function updated(Subtask $subtask): void
+    {
+        if (! $subtask->wasChanged('is_completed')) {
+            return;
+        }
+
+        if ($subtask->is_completed) {
+            $this->awardService->awardForSubtask($subtask);
+
+            return;
+        }
+
+        $this->awardService->reverseForSubtask($subtask);
+    }
+}

--- a/app/Modules/Points/Observers/PointsTaskObserver.php
+++ b/app/Modules/Points/Observers/PointsTaskObserver.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Modules\Points\Observers;
+
+use App\Models\Task;
+use App\Modules\Points\Services\PointsAwardService;
+
+/**
+ * Awards / reverses task-completion points off the `completed_at` transition,
+ * so it uniformly catches manual toggles, subtask-driven auto-completes, and
+ * recurring resets — regardless of which code path changed the task.
+ */
+class PointsTaskObserver
+{
+    public function __construct(
+        private PointsAwardService $awardService,
+    ) {}
+
+    public function updated(Task $task): void
+    {
+        if (! $task->wasChanged('completed_at')) {
+            return;
+        }
+
+        if ($task->completed_at !== null) {
+            $this->awardService->awardForTask($task);
+
+            return;
+        }
+
+        $this->awardService->reverseForTask($task);
+    }
+}

--- a/app/Modules/Points/PointsServiceProvider.php
+++ b/app/Modules/Points/PointsServiceProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Modules\Points;
+
+use App\Models\Subtask;
+use App\Models\Task;
+use App\Modules\Points\Observers\PointsSubtaskObserver;
+use App\Modules\Points\Observers\PointsTaskObserver;
+use App\Modules\Points\Repositories\Contracts\PointLedgerRepositoryInterface;
+use App\Modules\Points\Repositories\Contracts\PointWalletRepositoryInterface;
+use App\Modules\Points\Repositories\Contracts\PomodoroSessionRepositoryInterface;
+use App\Modules\Points\Repositories\Contracts\StoreItemRepositoryInterface;
+use App\Modules\Points\Repositories\Contracts\UserAvatarRepositoryInterface;
+use App\Modules\Points\Repositories\Contracts\UserStoreItemRepositoryInterface;
+use App\Modules\Points\Repositories\Eloquent\PointLedgerRepository;
+use App\Modules\Points\Repositories\Eloquent\PointWalletRepository;
+use App\Modules\Points\Repositories\Eloquent\PomodoroSessionRepository;
+use App\Modules\Points\Repositories\Eloquent\StoreItemRepository;
+use App\Modules\Points\Repositories\Eloquent\UserAvatarRepository;
+use App\Modules\Points\Repositories\Eloquent\UserStoreItemRepository;
+use Illuminate\Support\ServiceProvider;
+
+class PointsServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->bind(PointWalletRepositoryInterface::class, PointWalletRepository::class);
+        $this->app->bind(PointLedgerRepositoryInterface::class, PointLedgerRepository::class);
+        $this->app->bind(StoreItemRepositoryInterface::class, StoreItemRepository::class);
+        $this->app->bind(UserStoreItemRepositoryInterface::class, UserStoreItemRepository::class);
+        $this->app->bind(UserAvatarRepositoryInterface::class, UserAvatarRepository::class);
+        $this->app->bind(PomodoroSessionRepositoryInterface::class, PomodoroSessionRepository::class);
+    }
+
+    public function boot(): void
+    {
+        $this->loadRoutesFrom(__DIR__.'/routes.php');
+        $this->loadMigrationsFrom(__DIR__.'/database/migrations');
+
+        Task::observe(PointsTaskObserver::class);
+        Subtask::observe(PointsSubtaskObserver::class);
+    }
+}

--- a/app/Modules/Points/Repositories/Contracts/PointLedgerRepositoryInterface.php
+++ b/app/Modules/Points/Repositories/Contracts/PointLedgerRepositoryInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Modules\Points\Repositories\Contracts;
+
+use App\Modules\Points\Enums\PointSource;
+use App\Modules\Points\Models\PointLedgerEntry;
+use Illuminate\Database\Eloquent\Model;
+
+interface PointLedgerRepositoryInterface
+{
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function create(array $data): PointLedgerEntry;
+
+    /**
+     * Net amount (SUM of signed amounts) awarded for a given source + sourceable.
+     * Drives the idempotent net-award guard.
+     */
+    public function netAwardedFor(int $userId, PointSource $source, Model $sourceable): int;
+
+    public function existsByClientRequestId(int $userId, string $clientRequestId): bool;
+
+    public function findByClientRequestId(int $userId, string $clientRequestId): ?PointLedgerEntry;
+}

--- a/app/Modules/Points/Repositories/Contracts/PointLedgerRepositoryInterface.php
+++ b/app/Modules/Points/Repositories/Contracts/PointLedgerRepositoryInterface.php
@@ -14,10 +14,13 @@ interface PointLedgerRepositoryInterface
     public function create(array $data): PointLedgerEntry;
 
     /**
-     * Net amount (SUM of signed amounts) awarded for a given source + sourceable.
-     * Drives the idempotent net-award guard.
+     * Whether an un-reversed award is outstanding for a source + sourceable,
+     * i.e. earn entries outnumber reversal (adjust) entries. Drives the
+     * idempotent award/reverse guard by completion *cycle* rather than by
+     * amount, so a balance-clamped reversal still closes the cycle and lets a
+     * recurring task earn again.
      */
-    public function netAwardedFor(int $userId, PointSource $source, Model $sourceable): int;
+    public function awardCycleOpen(int $userId, PointSource $source, Model $sourceable): bool;
 
     public function existsByClientRequestId(int $userId, string $clientRequestId): bool;
 

--- a/app/Modules/Points/Repositories/Contracts/PointWalletRepositoryInterface.php
+++ b/app/Modules/Points/Repositories/Contracts/PointWalletRepositoryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Modules\Points\Repositories\Contracts;
+
+use App\Modules\Points\Models\PointWallet;
+
+interface PointWalletRepositoryInterface
+{
+    public function findForUser(int $userId): ?PointWallet;
+
+    public function ensureForUser(int $userId): PointWallet;
+
+    /**
+     * Fetch the wallet row with a pessimistic lock (SELECT ... FOR UPDATE).
+     * Must be called inside a transaction. Creates the row first if missing.
+     */
+    public function lockForUser(int $userId): PointWallet;
+}

--- a/app/Modules/Points/Repositories/Contracts/PomodoroSessionRepositoryInterface.php
+++ b/app/Modules/Points/Repositories/Contracts/PomodoroSessionRepositoryInterface.php
@@ -17,7 +17,8 @@ interface PomodoroSessionRepositoryInterface
     public function findByClientRequestId(int $userId, string $clientRequestId): ?PomodoroSession;
 
     /**
-     * Count of sessions that already earned points within the given window.
+     * Count of sessions that already earned points within the given window,
+     * measured by server-set created_at (not client-supplied completed_at).
      */
     public function todaysAwardedCount(int $userId, CarbonInterface $start, CarbonInterface $end): int;
 }

--- a/app/Modules/Points/Repositories/Contracts/PomodoroSessionRepositoryInterface.php
+++ b/app/Modules/Points/Repositories/Contracts/PomodoroSessionRepositoryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Modules\Points\Repositories\Contracts;
+
+use App\Modules\Points\Models\PomodoroSession;
+use Carbon\CarbonInterface;
+
+interface PomodoroSessionRepositoryInterface
+{
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function create(array $data): PomodoroSession;
+
+    public function existsByClientRequestId(int $userId, string $clientRequestId): bool;
+
+    public function findByClientRequestId(int $userId, string $clientRequestId): ?PomodoroSession;
+
+    /**
+     * Count of sessions that already earned points within the given window.
+     */
+    public function todaysAwardedCount(int $userId, CarbonInterface $start, CarbonInterface $end): int;
+}

--- a/app/Modules/Points/Repositories/Contracts/StoreItemRepositoryInterface.php
+++ b/app/Modules/Points/Repositories/Contracts/StoreItemRepositoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Modules\Points\Repositories\Contracts;
+
+use App\Modules\Points\Models\StoreItem;
+use Illuminate\Database\Eloquent\Collection;
+
+interface StoreItemRepositoryInterface
+{
+    /**
+     * @return Collection<int, StoreItem>
+     */
+    public function allActive(): Collection;
+
+    public function findById(int $id): ?StoreItem;
+
+    public function findByKey(string $key): ?StoreItem;
+
+    public function defaultBase(): ?StoreItem;
+}

--- a/app/Modules/Points/Repositories/Contracts/UserAvatarRepositoryInterface.php
+++ b/app/Modules/Points/Repositories/Contracts/UserAvatarRepositoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Modules\Points\Repositories\Contracts;
+
+use App\Modules\Points\Models\UserAvatar;
+
+interface UserAvatarRepositoryInterface
+{
+    public function getForUser(int $userId): ?UserAvatar;
+
+    public function ensureForUser(int $userId): UserAvatar;
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function upsertForUser(int $userId, array $data): UserAvatar;
+}

--- a/app/Modules/Points/Repositories/Contracts/UserStoreItemRepositoryInterface.php
+++ b/app/Modules/Points/Repositories/Contracts/UserStoreItemRepositoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Modules\Points\Repositories\Contracts;
+
+use App\Modules\Points\Models\UserStoreItem;
+use Illuminate\Database\Eloquent\Collection;
+
+interface UserStoreItemRepositoryInterface
+{
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function create(array $data): UserStoreItem;
+
+    public function existsForUser(int $userId, int $storeItemId): bool;
+
+    /**
+     * @return Collection<int, UserStoreItem>
+     */
+    public function listForUser(int $userId): Collection;
+
+    /**
+     * @return array<int, int>
+     */
+    public function ownedItemIds(int $userId): array;
+}

--- a/app/Modules/Points/Repositories/Eloquent/PointLedgerRepository.php
+++ b/app/Modules/Points/Repositories/Eloquent/PointLedgerRepository.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Modules\Points\Repositories\Eloquent;
+
+use App\Modules\Points\Enums\PointSource;
+use App\Modules\Points\Models\PointLedgerEntry;
+use App\Modules\Points\Repositories\Contracts\PointLedgerRepositoryInterface;
+use Illuminate\Database\Eloquent\Model;
+
+class PointLedgerRepository implements PointLedgerRepositoryInterface
+{
+    public function create(array $data): PointLedgerEntry
+    {
+        return PointLedgerEntry::create($data);
+    }
+
+    public function netAwardedFor(int $userId, PointSource $source, Model $sourceable): int
+    {
+        return (int) PointLedgerEntry::query()
+            ->where('user_id', $userId)
+            ->where('source', $source->value)
+            ->where('sourceable_type', $sourceable->getMorphClass())
+            ->where('sourceable_id', $sourceable->getKey())
+            ->sum('amount');
+    }
+
+    public function existsByClientRequestId(int $userId, string $clientRequestId): bool
+    {
+        return PointLedgerEntry::query()
+            ->where('user_id', $userId)
+            ->where('client_request_id', $clientRequestId)
+            ->exists();
+    }
+
+    public function findByClientRequestId(int $userId, string $clientRequestId): ?PointLedgerEntry
+    {
+        return PointLedgerEntry::query()
+            ->where('user_id', $userId)
+            ->where('client_request_id', $clientRequestId)
+            ->first();
+    }
+}

--- a/app/Modules/Points/Repositories/Eloquent/PointLedgerRepository.php
+++ b/app/Modules/Points/Repositories/Eloquent/PointLedgerRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Modules\Points\Repositories\Eloquent;
 
+use App\Modules\Points\Enums\PointLedgerType;
 use App\Modules\Points\Enums\PointSource;
 use App\Modules\Points\Models\PointLedgerEntry;
 use App\Modules\Points\Repositories\Contracts\PointLedgerRepositoryInterface;
@@ -14,14 +15,18 @@ class PointLedgerRepository implements PointLedgerRepositoryInterface
         return PointLedgerEntry::create($data);
     }
 
-    public function netAwardedFor(int $userId, PointSource $source, Model $sourceable): int
+    public function awardCycleOpen(int $userId, PointSource $source, Model $sourceable): bool
     {
-        return (int) PointLedgerEntry::query()
+        $base = PointLedgerEntry::query()
             ->where('user_id', $userId)
             ->where('source', $source->value)
             ->where('sourceable_type', $sourceable->getMorphClass())
-            ->where('sourceable_id', $sourceable->getKey())
-            ->sum('amount');
+            ->where('sourceable_id', $sourceable->getKey());
+
+        $earns = (clone $base)->where('type', PointLedgerType::Earn->value)->count();
+        $reversals = (clone $base)->where('type', PointLedgerType::Adjust->value)->count();
+
+        return $earns > $reversals;
     }
 
     public function existsByClientRequestId(int $userId, string $clientRequestId): bool

--- a/app/Modules/Points/Repositories/Eloquent/PointWalletRepository.php
+++ b/app/Modules/Points/Repositories/Eloquent/PointWalletRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Modules\Points\Repositories\Eloquent;
+
+use App\Modules\Points\Models\PointWallet;
+use App\Modules\Points\Repositories\Contracts\PointWalletRepositoryInterface;
+
+class PointWalletRepository implements PointWalletRepositoryInterface
+{
+    public function findForUser(int $userId): ?PointWallet
+    {
+        return PointWallet::query()->where('user_id', $userId)->first();
+    }
+
+    public function ensureForUser(int $userId): PointWallet
+    {
+        return PointWallet::query()->firstOrCreate(['user_id' => $userId]);
+    }
+
+    public function lockForUser(int $userId): PointWallet
+    {
+        $wallet = PointWallet::query()
+            ->where('user_id', $userId)
+            ->lockForUpdate()
+            ->first();
+
+        if ($wallet) {
+            return $wallet;
+        }
+
+        // No wallet yet — create it, then re-select under a lock so the caller
+        // holds the row lock for the remainder of the transaction.
+        PointWallet::query()->firstOrCreate(['user_id' => $userId]);
+
+        return PointWallet::query()
+            ->where('user_id', $userId)
+            ->lockForUpdate()
+            ->firstOrFail();
+    }
+}

--- a/app/Modules/Points/Repositories/Eloquent/PomodoroSessionRepository.php
+++ b/app/Modules/Points/Repositories/Eloquent/PomodoroSessionRepository.php
@@ -31,10 +31,12 @@ class PomodoroSessionRepository implements PomodoroSessionRepositoryInterface
 
     public function todaysAwardedCount(int $userId, CarbonInterface $start, CarbonInterface $end): int
     {
+        // Count against server-set created_at, never the client-supplied
+        // completed_at — otherwise backdated sessions escape the daily cap.
         return PomodoroSession::query()
             ->where('user_id', $userId)
             ->where('awarded_points', '>', 0)
-            ->whereBetween('completed_at', [$start, $end])
+            ->whereBetween('created_at', [$start, $end])
             ->count();
     }
 }

--- a/app/Modules/Points/Repositories/Eloquent/PomodoroSessionRepository.php
+++ b/app/Modules/Points/Repositories/Eloquent/PomodoroSessionRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Modules\Points\Repositories\Eloquent;
+
+use App\Modules\Points\Models\PomodoroSession;
+use App\Modules\Points\Repositories\Contracts\PomodoroSessionRepositoryInterface;
+use Carbon\CarbonInterface;
+
+class PomodoroSessionRepository implements PomodoroSessionRepositoryInterface
+{
+    public function create(array $data): PomodoroSession
+    {
+        return PomodoroSession::create($data);
+    }
+
+    public function existsByClientRequestId(int $userId, string $clientRequestId): bool
+    {
+        return PomodoroSession::query()
+            ->where('user_id', $userId)
+            ->where('client_request_id', $clientRequestId)
+            ->exists();
+    }
+
+    public function findByClientRequestId(int $userId, string $clientRequestId): ?PomodoroSession
+    {
+        return PomodoroSession::query()
+            ->where('user_id', $userId)
+            ->where('client_request_id', $clientRequestId)
+            ->first();
+    }
+
+    public function todaysAwardedCount(int $userId, CarbonInterface $start, CarbonInterface $end): int
+    {
+        return PomodoroSession::query()
+            ->where('user_id', $userId)
+            ->where('awarded_points', '>', 0)
+            ->whereBetween('completed_at', [$start, $end])
+            ->count();
+    }
+}

--- a/app/Modules/Points/Repositories/Eloquent/StoreItemRepository.php
+++ b/app/Modules/Points/Repositories/Eloquent/StoreItemRepository.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Modules\Points\Repositories\Eloquent;
+
+use App\Modules\Points\Models\StoreItem;
+use App\Modules\Points\Repositories\Contracts\StoreItemRepositoryInterface;
+use Illuminate\Database\Eloquent\Collection;
+
+class StoreItemRepository implements StoreItemRepositoryInterface
+{
+    public function allActive(): Collection
+    {
+        return StoreItem::query()
+            ->where('is_active', true)
+            ->orderBy('sort_order')
+            ->orderBy('cost')
+            ->orderBy('id')
+            ->get();
+    }
+
+    public function findById(int $id): ?StoreItem
+    {
+        return StoreItem::query()->find($id);
+    }
+
+    public function findByKey(string $key): ?StoreItem
+    {
+        return StoreItem::query()->where('key', $key)->first();
+    }
+
+    public function defaultBase(): ?StoreItem
+    {
+        return StoreItem::query()
+            ->where('is_default', true)
+            ->where('is_active', true)
+            ->orderBy('id')
+            ->first();
+    }
+}

--- a/app/Modules/Points/Repositories/Eloquent/UserAvatarRepository.php
+++ b/app/Modules/Points/Repositories/Eloquent/UserAvatarRepository.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Modules\Points\Repositories\Eloquent;
+
+use App\Modules\Points\Models\UserAvatar;
+use App\Modules\Points\Repositories\Contracts\UserAvatarRepositoryInterface;
+
+class UserAvatarRepository implements UserAvatarRepositoryInterface
+{
+    public function getForUser(int $userId): ?UserAvatar
+    {
+        return UserAvatar::query()
+            ->with('baseItem')
+            ->where('user_id', $userId)
+            ->first();
+    }
+
+    public function ensureForUser(int $userId): UserAvatar
+    {
+        return UserAvatar::query()->firstOrCreate(['user_id' => $userId]);
+    }
+
+    public function upsertForUser(int $userId, array $data): UserAvatar
+    {
+        $avatar = UserAvatar::query()->firstOrCreate(['user_id' => $userId]);
+        $avatar->fill($data);
+        $avatar->save();
+
+        return $avatar;
+    }
+}

--- a/app/Modules/Points/Repositories/Eloquent/UserStoreItemRepository.php
+++ b/app/Modules/Points/Repositories/Eloquent/UserStoreItemRepository.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Modules\Points\Repositories\Eloquent;
+
+use App\Modules\Points\Models\UserStoreItem;
+use App\Modules\Points\Repositories\Contracts\UserStoreItemRepositoryInterface;
+use Illuminate\Database\Eloquent\Collection;
+
+class UserStoreItemRepository implements UserStoreItemRepositoryInterface
+{
+    public function create(array $data): UserStoreItem
+    {
+        return UserStoreItem::create($data);
+    }
+
+    public function existsForUser(int $userId, int $storeItemId): bool
+    {
+        return UserStoreItem::query()
+            ->where('user_id', $userId)
+            ->where('store_item_id', $storeItemId)
+            ->exists();
+    }
+
+    public function listForUser(int $userId): Collection
+    {
+        return UserStoreItem::query()
+            ->where('user_id', $userId)
+            ->get();
+    }
+
+    public function ownedItemIds(int $userId): array
+    {
+        return UserStoreItem::query()
+            ->where('user_id', $userId)
+            ->pluck('store_item_id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
+    }
+}

--- a/app/Modules/Points/Requests/EquipAvatarRequest.php
+++ b/app/Modules/Points/Requests/EquipAvatarRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Modules\Points\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class EquipAvatarRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'store_item_id' => ['required', 'integer', 'exists:store_items,id'],
+        ];
+    }
+}

--- a/app/Modules/Points/Requests/PurchaseStoreItemRequest.php
+++ b/app/Modules/Points/Requests/PurchaseStoreItemRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Modules\Points\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PurchaseStoreItemRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'store_item_id' => ['required', 'integer', 'exists:store_items,id'],
+            'client_request_id' => ['required', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Modules/Points/Requests/StorePomodoroSessionRequest.php
+++ b/app/Modules/Points/Requests/StorePomodoroSessionRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Modules\Points\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StorePomodoroSessionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'type' => ['required', 'string', Rule::in(['work', 'short_break', 'long_break', 'break'])],
+            'duration_seconds' => ['required', 'integer', 'min:1'],
+            'started_at' => ['nullable', 'date'],
+            'completed_at' => ['required', 'date', 'before_or_equal:now'],
+            'client_request_id' => ['required', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Modules/Points/Services/AvatarService.php
+++ b/app/Modules/Points/Services/AvatarService.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Modules\Points\Services;
+
+use App\Models\User;
+use App\Modules\Points\Repositories\Contracts\UserAvatarRepositoryInterface;
+use Illuminate\Support\Str;
+
+class AvatarService
+{
+    public function __construct(
+        private UserAvatarRepositoryInterface $avatars,
+    ) {}
+
+    /**
+     * The shared avatar prop shape. Phase 1 exposes the base layer URL plus a
+     * token-colored initials fallback the frontend renders when no art exists.
+     *
+     * @return array{base_url: string|null, initials: string}
+     */
+    public function presentFor(int $userId): array
+    {
+        $avatar = $this->avatars->getForUser($userId);
+        $baseItem = $avatar?->baseItem;
+
+        return [
+            'base_url' => $this->assetUrl($baseItem?->asset),
+            'initials' => $this->initialsFor($userId),
+        ];
+    }
+
+    private function assetUrl(?string $path): ?string
+    {
+        if ($path === null || $path === '') {
+            return null;
+        }
+
+        return asset('images/avatars/'.$path);
+    }
+
+    private function initialsFor(int $userId): string
+    {
+        $user = User::query()->select(['id', 'name', 'email'])->find($userId);
+
+        $name = trim((string) ($user?->name ?? ''));
+
+        if ($name !== '') {
+            $parts = preg_split('/\s+/', $name) ?: [];
+            $first = Str::substr($parts[0] ?? '', 0, 1);
+            $second = count($parts) > 1 ? Str::substr($parts[count($parts) - 1], 0, 1) : '';
+
+            $initials = Str::upper($first.$second);
+
+            if ($initials !== '') {
+                return $initials;
+            }
+        }
+
+        $email = (string) ($user?->email ?? '');
+
+        return $email !== '' ? Str::upper(Str::substr($email, 0, 1)) : '?';
+    }
+}

--- a/app/Modules/Points/Services/PointsAwardService.php
+++ b/app/Modules/Points/Services/PointsAwardService.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Modules\Points\Services;
+
+use App\Models\Subtask;
+use App\Models\Task;
+use App\Models\User;
+use App\Modules\Points\Enums\PointSource;
+use App\Modules\Points\Models\PointLedgerEntry;
+use App\Modules\Points\Models\PointWallet;
+use App\Modules\Points\Models\PomodoroSession;
+use App\Modules\Points\Repositories\Contracts\PointLedgerRepositoryInterface;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Translates productive actions into point awards / reversals.
+ *
+ * Award idempotency uses a net-award guard: award only when the running net
+ * (SUM of signed ledger amounts) for a source + sourceable is <= 0. Reversals
+ * subtract the outstanding net but are clamped by the wallet so the balance
+ * never drops below 0. Every earn also rolls the daily streak.
+ */
+class PointsAwardService
+{
+    public function __construct(
+        private PointsWalletService $walletService,
+        private PointLedgerRepositoryInterface $ledger,
+    ) {}
+
+    public function awardForTask(Task $task): void
+    {
+        $this->awardFor($task, $task->user, PointSource::TaskCompletion, (int) config('points.award.task_completion'));
+    }
+
+    public function reverseForTask(Task $task): void
+    {
+        $this->reverseFor($task, $task->user_id, PointSource::TaskCompletion);
+    }
+
+    public function awardForSubtask(Subtask $subtask): void
+    {
+        $task = $subtask->task;
+
+        if (! $task) {
+            return;
+        }
+
+        $this->awardFor($subtask, $task->user, PointSource::SubtaskCompletion, (int) config('points.award.subtask_completion'));
+    }
+
+    public function reverseForSubtask(Subtask $subtask): void
+    {
+        $task = $subtask->task;
+
+        if (! $task) {
+            return;
+        }
+
+        $this->reverseFor($subtask, $task->user_id, PointSource::SubtaskCompletion);
+    }
+
+    /**
+     * Credit a completed, awardable Pomodoro session and roll the streak.
+     */
+    public function awardForPomodoro(PomodoroSession $session): PointLedgerEntry
+    {
+        $user = $session->user;
+        $amount = (int) config('points.award.pomodoro_session');
+
+        $entry = $this->walletService->credit(
+            $user->id,
+            $amount,
+            PointSource::PomodoroSession,
+            $session,
+        );
+
+        $this->registerStreakActivity($this->walletService->ensureWallet($user->id), $user);
+
+        return $entry;
+    }
+
+    /**
+     * Roll the user's daily streak and award the once-per-day streak bonus.
+     */
+    public function registerStreakActivity(PointWallet $wallet, User $user): void
+    {
+        $wallet->refresh();
+
+        $today = $user->todayInUserTimezone()->toDateString();
+        $yesterday = $user->todayInUserTimezone()->subDay()->toDateString();
+        $lastEarned = $wallet->last_earned_on?->toDateString();
+
+        if ($lastEarned === $today) {
+            // Already active today; keep the streak but ensure it is at least 1.
+            $wallet->current_streak_days = max(1, $wallet->current_streak_days);
+        } elseif ($lastEarned === $yesterday) {
+            $wallet->current_streak_days = $wallet->current_streak_days + 1;
+        } else {
+            $wallet->current_streak_days = 1;
+        }
+
+        $wallet->longest_streak_days = max($wallet->longest_streak_days, $wallet->current_streak_days);
+        $wallet->last_earned_on = $today;
+        $wallet->save();
+
+        if ($wallet->last_streak_awarded_on?->toDateString() === $today) {
+            return;
+        }
+
+        $this->walletService->credit(
+            $user->id,
+            (int) config('points.award.daily_streak'),
+            PointSource::DailyStreak,
+            null,
+            "streak:{$user->id}:{$today}",
+        );
+
+        $wallet->last_streak_awarded_on = $today;
+        $wallet->save();
+    }
+
+    private function awardFor(Model $sourceable, ?User $user, PointSource $source, int $amount): void
+    {
+        if (! $user) {
+            return;
+        }
+
+        // Net-award guard: only award when nothing net-positive is outstanding.
+        if ($this->ledger->netAwardedFor($user->id, $source, $sourceable) > 0) {
+            return;
+        }
+
+        $this->walletService->credit($user->id, $amount, $source, $sourceable);
+
+        $this->registerStreakActivity($this->walletService->ensureWallet($user->id), $user);
+    }
+
+    private function reverseFor(Model $sourceable, ?int $userId, PointSource $source): void
+    {
+        if (! $userId) {
+            return;
+        }
+
+        $net = $this->ledger->netAwardedFor($userId, $source, $sourceable);
+
+        if ($net <= 0) {
+            return;
+        }
+
+        $this->walletService->adjust($userId, $net, $source, $sourceable);
+    }
+}

--- a/app/Modules/Points/Services/PointsAwardService.php
+++ b/app/Modules/Points/Services/PointsAwardService.php
@@ -15,10 +15,12 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Translates productive actions into point awards / reversals.
  *
- * Award idempotency uses a net-award guard: award only when the running net
- * (SUM of signed ledger amounts) for a source + sourceable is <= 0. Reversals
- * subtract the outstanding net but are clamped by the wallet so the balance
- * never drops below 0. Every earn also rolls the daily streak.
+ * Award idempotency uses a completion-*cycle* guard: award only when no
+ * un-reversed award is outstanding (earn entries do not outnumber reversals)
+ * for a source + sourceable. Reversals deduct the fixed award amount but are
+ * clamped by the wallet so the balance never drops below 0 — the reversal entry
+ * still closes the cycle even when clamped to 0, so a recurring task can earn
+ * again after a reset. Every earn also rolls the daily streak.
  */
 class PointsAwardService
 {
@@ -34,7 +36,7 @@ class PointsAwardService
 
     public function reverseForTask(Task $task): void
     {
-        $this->reverseFor($task, $task->user_id, PointSource::TaskCompletion);
+        $this->reverseFor($task, $task->user_id, PointSource::TaskCompletion, (int) config('points.award.task_completion'));
     }
 
     public function awardForSubtask(Subtask $subtask): void
@@ -56,7 +58,7 @@ class PointsAwardService
             return;
         }
 
-        $this->reverseFor($subtask, $task->user_id, PointSource::SubtaskCompletion);
+        $this->reverseFor($subtask, $task->user_id, PointSource::SubtaskCompletion, (int) config('points.award.subtask_completion'));
     }
 
     /**
@@ -125,8 +127,8 @@ class PointsAwardService
             return;
         }
 
-        // Net-award guard: only award when nothing net-positive is outstanding.
-        if ($this->ledger->netAwardedFor($user->id, $source, $sourceable) > 0) {
+        // Cycle guard: skip when an un-reversed award is still outstanding.
+        if ($this->ledger->awardCycleOpen($user->id, $source, $sourceable)) {
             return;
         }
 
@@ -135,18 +137,18 @@ class PointsAwardService
         $this->registerStreakActivity($this->walletService->ensureWallet($user->id), $user);
     }
 
-    private function reverseFor(Model $sourceable, ?int $userId, PointSource $source): void
+    private function reverseFor(Model $sourceable, ?int $userId, PointSource $source, int $amount): void
     {
         if (! $userId) {
             return;
         }
 
-        $net = $this->ledger->netAwardedFor($userId, $source, $sourceable);
-
-        if ($net <= 0) {
+        // Nothing to reverse unless an award cycle is open. The adjust is
+        // clamped to the wallet balance but its entry still closes the cycle.
+        if (! $this->ledger->awardCycleOpen($userId, $source, $sourceable)) {
             return;
         }
 
-        $this->walletService->adjust($userId, $net, $source, $sourceable);
+        $this->walletService->adjust($userId, $amount, $source, $sourceable);
     }
 }

--- a/app/Modules/Points/Services/PointsWalletService.php
+++ b/app/Modules/Points/Services/PointsWalletService.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace App\Modules\Points\Services;
+
+use App\Modules\Points\Enums\PointLedgerType;
+use App\Modules\Points\Enums\PointSource;
+use App\Modules\Points\Exceptions\InsufficientBalanceException;
+use App\Modules\Points\Models\PointLedgerEntry;
+use App\Modules\Points\Models\PointWallet;
+use App\Modules\Points\Repositories\Contracts\PointLedgerRepositoryInterface;
+use App\Modules\Points\Repositories\Contracts\PointWalletRepositoryInterface;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * The single atomic authority over a user's point balance + ledger.
+ *
+ * Every mutation runs inside DB::transaction with a pessimistic lock on the
+ * wallet row so concurrent earns/spends can never race the running balance.
+ * The balance floors at 0 and each mutation appends an immutable, signed
+ * ledger entry carrying the post-mutation balance_after.
+ */
+class PointsWalletService
+{
+    public function __construct(
+        private PointWalletRepositoryInterface $wallets,
+        private PointLedgerRepositoryInterface $ledger,
+    ) {}
+
+    public function ensureWallet(int $userId): PointWallet
+    {
+        return $this->wallets->ensureForUser($userId);
+    }
+
+    /**
+     * Add points. Positive $amount only. Idempotent when $clientRequestId
+     * matches an existing entry.
+     *
+     * @param  array<string, mixed>  $metadata
+     */
+    public function credit(
+        int $userId,
+        int $amount,
+        PointSource $source,
+        ?Model $sourceable = null,
+        ?string $clientRequestId = null,
+        array $metadata = [],
+        PointLedgerType $type = PointLedgerType::Earn,
+    ): PointLedgerEntry {
+        $amount = max(0, $amount);
+
+        return DB::transaction(function () use ($userId, $amount, $source, $sourceable, $clientRequestId, $metadata, $type) {
+            $wallet = $this->wallets->lockForUser($userId);
+
+            if ($existing = $this->existingEntry($userId, $clientRequestId)) {
+                return $existing;
+            }
+
+            $newBalance = $wallet->balance + $amount;
+            $wallet->balance = $newBalance;
+            $wallet->lifetime_earned = $wallet->lifetime_earned + $amount;
+            $wallet->save();
+
+            return $this->writeEntry($userId, $amount, $newBalance, $type, $source, $sourceable, $clientRequestId, $metadata);
+        });
+    }
+
+    /**
+     * Spend points. Positive $amount only. Throws when the balance cannot
+     * cover the spend. Idempotent when $clientRequestId matches.
+     *
+     * @param  array<string, mixed>  $metadata
+     */
+    public function debit(
+        int $userId,
+        int $amount,
+        PointSource $source,
+        ?Model $sourceable = null,
+        ?string $clientRequestId = null,
+        array $metadata = [],
+        PointLedgerType $type = PointLedgerType::Spend,
+    ): PointLedgerEntry {
+        $amount = max(0, $amount);
+
+        return DB::transaction(function () use ($userId, $amount, $source, $sourceable, $clientRequestId, $metadata, $type) {
+            $wallet = $this->wallets->lockForUser($userId);
+
+            if ($existing = $this->existingEntry($userId, $clientRequestId)) {
+                return $existing;
+            }
+
+            if ($wallet->balance < $amount) {
+                throw InsufficientBalanceException::forPurchase($wallet->balance, $amount);
+            }
+
+            $newBalance = $wallet->balance - $amount;
+            $wallet->balance = $newBalance;
+            $wallet->lifetime_spent = $wallet->lifetime_spent + $amount;
+            $wallet->save();
+
+            return $this->writeEntry($userId, -$amount, $newBalance, $type, $source, $sourceable, $clientRequestId, $metadata);
+        });
+    }
+
+    /**
+     * Reduce the balance by up to $decreaseBy without ever going negative
+     * (never claws back already-spent points). Used to reverse an earlier
+     * award. Records a clamped, signed `adjust` entry and logs any clamp.
+     *
+     * @param  array<string, mixed>  $metadata
+     */
+    public function adjust(
+        int $userId,
+        int $decreaseBy,
+        PointSource $source,
+        ?Model $sourceable = null,
+        ?string $clientRequestId = null,
+        array $metadata = [],
+    ): PointLedgerEntry {
+        $decreaseBy = max(0, $decreaseBy);
+
+        return DB::transaction(function () use ($userId, $decreaseBy, $source, $sourceable, $clientRequestId, $metadata) {
+            $wallet = $this->wallets->lockForUser($userId);
+
+            if ($existing = $this->existingEntry($userId, $clientRequestId)) {
+                return $existing;
+            }
+
+            $actual = min($decreaseBy, $wallet->balance);
+
+            if ($actual < $decreaseBy) {
+                Log::info('Points reversal clamped to floor balance at 0.', [
+                    'user_id' => $userId,
+                    'source' => $source->value,
+                    'requested' => $decreaseBy,
+                    'applied' => $actual,
+                    'balance' => $wallet->balance,
+                ]);
+            }
+
+            $newBalance = $wallet->balance - $actual;
+            $wallet->balance = $newBalance;
+            $wallet->save();
+
+            return $this->writeEntry($userId, -$actual, $newBalance, PointLedgerType::Adjust, $source, $sourceable, $clientRequestId, $metadata);
+        });
+    }
+
+    private function existingEntry(int $userId, ?string $clientRequestId): ?PointLedgerEntry
+    {
+        if ($clientRequestId === null) {
+            return null;
+        }
+
+        return $this->ledger->findByClientRequestId($userId, $clientRequestId);
+    }
+
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    private function writeEntry(
+        int $userId,
+        int $signedAmount,
+        int $balanceAfter,
+        PointLedgerType $type,
+        PointSource $source,
+        ?Model $sourceable,
+        ?string $clientRequestId,
+        array $metadata,
+    ): PointLedgerEntry {
+        return $this->ledger->create([
+            'user_id' => $userId,
+            'type' => $type->value,
+            'source' => $source->value,
+            'amount' => $signedAmount,
+            'balance_after' => $balanceAfter,
+            'sourceable_type' => $sourceable?->getMorphClass(),
+            'sourceable_id' => $sourceable?->getKey(),
+            'client_request_id' => $clientRequestId,
+            'metadata' => $metadata !== [] ? $metadata : null,
+        ]);
+    }
+}

--- a/app/Modules/Points/Services/PomodoroSessionService.php
+++ b/app/Modules/Points/Services/PomodoroSessionService.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Modules\Points\Services;
+
+use App\Models\User;
+use App\Modules\Points\Models\PomodoroSession;
+use App\Modules\Points\Repositories\Contracts\PomodoroSessionRepositoryInterface;
+use Carbon\Carbon;
+
+/**
+ * Persists client-driven Pomodoro sessions with server-authoritative award
+ * rules. Amounts and validity windows come from config only; client-supplied
+ * point values are ignored.
+ */
+class PomodoroSessionService
+{
+    public function __construct(
+        private PomodoroSessionRepositoryInterface $sessions,
+        private PointsAwardService $awardService,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function record(User $user, array $data): PomodoroSession
+    {
+        $clientRequestId = $data['client_request_id'] ?? null;
+
+        if ($clientRequestId !== null && ($existing = $this->sessions->findByClientRequestId($user->id, $clientRequestId))) {
+            return $existing;
+        }
+
+        $type = (string) $data['type'];
+        $duration = (int) $data['duration_seconds'];
+        $completedAt = ! empty($data['completed_at']) ? Carbon::parse($data['completed_at']) : now();
+        $startedAt = ! empty($data['started_at']) ? Carbon::parse($data['started_at']) : null;
+
+        $awardable = $this->isAwardable($user, $type, $duration);
+
+        $session = $this->sessions->create([
+            'user_id' => $user->id,
+            'client_request_id' => $clientRequestId,
+            'type' => $type,
+            'duration_seconds' => $duration,
+            'started_at' => $startedAt,
+            'completed_at' => $completedAt,
+            'awarded_points' => 0,
+        ]);
+
+        if ($awardable) {
+            $entry = $this->awardService->awardForPomodoro($session);
+
+            $session->awarded_points = (int) config('points.award.pomodoro_session');
+            $session->point_ledger_entry_id = $entry->id;
+            $session->save();
+        }
+
+        return $session;
+    }
+
+    private function isAwardable(User $user, string $type, int $duration): bool
+    {
+        $awardableTypes = (array) config('points.pomodoro.awardable_types', []);
+
+        if (! in_array($type, $awardableTypes, true)) {
+            return false;
+        }
+
+        $min = (int) config('points.pomodoro.min_seconds');
+        $max = (int) config('points.pomodoro.max_seconds');
+
+        if ($duration < $min || $duration > $max) {
+            return false;
+        }
+
+        // Stored timestamps are UTC — convert the user's local day boundaries.
+        $start = $user->todayInUserTimezone()->utc();
+        $end = $start->copy()->addDay();
+        $cap = (int) config('points.pomodoro.daily_award_cap');
+
+        return $this->sessions->todaysAwardedCount($user->id, $start, $end) < $cap;
+    }
+}

--- a/app/Modules/Points/Services/StoreService.php
+++ b/app/Modules/Points/Services/StoreService.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace App\Modules\Points\Services;
+
+use App\Models\User;
+use App\Modules\Points\Enums\PointSource;
+use App\Modules\Points\Enums\StoreItemType;
+use App\Modules\Points\Models\StoreItem;
+use App\Modules\Points\Models\UserStoreItem;
+use App\Modules\Points\Repositories\Contracts\StoreItemRepositoryInterface;
+use App\Modules\Points\Repositories\Contracts\UserAvatarRepositoryInterface;
+use App\Modules\Points\Repositories\Contracts\UserStoreItemRepositoryInterface;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+class StoreService
+{
+    public function __construct(
+        private StoreItemRepositoryInterface $storeItems,
+        private UserStoreItemRepositoryInterface $inventory,
+        private UserAvatarRepositoryInterface $avatars,
+        private PointsWalletService $walletService,
+    ) {}
+
+    /**
+     * The full active catalog, decorated with per-user owned/equipped flags.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function listCatalogFor(User $user): array
+    {
+        $items = $this->storeItems->allActive();
+        $ownedIds = $this->inventory->ownedItemIds($user->id);
+        $avatar = $this->avatars->getForUser($user->id);
+        $baseItemId = $avatar?->base_item_id;
+        $equippedMap = $avatar?->equipped ?? [];
+
+        return $items->map(function (StoreItem $item) use ($ownedIds, $baseItemId, $equippedMap): array {
+            $slot = $item->slot?->value;
+            $isBase = $item->type === StoreItemType::AvatarBase;
+
+            $equipped = $isBase
+                ? ($baseItemId !== null && (int) $baseItemId === (int) $item->id)
+                : ($slot !== null && (int) ($equippedMap[$slot] ?? 0) === (int) $item->id);
+
+            return [
+                'id' => (int) $item->id,
+                'key' => $item->key,
+                'name' => $item->name,
+                'description' => $item->description,
+                'type' => $item->type->value,
+                'slot' => $slot,
+                'cost' => (int) $item->cost,
+                'preview_url' => $this->assetUrl($item->preview_asset ?? $item->asset),
+                'owned' => in_array((int) $item->id, $ownedIds, true),
+                'equipped' => $equipped,
+            ];
+        })->all();
+    }
+
+    /**
+     * Purchase an item: atomic debit + inventory row + optional auto-equip.
+     * Idempotent per $clientRequestId (the debit short-circuits on retry) and
+     * a no-op when the user already owns the item.
+     */
+    public function purchase(User $user, StoreItem $storeItem, string $clientRequestId): ?UserStoreItem
+    {
+        return DB::transaction(function () use ($user, $storeItem, $clientRequestId) {
+            if (! $storeItem->is_active) {
+                throw new RuntimeException('This item is not available.');
+            }
+
+            if ($this->inventory->existsForUser($user->id, $storeItem->id)) {
+                return null;
+            }
+
+            $entry = $this->walletService->debit(
+                $user->id,
+                (int) $storeItem->cost,
+                PointSource::StorePurchase,
+                $storeItem,
+                $clientRequestId,
+            );
+
+            $inventory = $this->inventory->create([
+                'user_id' => $user->id,
+                'store_item_id' => $storeItem->id,
+                'acquired_via' => 'purchase',
+                'point_ledger_entry_id' => $entry->id,
+                'acquired_at' => now(),
+            ]);
+
+            // Auto-equip a base avatar when the user has none yet.
+            if ($storeItem->type === StoreItemType::AvatarBase) {
+                $avatar = $this->avatars->ensureForUser($user->id);
+
+                if ($avatar->base_item_id === null) {
+                    $avatar->base_item_id = $storeItem->id;
+                    $avatar->save();
+                }
+            }
+
+            return $inventory;
+        });
+    }
+
+    /**
+     * Equip an owned item. Aborts 403 when the user does not own it.
+     */
+    public function equip(User $user, StoreItem $storeItem): void
+    {
+        if (! $this->inventory->existsForUser($user->id, $storeItem->id)) {
+            abort(403, 'You do not own this item.');
+        }
+
+        $avatar = $this->avatars->ensureForUser($user->id);
+
+        if ($storeItem->type === StoreItemType::AvatarBase) {
+            $avatar->base_item_id = $storeItem->id;
+            $avatar->save();
+
+            return;
+        }
+
+        // Accessory slots (Phase 2 layering) — record in the equipped map.
+        $slot = $storeItem->slot?->value;
+
+        if ($slot !== null) {
+            $equipped = $avatar->equipped ?? [];
+            $equipped[$slot] = (int) $storeItem->id;
+            $avatar->equipped = $equipped;
+            $avatar->save();
+        }
+    }
+
+    private function assetUrl(?string $path): ?string
+    {
+        if ($path === null || $path === '') {
+            return null;
+        }
+
+        return asset('images/avatars/'.$path);
+    }
+}

--- a/app/Modules/Points/Services/StoreService.php
+++ b/app/Modules/Points/Services/StoreService.php
@@ -82,6 +82,16 @@ class StoreService
                 $clientRequestId,
             );
 
+            // Guard against a client_request_id reused across different items:
+            // debit() is idempotent per request id and would otherwise return
+            // the *first* item's spend entry, granting this item for free.
+            $matchesItem = (int) $entry->sourceable_id === (int) $storeItem->id
+                && $entry->sourceable_type === $storeItem->getMorphClass();
+
+            if (! $matchesItem) {
+                throw new RuntimeException('This request has already been used for a different purchase.');
+            }
+
             $inventory = $this->inventory->create([
                 'user_id' => $user->id,
                 'store_item_id' => $storeItem->id,

--- a/app/Modules/Points/database/migrations/2026_08_09_000001_create_point_wallets_table.php
+++ b/app/Modules/Points/database/migrations/2026_08_09_000001_create_point_wallets_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('point_wallets', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->integer('balance')->default(0);
+            $table->integer('lifetime_earned')->default(0);
+            $table->integer('lifetime_spent')->default(0);
+            $table->integer('current_streak_days')->default(0);
+            $table->integer('longest_streak_days')->default(0);
+            $table->date('last_earned_on')->nullable();
+            $table->date('last_streak_awarded_on')->nullable();
+            $table->timestamps();
+
+            $table->unique('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('point_wallets');
+    }
+};

--- a/app/Modules/Points/database/migrations/2026_08_09_000002_create_store_items_table.php
+++ b/app/Modules/Points/database/migrations/2026_08_09_000002_create_store_items_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('store_items', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->string('name');
+            $table->text('description')->nullable();
+            // avatar_base / accessory
+            $table->string('type');
+            // base / hat / background / frame
+            $table->string('slot')->nullable();
+            $table->integer('cost')->default(0);
+            $table->string('asset')->nullable();
+            $table->string('preview_asset')->nullable();
+            $table->json('metadata')->nullable();
+            $table->integer('sort_order')->default(0);
+            $table->boolean('is_active')->default(true);
+            $table->boolean('is_default')->default(false);
+            $table->boolean('is_premium')->default(false);
+            $table->timestamp('available_from')->nullable();
+            $table->timestamp('available_until')->nullable();
+            $table->timestamps();
+
+            $table->index(['type', 'is_active']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('store_items');
+    }
+};

--- a/app/Modules/Points/database/migrations/2026_08_09_000003_create_point_ledger_entries_table.php
+++ b/app/Modules/Points/database/migrations/2026_08_09_000003_create_point_ledger_entries_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('point_ledger_entries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            // earn / spend / adjust / refund
+            $table->string('type');
+            // task_completion / subtask_completion / daily_streak / pomodoro_session /
+            // store_purchase / purchase_refund / admin_adjust
+            $table->string('source');
+            // Signed so SUM(amount) == wallet balance.
+            $table->integer('amount');
+            $table->integer('balance_after');
+            $table->string('sourceable_type')->nullable();
+            $table->unsignedBigInteger('sourceable_id')->nullable();
+            $table->string('client_request_id')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'created_at']);
+            // Idempotency: a client_request_id is used at most once per user.
+            $table->unique(['user_id', 'client_request_id']);
+            // Net-award guard lookups.
+            $table->index(['sourceable_type', 'sourceable_id', 'source']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('point_ledger_entries');
+    }
+};

--- a/app/Modules/Points/database/migrations/2026_08_09_000004_create_user_store_items_table.php
+++ b/app/Modules/Points/database/migrations/2026_08_09_000004_create_user_store_items_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('user_store_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('store_item_id')->constrained('store_items')->cascadeOnDelete();
+            // purchase / grant / default
+            $table->string('acquired_via')->nullable();
+            $table->foreignId('point_ledger_entry_id')->nullable()
+                ->constrained('point_ledger_entries')->nullOnDelete();
+            $table->timestamp('acquired_at')->nullable();
+            $table->timestamps();
+
+            // Double-purchase guard.
+            $table->unique(['user_id', 'store_item_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_store_items');
+    }
+};

--- a/app/Modules/Points/database/migrations/2026_08_09_000005_create_user_avatars_table.php
+++ b/app/Modules/Points/database/migrations/2026_08_09_000005_create_user_avatars_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('user_avatars', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('base_item_id')->nullable()
+                ->constrained('store_items')->nullOnDelete();
+            // slot => store_item_id map (Phase 1 uses base_item_id only).
+            $table->json('equipped')->nullable();
+            $table->timestamps();
+
+            $table->unique('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_avatars');
+    }
+};

--- a/app/Modules/Points/database/migrations/2026_08_09_000006_create_pomodoro_sessions_table.php
+++ b/app/Modules/Points/database/migrations/2026_08_09_000006_create_pomodoro_sessions_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pomodoro_sessions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('client_request_id')->nullable();
+            // work / short_break / long_break
+            $table->string('type');
+            $table->integer('duration_seconds');
+            $table->timestamp('started_at')->nullable();
+            $table->timestamp('completed_at')->nullable();
+            $table->integer('awarded_points')->default(0);
+            $table->foreignId('point_ledger_entry_id')->nullable()
+                ->constrained('point_ledger_entries')->nullOnDelete();
+            $table->timestamps();
+
+            // Idempotency per client-generated session id.
+            $table->unique(['user_id', 'client_request_id']);
+            $table->index(['user_id', 'completed_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pomodoro_sessions');
+    }
+};

--- a/app/Modules/Points/routes.php
+++ b/app/Modules/Points/routes.php
@@ -1,0 +1,14 @@
+<?php
+
+use App\Modules\Points\Controllers\PomodoroSessionController;
+use App\Modules\Points\Controllers\StoreController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['web', 'auth'])->group(function () {
+    Route::get('store', [StoreController::class, 'index'])->name('store.index');
+    Route::post('store/purchase', [StoreController::class, 'purchase'])->name('store.purchase');
+    Route::post('store/equip', [StoreController::class, 'equip'])->name('store.equip');
+
+    Route::post('pomodoro/sessions', [PomodoroSessionController::class, 'store'])
+        ->name('pomodoro.sessions.store');
+});

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -5,6 +5,10 @@ namespace App\Observers;
 use App\Models\EventCalendar;
 use App\Models\User;
 use App\Modules\Finance\Models\FinanceAccount;
+use App\Modules\Points\Models\PointWallet;
+use App\Modules\Points\Models\StoreItem;
+use App\Modules\Points\Models\UserAvatar;
+use App\Modules\Points\Models\UserStoreItem;
 
 class UserObserver
 {
@@ -19,6 +23,8 @@ class UserObserver
             ['user_id' => $user->id, 'is_default' => true],
             ['name' => 'Personal', 'color' => '#4ACF91', 'position' => 0]
         );
+
+        $this->seedPointsProfile($user);
 
         $hasDefault = FinanceAccount::query()
             ->where('user_id', $user->id)
@@ -40,5 +46,37 @@ class UserObserver
             'is_active' => true,
             'is_default' => true,
         ]);
+    }
+
+    /**
+     * Seed the Points profile: a wallet, an avatar row, and (when the catalog
+     * has one) the free default base avatar, granted and equipped. The wallet
+     * and avatar row are always created; the default grant is null-safe so the
+     * feature bootstraps even before the store catalog is seeded.
+     */
+    private function seedPointsProfile(User $user): void
+    {
+        PointWallet::firstOrCreate(['user_id' => $user->id]);
+        $avatar = UserAvatar::firstOrCreate(['user_id' => $user->id]);
+
+        $defaultBase = StoreItem::query()
+            ->where('is_default', true)
+            ->where('is_active', true)
+            ->orderBy('id')
+            ->first();
+
+        if (! $defaultBase) {
+            return;
+        }
+
+        UserStoreItem::firstOrCreate(
+            ['user_id' => $user->id, 'store_item_id' => $defaultBase->id],
+            ['acquired_via' => 'default', 'acquired_at' => now()]
+        );
+
+        if ($avatar->base_item_id === null) {
+            $avatar->base_item_id = $defaultBase->id;
+            $avatar->save();
+        }
     }
 }

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -4,4 +4,5 @@ return [
     App\Providers\AppServiceProvider::class,
     App\Modules\Journal\JournalServiceProvider::class,
     App\Modules\MealPlanning\MealPlanningServiceProvider::class,
+    App\Modules\Points\PointsServiceProvider::class,
 ];

--- a/config/points.php
+++ b/config/points.php
@@ -1,0 +1,56 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Award amounts
+    |--------------------------------------------------------------------------
+    |
+    | Point values granted per productive action. These are the ONLY source of
+    | award amounts — client-supplied values are always ignored.
+    |
+    */
+
+    'award' => [
+        'task_completion' => (int) env('POINTS_TASK_COMPLETION', 10),
+        'subtask_completion' => (int) env('POINTS_SUBTASK_COMPLETION', 2),
+        'daily_streak' => (int) env('POINTS_DAILY_STREAK', 5),
+        'pomodoro_session' => (int) env('POINTS_POMODORO_SESSION', 8),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Streak rules
+    |--------------------------------------------------------------------------
+    |
+    | Phase 1 credits a flat `award.daily_streak` bonus once per active day.
+    | These knobs back a Phase 2 escalating bonus and are defined up front so
+    | no config rewrite is needed later.
+    |
+    */
+
+    'streak' => [
+        'bonus_per_day' => (int) env('POINTS_STREAK_BONUS_PER_DAY', 1),
+        'max_bonus' => (int) env('POINTS_STREAK_MAX_BONUS', 20),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pomodoro rules
+    |--------------------------------------------------------------------------
+    |
+    | Server-side validation window for awarding focus sessions. Only the
+    | listed session types earn, and only within the duration bounds and under
+    | the per-day cap.
+    |
+    */
+
+    'pomodoro' => [
+        'min_seconds' => (int) env('POINTS_POMODORO_MIN_SECONDS', 900),
+        'max_seconds' => (int) env('POINTS_POMODORO_MAX_SECONDS', 7200),
+        'daily_award_cap' => (int) env('POINTS_POMODORO_DAILY_CAP', 16),
+        'awardable_types' => ['work'],
+    ],
+
+];

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,6 +13,10 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
+        // Seed the Points store catalog first so the UserObserver can grant and
+        // equip the default base avatar to users created below.
+        $this->call(PointsStoreCatalogSeeder::class);
+
         // Create admin user
         User::factory()->create([
             'name' => 'Admin User',

--- a/database/seeders/PointsStoreCatalogSeeder.php
+++ b/database/seeders/PointsStoreCatalogSeeder.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Modules\Points\Enums\StoreItemSlot;
+use App\Modules\Points\Enums\StoreItemType;
+use App\Modules\Points\Models\StoreItem;
+use Illuminate\Database\Seeder;
+
+/**
+ * Seeds the Phase 1 avatar-base catalog.
+ *
+ * Art pipeline: bases are pre-generated (OpenArt) transparent PNGs on a fixed
+ * 512x512 canvas and committed under public/images/avatars/bases/<key>.png.
+ * The `asset` column stores the "bases/<key>" path resolved by AvatarService.
+ * Files may not exist yet — the frontend renders an initials fallback until
+ * the art lands. Add new drops by appending rows here.
+ */
+class PointsStoreCatalogSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $bases = [
+            [
+                'key' => 'avatar_base_default',
+                'name' => 'Starter',
+                'description' => 'The free starter avatar every account begins with.',
+                'cost' => 0,
+                'is_default' => true,
+                'sort_order' => 0,
+            ],
+            [
+                'key' => 'avatar_base_fox',
+                'name' => 'Fox',
+                'description' => 'A clever little fox to focus with.',
+                'cost' => 50,
+                'is_default' => false,
+                'sort_order' => 1,
+            ],
+            [
+                'key' => 'avatar_base_owl',
+                'name' => 'Owl',
+                'description' => 'A night-owl companion for late sessions.',
+                'cost' => 75,
+                'is_default' => false,
+                'sort_order' => 2,
+            ],
+            [
+                'key' => 'avatar_base_cat',
+                'name' => 'Cat',
+                'description' => 'A calm cat that keeps you company.',
+                'cost' => 100,
+                'is_default' => false,
+                'sort_order' => 3,
+            ],
+            [
+                'key' => 'avatar_base_robot',
+                'name' => 'Robot',
+                'description' => 'A productivity-optimized robot buddy.',
+                'cost' => 150,
+                'is_default' => false,
+                'sort_order' => 4,
+            ],
+            [
+                'key' => 'avatar_base_dragon',
+                'name' => 'Dragon',
+                'description' => 'A legendary dragon for streak champions.',
+                'cost' => 250,
+                'is_default' => false,
+                'sort_order' => 5,
+            ],
+        ];
+
+        foreach ($bases as $base) {
+            $key = $base['key'];
+            $assetKey = str_replace('avatar_base_', '', $key);
+
+            StoreItem::updateOrCreate(
+                ['key' => $key],
+                [
+                    'name' => $base['name'],
+                    'description' => $base['description'],
+                    'type' => StoreItemType::AvatarBase->value,
+                    'slot' => StoreItemSlot::Base->value,
+                    'cost' => $base['cost'],
+                    'asset' => 'bases/'.$assetKey.'.png',
+                    'preview_asset' => 'bases/preview/'.$assetKey.'.png',
+                    'sort_order' => $base['sort_order'],
+                    'is_active' => true,
+                    'is_default' => $base['is_default'],
+                    'is_premium' => false,
+                ]
+            );
+        }
+    }
+}

--- a/public/images/avatars/README.md
+++ b/public/images/avatars/README.md
@@ -1,0 +1,36 @@
+# Avatar art assets
+
+Static, pre-generated avatar art for the Points store. These are **not** generated at
+runtime — the catalog is fixed and everyone buys from the same set. Generate art once
+per catalog drop (OpenArt), commit the PNGs here, and register each item in
+`database/seeders/PointsStoreCatalogSeeder.php`.
+
+## Layout
+
+```
+public/images/avatars/
+  bases/<key>.png            # full base avatar, e.g. bases/fox.png
+  bases/preview/<key>.png     # store-card preview variant
+  hats/<key>.png              # Phase 2 accessory layers
+  frames/<key>.png            # Phase 2
+  backgrounds/<key>.png       # Phase 2
+```
+
+The seeder stores `asset` as `bases/<key>.png` and `preview_asset` as
+`bases/preview/<key>.png`; `AvatarService::presentFor()` resolves them with
+`asset('images/avatars/'.$path)`. If a file is missing, the `<Avatar>` component
+falls back to a token-coloured initials circle (via `onError`), so the feature works
+before art lands.
+
+## Canvas / style spec (keep drops consistent)
+
+- **Canvas:** 512×512, transparent background (PNG), subject centered.
+- **Preview:** same art, may be tighter-cropped; ~256×256 is fine.
+- **Style prompt:** use one shared prompt across a drop so all avatars read as a set
+  (same rendering style, lighting, line weight, palette family). Record the exact
+  prompt alongside the drop for reproducibility.
+
+## Phase 1 catalog keys
+
+`avatar_base_default` (free), `avatar_base_fox`, `avatar_base_owl`, `avatar_base_cat`,
+`avatar_base_robot`, `avatar_base_dragon` → files `bases/{default,fox,owl,cat,robot,dragon}.png`.

--- a/resources/js/Components/Avatar/Avatar.jsx
+++ b/resources/js/Components/Avatar/Avatar.jsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+import { User } from "lucide-react";
+
+/**
+ * Renders a user's customizable avatar.
+ *
+ * `avatar` shape (from the shared `auth.avatar` prop / store item preview):
+ *   { base_url: string | null, initials: string }
+ *
+ * The component is built as an absolutely-positioned layer stack so future
+ * phases can composite background → base → frame → hat over the same square.
+ * Phase 1 renders only the base image, with a token-coloured initials / lucide
+ * `User` fallback when no base asset is available yet.
+ */
+const SIZES = {
+    sm: { box: "h-8 w-8", text: "text-xs", icon: "h-4 w-4" },
+    md: { box: "h-12 w-12", text: "text-base", icon: "h-6 w-6" },
+    lg: { box: "h-20 w-20 sm:h-24 sm:w-24", text: "text-2xl", icon: "h-12 w-12" },
+};
+
+export default function Avatar({ avatar, size = "md", className = "" }) {
+    const dims = SIZES[size] ?? SIZES.md;
+    const baseUrl = avatar?.base_url ?? null;
+    const initials = avatar?.initials ?? "";
+
+    // Fall back to initials when the art file is missing (404) — base_url can be
+    // a valid URL that points at not-yet-committed art. Track the URL that failed
+    // so equipping a different avatar retries instead of staying hidden.
+    const [failedUrl, setFailedUrl] = useState(null);
+    const showImage = baseUrl && failedUrl !== baseUrl;
+
+    return (
+        <div
+            className={`relative flex-shrink-0 overflow-hidden rounded-full ${dims.box} ${className}`}
+        >
+            {showImage ? (
+                /* Base layer — future accessory layers stack on top of this. */
+                <img
+                    key={baseUrl}
+                    src={baseUrl}
+                    alt=""
+                    draggable={false}
+                    onError={() => setFailedUrl(baseUrl)}
+                    className="absolute inset-0 h-full w-full object-cover"
+                />
+            ) : (
+                <div className="absolute inset-0 flex items-center justify-center bg-primary-100 text-primary-700 dark:bg-primary-900/40 dark:text-primary-200">
+                    {initials ? (
+                        <span className={`font-semibold uppercase ${dims.text}`}>
+                            {initials}
+                        </span>
+                    ) : (
+                        <User className={dims.icon} aria-hidden="true" />
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/resources/js/Components/Points/PointsBadge.jsx
+++ b/resources/js/Components/Points/PointsBadge.jsx
@@ -1,0 +1,35 @@
+import { usePage } from "@inertiajs/react";
+import { Flame, Sparkles } from "lucide-react";
+
+/**
+ * Compact points balance pill, driven by the shared `auth.points` prop
+ * ({ balance, streak }). Renders nothing when points aren't shared yet
+ * (older cached pages / unauthenticated), so it's safe to drop anywhere.
+ */
+export default function PointsBadge({ showStreak = true, className = "" }) {
+    const points = usePage().props?.auth?.points;
+    if (!points) return null;
+
+    const balance = points.balance ?? 0;
+    const streak = points.streak ?? 0;
+
+    return (
+        <span
+            className={`inline-flex items-center gap-1.5 rounded-full bg-primary-100 px-2.5 py-1 text-sm font-semibold text-primary-700 dark:bg-primary-900/30 dark:text-primary-200 ${className}`}
+            aria-label={`${balance.toLocaleString()} points`}
+            title={`${balance.toLocaleString()} points`}
+        >
+            <Sparkles className="h-4 w-4" aria-hidden="true" />
+            <span>{balance.toLocaleString()}</span>
+            {showStreak && streak > 0 && (
+                <span
+                    className="ml-1 inline-flex items-center gap-0.5 text-amber-600 dark:text-amber-400"
+                    title={`${streak}-day streak`}
+                >
+                    <Flame className="h-3.5 w-3.5" aria-hidden="true" />
+                    {streak}
+                </span>
+            )}
+        </span>
+    );
+}

--- a/resources/js/Components/Pomodoro/PomodoroContext.jsx
+++ b/resources/js/Components/Pomodoro/PomodoroContext.jsx
@@ -1,3 +1,4 @@
+import { router } from "@inertiajs/react";
 import React, {
     createContext,
     useContext,
@@ -7,6 +8,17 @@ import React, {
 } from "react";
 
 const PomodoroContext = createContext();
+
+/**
+ * Collision-resistant idempotency id for a pomodoro session. Prefers the
+ * platform UUID generator, falling back where it isn't available.
+ */
+function newClientRequestId() {
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+        return crypto.randomUUID();
+    }
+    return `req-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
 
 // Timer states
 const TIMER_STATES = {
@@ -153,6 +165,9 @@ export function PomodoroProvider({ children }) {
     const [state, dispatch] = useReducer(pomodoroReducer, initialState);
     const intervalRef = useRef(null);
     const audioRef = useRef(null);
+    // Tracks the in-flight work session so points are awarded once, server-side,
+    // when it completes naturally. Holds { clientRequestId, startedAt, durationSeconds }.
+    const workSessionRef = useRef(null);
 
     // Load state from localStorage on mount
     useEffect(() => {
@@ -256,6 +271,61 @@ export function PomodoroProvider({ children }) {
             }
         }
     }, [state.timeLeft, state.state]);
+
+    // Award points server-side when a WORK session completes naturally.
+    // The reducer flips a finished work session to the BREAK state (manual
+    // resets/skips go to IDLE instead, so they never award). An idempotency id
+    // is minted once per session start and reused on retries.
+    useEffect(() => {
+        // A fresh work session began — capture id + start time once. Resuming
+        // from pause keeps the same id (the ref is still set), so no re-award.
+        if (
+            state.state === TIMER_STATES.RUNNING &&
+            state.currentSession === "work" &&
+            !workSessionRef.current
+        ) {
+            workSessionRef.current = {
+                clientRequestId: newClientRequestId(),
+                startedAt: new Date().toISOString(),
+                durationSeconds: state.totalTime,
+            };
+            return;
+        }
+
+        // Work session finished naturally → record it so the backend awards points.
+        if (state.state === TIMER_STATES.BREAK && workSessionRef.current) {
+            const session = workSessionRef.current;
+            workSessionRef.current = null;
+
+            try {
+                router.post(
+                    route("pomodoro.sessions.store"),
+                    {
+                        type: "work",
+                        duration_seconds: session.durationSeconds,
+                        started_at: session.startedAt,
+                        completed_at: new Date().toISOString(),
+                        client_request_id: session.clientRequestId,
+                    },
+                    {
+                        preserveState: true,
+                        preserveScroll: true,
+                        only: ["auth"],
+                    }
+                );
+            } catch (error) {
+                // Never let points wiring disrupt the timer experience.
+                console.error("Failed to record pomodoro session:", error);
+            }
+            return;
+        }
+
+        // Manual reset/skip during a work session (goes IDLE): drop the pending
+        // session so nothing is awarded and the next session mints a fresh id.
+        if (state.state === TIMER_STATES.IDLE && workSessionRef.current) {
+            workSessionRef.current = null;
+        }
+    }, [state.state, state.currentSession, state.totalTime]);
 
     const actions = {
         startTimer: () => dispatch({ type: "START_TIMER" }),

--- a/resources/js/Components/Store/PurchaseButton.jsx
+++ b/resources/js/Components/Store/PurchaseButton.jsx
@@ -1,0 +1,72 @@
+import { fireConfetti } from "@/lib/confetti";
+import { router } from "@inertiajs/react";
+import { Sparkles } from "lucide-react";
+import { useState } from "react";
+import { toast } from "react-toastify";
+import Swal from "sweetalert2";
+
+/**
+ * A tiny, collision-resistant id. Prefers the platform UUID generator and
+ * falls back gracefully in non-secure contexts where it may be unavailable.
+ */
+function newRequestId() {
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+        return crypto.randomUUID();
+    }
+    return `req-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+/**
+ * Confirm → purchase flow for a store item. The purchase is server-authoritative:
+ * on success Inertia re-renders with fresh balance/owned/equipped state, so we
+ * only celebrate here. Errors (e.g. insufficient balance) come back as
+ * `flash.error` and are surfaced by the global FlashToaster — no extra handling.
+ */
+export default function PurchaseButton({ item, disabled = false, className = "" }) {
+    const [processing, setProcessing] = useState(false);
+
+    const handleBuy = async () => {
+        const result = await Swal.fire({
+            title: `Buy ${item.name}?`,
+            text: `This will cost ${item.cost} points.`,
+            icon: "question",
+            showCancelButton: true,
+            confirmButtonText: "Buy",
+            cancelButtonText: "Cancel",
+            confirmButtonColor: "#4ACF91",
+            cancelButtonColor: "#6B7280",
+        });
+
+        if (!result.isConfirmed) {
+            return;
+        }
+
+        setProcessing(true);
+        router.post(
+            route("store.purchase"),
+            { store_item_id: item.id, client_request_id: newRequestId() },
+            {
+                preserveScroll: true,
+                onSuccess: () => {
+                    fireConfetti();
+                    toast.success(`${item.name} unlocked!`);
+                },
+                onFinish: () => setProcessing(false),
+            }
+        );
+    };
+
+    const isDisabled = disabled || processing;
+
+    return (
+        <button
+            type="button"
+            onClick={handleBuy}
+            disabled={isDisabled}
+            className={`inline-flex w-full items-center justify-center gap-1.5 rounded-lg bg-primary-400 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400/50 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-primary-500 dark:hover:bg-primary-600 ${className}`}
+        >
+            <Sparkles className="h-4 w-4" aria-hidden="true" />
+            {processing ? "Buying…" : `Buy · ${item.cost}`}
+        </button>
+    );
+}

--- a/resources/js/Components/Store/StoreItemCard.jsx
+++ b/resources/js/Components/Store/StoreItemCard.jsx
@@ -1,0 +1,81 @@
+import Avatar from "@/Components/Avatar/Avatar";
+import PurchaseButton from "@/Components/Store/PurchaseButton";
+import { router } from "@inertiajs/react";
+import { Check, Sparkles } from "lucide-react";
+import { useState } from "react";
+
+/**
+ * A single catalog card: avatar preview, name, description, cost, and a
+ * state-aware action — Equipped (owned + active), Equip (owned), or Buy.
+ */
+export default function StoreItemCard({ item, balance = 0 }) {
+    const [equipping, setEquipping] = useState(false);
+    const canAfford = balance >= item.cost;
+
+    const handleEquip = () => {
+        setEquipping(true);
+        router.post(
+            route("store.equip"),
+            { store_item_id: item.id },
+            {
+                preserveScroll: true,
+                onFinish: () => setEquipping(false),
+            }
+        );
+    };
+
+    return (
+        <div className="card flex flex-col p-4">
+            <div className="flex justify-center py-2">
+                <Avatar
+                    avatar={{
+                        base_url: item.preview_url,
+                        initials: item.name?.[0] ?? "?",
+                    }}
+                    size="lg"
+                />
+            </div>
+
+            <h3 className="mt-3 truncate text-sm font-semibold text-light-primary dark:text-dark-primary">
+                {item.name}
+            </h3>
+            {item.description && (
+                <p className="mt-1 line-clamp-2 text-xs text-light-muted dark:text-dark-muted">
+                    {item.description}
+                </p>
+            )}
+
+            <div className="mt-auto pt-3">
+                <div className="mb-2 flex items-center gap-1.5 text-sm font-semibold text-primary-600 dark:text-primary-300">
+                    <Sparkles className="h-4 w-4" aria-hidden="true" />
+                    <span>{item.cost}</span>
+                </div>
+
+                {item.equipped ? (
+                    <span className="inline-flex w-full items-center justify-center gap-1.5 rounded-lg bg-primary-100 px-3 py-2 text-sm font-medium text-primary-700 dark:bg-primary-900/30 dark:text-primary-200">
+                        <Check className="h-4 w-4" aria-hidden="true" />
+                        Equipped
+                    </span>
+                ) : item.owned ? (
+                    <button
+                        type="button"
+                        onClick={handleEquip}
+                        disabled={equipping}
+                        className="inline-flex w-full items-center justify-center rounded-lg border border-light-border px-3 py-2 text-sm font-medium text-light-primary transition-colors hover:bg-light-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400/50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-dark-border dark:text-dark-primary dark:hover:bg-dark-hover"
+                    >
+                        {equipping ? "Equipping…" : "Equip"}
+                    </button>
+                ) : (
+                    <>
+                        <PurchaseButton item={item} disabled={!canAfford} />
+                        {!canAfford && (
+                            <p className="mt-1.5 text-center text-xs text-light-muted dark:text-dark-muted">
+                                Not enough points
+                            </p>
+                        )}
+                    </>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/resources/js/Layouts/AuthenticatedLayout.jsx
+++ b/resources/js/Layouts/AuthenticatedLayout.jsx
@@ -1,14 +1,18 @@
 import ApplicationLogo from "@/Components/ApplicationLogo";
+import Avatar from "@/Components/Avatar/Avatar";
 import Dropdown from "@/Components/Dropdown";
 import NavLink from "@/Components/NavLink";
 import OnboardingTour from "@/Components/OnboardingTour";
+import PointsBadge from "@/Components/Points/PointsBadge";
 import ResponsiveNavLink from "@/Components/ResponsiveNavLink";
 import { FloatingPomodoroWidget, FocusMode } from "@/Components/Pomodoro";
 import { Link, usePage } from "@inertiajs/react";
+import { ShoppingBag } from "lucide-react";
 import { useState } from "react";
 
 export default function AuthenticatedLayout({ header, children }) {
-    const user = usePage().props.auth.user;
+    const auth = usePage().props.auth;
+    const user = auth.user;
     const isFinanceRoute =
         route().current("finance.*") || route().current("weviewallet.*");
 
@@ -71,10 +75,20 @@ export default function AuthenticatedLayout({ header, children }) {
                                         WevieWallet
                                     </NavLink>
                                 </span>
+                                <span data-tour="nav-store">
+                                    <NavLink
+                                        href={route("store.index")}
+                                        active={route().current("store.*")}
+                                    >
+                                        <ShoppingBag className="me-1.5 h-4 w-4" aria-hidden="true" />
+                                        Store
+                                    </NavLink>
+                                </span>
                             </div>
                         </div>
 
                         <div className="hidden sm:ms-6 sm:flex sm:items-center">
+                            <PointsBadge className="me-3" />
                             <div className="relative ms-3" data-tour="user-menu">
                                 <Dropdown>
                                     <Dropdown.Trigger>
@@ -83,6 +97,11 @@ export default function AuthenticatedLayout({ header, children }) {
                                                 type="button"
                                                 className="inline-flex items-center rounded-md border border-transparent bg-white px-3 py-2 text-sm font-medium leading-4 text-gray-500 transition duration-150 ease-in-out hover:text-gray-700 focus:outline-none dark:bg-gray-800 dark:text-gray-400 dark:hover:text-gray-300"
                                             >
+                                                <Avatar
+                                                    avatar={auth.avatar}
+                                                    size="sm"
+                                                    className="me-2"
+                                                />
                                                 {user.name}
 
                                                 <svg
@@ -211,16 +230,26 @@ export default function AuthenticatedLayout({ header, children }) {
                         >
                             WevieWallet
                         </ResponsiveNavLink>
+                        <ResponsiveNavLink
+                            href={route("store.index")}
+                            active={route().current("store.*")}
+                        >
+                            Store
+                        </ResponsiveNavLink>
                     </div>
 
                     <div className="border-t border-gray-200 pb-1 pt-4 dark:border-gray-600">
-                        <div className="px-4">
-                            <div className="text-base font-medium text-gray-800 dark:text-gray-200">
-                                {user.name}
+                        <div className="flex items-center gap-3 px-4">
+                            <Avatar avatar={auth.avatar} size="sm" />
+                            <div className="min-w-0 flex-1">
+                                <div className="text-base font-medium text-gray-800 dark:text-gray-200">
+                                    {user.name}
+                                </div>
+                                <div className="text-sm font-medium text-gray-500">
+                                    {user.email}
+                                </div>
                             </div>
-                            <div className="text-sm font-medium text-gray-500">
-                                {user.email}
-                            </div>
+                            <PointsBadge />
                         </div>
 
                         <div className="mt-3 space-y-1">

--- a/resources/js/Layouts/TodoLayout.jsx
+++ b/resources/js/Layouts/TodoLayout.jsx
@@ -1,6 +1,8 @@
 import ApplicationLogo from "@/Components/ApplicationLogo";
+import Avatar from "@/Components/Avatar/Avatar";
 import Dropdown from "@/Components/Dropdown";
 import NotificationBell from "@/Components/NotificationBell";
+import PointsBadge from "@/Components/Points/PointsBadge";
 import MobileFab from "@/Components/Mobile/MobileFab";
 import MobileTabBar from "@/Components/Mobile/MobileTabBar";
 import OnboardingTour from "@/Components/OnboardingTour";
@@ -37,10 +39,12 @@ import {
     ListChecks,
     Wrench,
     UtensilsCrossed,
+    ShoppingBag,
 } from "lucide-react";
 
 export default function TodoLayout({ header, children }) {
-    const user = usePage().props.auth.user;
+    const auth = usePage().props.auth;
+    const user = auth.user;
     const isFinanceRoute = route().current("finance.*") || route().current("weviewallet.*");
     const isWevieWalletRoute = route().current("weviewallet.*");
     const walletSubLinks = [
@@ -208,6 +212,13 @@ export default function TodoLayout({ header, children }) {
             icon: BookOpen,
             current: route().current("journal.*"),
             tourKey: "nav-journal",
+        },
+        {
+            name: "Store",
+            href: route("store.index"),
+            icon: ShoppingBag,
+            current: route().current("store.*"),
+            tourKey: "nav-store",
         },
         ...(user.role === "admin"
             ? [
@@ -547,13 +558,7 @@ export default function TodoLayout({ header, children }) {
                                 {/* User Profile */}
                                 <div className="border-t border-gray-200 dark:border-gray-700 p-4">
                                     <div className="flex items-center">
-                                        <div className="flex-shrink-0">
-                                            <div className="h-8 w-8 rounded-full bg-primary-400 dark:bg-[#2ED7A1] flex items-center justify-center">
-                                                <span className="text-sm font-medium text-white">
-                                                    {user.name.charAt(0).toUpperCase()}
-                                                </span>
-                                            </div>
-                                        </div>
+                                        <Avatar avatar={auth.avatar} size="sm" />
                                         <div className="ml-3 flex-1 min-w-0">
                                             <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
                                                 {user.name}
@@ -852,13 +857,7 @@ export default function TodoLayout({ header, children }) {
                     {/* User Profile */}
                     <div className="border-t border-light-border dark:border-dark-border p-4">
                         <div className="flex items-center">
-                            <div className="flex-shrink-0">
-                                <div className="h-8 w-8 rounded-full bg-primary-400 dark:bg-[#2ED7A1] flex items-center justify-center">
-                                    <span className="text-sm font-medium text-white">
-                                        {user.name.charAt(0).toUpperCase()}
-                                    </span>
-                                </div>
-                            </div>
+                            <Avatar avatar={auth.avatar} size="sm" />
                             <div className="ml-3 flex-1 min-w-0">
                                 <p className="text-sm font-medium text-light-primary dark:text-dark-primary truncate">
                                     {user.name}
@@ -930,6 +929,13 @@ export default function TodoLayout({ header, children }) {
                             )}
                         </div>
                         <div className="flex items-center space-x-4">
+                            <Link
+                                href={route("store.index")}
+                                className="hidden sm:inline-flex"
+                                title="Open the Store"
+                            >
+                                <PointsBadge />
+                            </Link>
                             {pendingCount > 0 && (
                                 <button
                                     type="button"

--- a/resources/js/Pages/Profile/Show.jsx
+++ b/resources/js/Pages/Profile/Show.jsx
@@ -1,7 +1,7 @@
+import Avatar from "@/Components/Avatar/Avatar";
 import TodoLayout from "@/Layouts/TodoLayout";
-import { Head, Link, useForm } from "@inertiajs/react";
+import { Head, Link, useForm, usePage } from "@inertiajs/react";
 import {
-    User,
     Mail,
     Calendar,
     Shield,
@@ -17,6 +17,7 @@ import SecondaryButton from "@/Components/SecondaryButton";
 import PrimaryButton from "@/Components/PrimaryButton";
 
 export default function Show({ user, stats }) {
+    const auth = usePage().props.auth;
     const { post } = useForm();
 
     const handleLogout = (e) => {
@@ -65,9 +66,7 @@ export default function Show({ user, stats }) {
                     <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:space-x-6">
                         {/* Avatar */}
                         <div className="flex-shrink-0">
-                            <div className="w-20 h-20 sm:w-24 sm:h-24 bg-blue-100 dark:bg-blue-900 rounded-full flex items-center justify-center">
-                                <User className="w-12 h-12 text-blue-600 dark:text-blue-300" />
-                            </div>
+                            <Avatar avatar={auth.avatar} size="lg" />
                         </div>
 
                         {/* User Info */}

--- a/resources/js/Pages/Store/Index.jsx
+++ b/resources/js/Pages/Store/Index.jsx
@@ -1,0 +1,77 @@
+import EmptyState from "@/Components/Finance/UI/EmptyState";
+import StatCard from "@/Components/Finance/UI/StatCard";
+import Tabs from "@/Components/Finance/UI/Tabs";
+import StoreItemCard from "@/Components/Store/StoreItemCard";
+import TodoLayout from "@/Layouts/TodoLayout";
+import { Head } from "@inertiajs/react";
+import { ShoppingBag, Sparkles } from "lucide-react";
+import { useMemo, useState } from "react";
+
+export default function Index({ items = [], balance = 0 }) {
+    const [tab, setTab] = useState("avatars");
+
+    const tabs = [
+        { value: "avatars", label: "Avatars" },
+        { value: "accessories", label: "Accessories · Coming soon" },
+    ];
+
+    // Phase 1 backend only sends avatar bases, but filter defensively so a
+    // future accessory drop doesn't leak into the Avatars tab.
+    const avatarItems = useMemo(
+        () => items.filter((item) => item.type === "avatar_base" || !item.type),
+        [items]
+    );
+
+    return (
+        <TodoLayout header="Store">
+            <Head title="Store" />
+
+            <div className="space-y-6">
+                {/* Balance header */}
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+                    <StatCard
+                        label="Your points"
+                        value={balance.toLocaleString()}
+                        icon={Sparkles}
+                        iconClassName="bg-primary-100 text-primary-600 dark:bg-primary-900/30 dark:text-primary-300"
+                        accent="text-primary-600 dark:text-primary-300"
+                        hint="Earn more by completing tasks and focus sessions"
+                    />
+                </div>
+
+                {/* Section tabs */}
+                <Tabs
+                    tabs={tabs}
+                    active={tab}
+                    onChange={(value) => {
+                        // Accessories are not purchasable in Phase 1.
+                        if (value === "accessories") return;
+                        setTab(value);
+                    }}
+                />
+
+                {tab === "avatars" && (
+                    <>
+                        {avatarItems.length === 0 ? (
+                            <EmptyState
+                                icon={ShoppingBag}
+                                title="No avatars available yet"
+                                description="Check back soon — new avatars are on the way."
+                            />
+                        ) : (
+                            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+                                {avatarItems.map((item) => (
+                                    <StoreItemCard
+                                        key={item.id}
+                                        item={item}
+                                        balance={balance}
+                                    />
+                                ))}
+                            </div>
+                        )}
+                    </>
+                )}
+            </div>
+        </TodoLayout>
+    );
+}

--- a/tests/Feature/Modules/Points/BootstrapTest.php
+++ b/tests/Feature/Modules/Points/BootstrapTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use App\Models\User;
+use App\Modules\Points\Enums\StoreItemSlot;
+use App\Modules\Points\Enums\StoreItemType;
+use App\Modules\Points\Models\PointWallet;
+use App\Modules\Points\Models\StoreItem;
+use App\Modules\Points\Models\UserAvatar;
+use App\Modules\Points\Models\UserStoreItem;
+
+function seedDefaultBase(): StoreItem
+{
+    return StoreItem::create([
+        'key' => 'avatar_base_default',
+        'name' => 'Starter',
+        'type' => StoreItemType::AvatarBase->value,
+        'slot' => StoreItemSlot::Base->value,
+        'cost' => 0,
+        'asset' => 'bases/default',
+        'is_active' => true,
+        'is_default' => true,
+    ]);
+}
+
+it('seeds a wallet, avatar, and default base for a new user via the observer', function () {
+    $default = seedDefaultBase();
+
+    $user = User::factory()->create();
+
+    expect(PointWallet::where('user_id', $user->id)->exists())->toBeTrue();
+
+    $avatar = UserAvatar::where('user_id', $user->id)->first();
+    expect($avatar)->not->toBeNull();
+    expect($avatar->base_item_id)->toBe($default->id);
+
+    $this->assertDatabaseHas('user_store_items', [
+        'user_id' => $user->id,
+        'store_item_id' => $default->id,
+        'acquired_via' => 'default',
+    ]);
+});
+
+it('still creates a wallet and avatar when the catalog is empty', function () {
+    $user = User::factory()->create();
+
+    expect(PointWallet::where('user_id', $user->id)->exists())->toBeTrue();
+    expect(UserAvatar::where('user_id', $user->id)->exists())->toBeTrue();
+});
+
+it('backfill is idempotent', function () {
+    // User created before the catalog exists — no default granted yet.
+    $user = User::factory()->create();
+    $default = seedDefaultBase();
+
+    $this->artisan('points:backfill')->assertSuccessful();
+    $this->artisan('points:backfill')->assertSuccessful();
+
+    expect(UserStoreItem::where('user_id', $user->id)->where('store_item_id', $default->id)->count())->toBe(1);
+    expect(UserAvatar::where('user_id', $user->id)->value('base_item_id'))->toBe($default->id);
+});

--- a/tests/Feature/Modules/Points/PomodoroSessionTest.php
+++ b/tests/Feature/Modules/Points/PomodoroSessionTest.php
@@ -70,6 +70,20 @@ it('stops awarding once the daily cap is reached', function () {
     expect(PomodoroSession::where('user_id', $user->id)->where('awarded_points', '>', 0)->count())->toBe(2);
 });
 
+it('counts backdated sessions against the daily cap by server time', function () {
+    config()->set('points.pomodoro.daily_award_cap', 2);
+    $user = User::factory()->create();
+
+    // Backdating completed_at must not let sessions escape the daily cap.
+    $backdated = ['completed_at' => now()->subDay()->toIso8601String()];
+    recordPomodoro($user, $backdated);
+    recordPomodoro($user, $backdated);
+    $third = recordPomodoro($user, $backdated);
+
+    expect($third->awarded_points)->toBe(0);
+    expect(PomodoroSession::where('user_id', $user->id)->where('awarded_points', '>', 0)->count())->toBe(2);
+});
+
 it('rejects a future completed_at at the request layer', function () {
     $user = User::factory()->create();
 

--- a/tests/Feature/Modules/Points/PomodoroSessionTest.php
+++ b/tests/Feature/Modules/Points/PomodoroSessionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use App\Models\User;
+use App\Modules\Points\Models\PointWallet;
+use App\Modules\Points\Models\PomodoroSession;
+use App\Modules\Points\Services\PomodoroSessionService;
+use Illuminate\Support\Str;
+
+function recordPomodoro(User $user, array $overrides = []): PomodoroSession
+{
+    return app(PomodoroSessionService::class)->record($user, array_merge([
+        'type' => 'work',
+        'duration_seconds' => 1500,
+        'started_at' => now()->subMinutes(25)->toIso8601String(),
+        'completed_at' => now()->toIso8601String(),
+        'client_request_id' => (string) Str::uuid(),
+    ], $overrides));
+}
+
+it('awards points for a valid work session', function () {
+    $user = User::factory()->create();
+
+    $session = recordPomodoro($user);
+
+    expect($session->awarded_points)->toBe(8);
+    expect($session->point_ledger_entry_id)->not->toBeNull();
+    expect(PointWallet::where('user_id', $user->id)->value('balance'))->toBe(8 + 5); // + streak bonus
+});
+
+it('records a below-minimum session without awarding', function () {
+    $user = User::factory()->create();
+
+    $session = recordPomodoro($user, ['duration_seconds' => 60]);
+
+    expect($session->awarded_points)->toBe(0);
+    expect($session->point_ledger_entry_id)->toBeNull();
+    expect(PointWallet::where('user_id', $user->id)->value('balance'))->toBe(0);
+});
+
+it('does not award break sessions', function () {
+    $user = User::factory()->create();
+
+    $session = recordPomodoro($user, ['type' => 'short_break']);
+
+    expect($session->awarded_points)->toBe(0);
+    expect(PointWallet::where('user_id', $user->id)->value('balance'))->toBe(0);
+});
+
+it('is idempotent for a repeated client_request_id', function () {
+    $user = User::factory()->create();
+    $crid = (string) Str::uuid();
+
+    $first = recordPomodoro($user, ['client_request_id' => $crid]);
+    $second = recordPomodoro($user, ['client_request_id' => $crid]);
+
+    expect($second->id)->toBe($first->id);
+    expect(PomodoroSession::where('user_id', $user->id)->count())->toBe(1);
+    expect(PointWallet::where('user_id', $user->id)->value('balance'))->toBe(8 + 5);
+});
+
+it('stops awarding once the daily cap is reached', function () {
+    config()->set('points.pomodoro.daily_award_cap', 2);
+    $user = User::factory()->create();
+
+    recordPomodoro($user);
+    recordPomodoro($user);
+    $third = recordPomodoro($user);
+
+    expect($third->awarded_points)->toBe(0);
+    expect(PomodoroSession::where('user_id', $user->id)->where('awarded_points', '>', 0)->count())->toBe(2);
+});
+
+it('rejects a future completed_at at the request layer', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->from(route('store.index'))
+        ->post(route('pomodoro.sessions.store'), [
+            'type' => 'work',
+            'duration_seconds' => 1500,
+            'started_at' => now()->toIso8601String(),
+            'completed_at' => now()->addHour()->toIso8601String(),
+            'client_request_id' => (string) Str::uuid(),
+        ])
+        ->assertSessionHasErrors('completed_at');
+
+    expect(PomodoroSession::where('user_id', $user->id)->count())->toBe(0);
+});

--- a/tests/Feature/Modules/Points/RecurringResetCommandTest.php
+++ b/tests/Feature/Modules/Points/RecurringResetCommandTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Models\Subtask;
+use App\Models\Task;
+use App\Models\User;
+use App\Modules\Points\Enums\PointSource;
+use App\Modules\Points\Models\PointLedgerEntry;
+
+/**
+ * The tasks:reset-recurring command must reset subtasks through an
+ * event-firing path so the points observers reverse their completion awards.
+ * A bulk relationship update() would skip observers, leaving the award cycle
+ * permanently open and blocking future earnings.
+ */
+it('reverses and re-enables subtask awards when the recurring-reset command runs', function () {
+    $user = User::factory()->create();
+
+    $task = Task::create([
+        'user_id' => $user->id,
+        'title' => 'Daily recurring',
+        'status' => 'completed',
+        'position' => 1,
+        'is_recurring' => true,
+        'recurrence_type' => 'daily',
+        'completed_at' => now()->subDay(),
+        'recurring_until' => now()->addDay(),
+    ]);
+
+    $subtask = Subtask::create([
+        'task_id' => $task->id,
+        'title' => 'Step',
+        'is_completed' => false,
+        'position' => 1,
+    ]);
+
+    // Earn the subtask award (fires the observer).
+    $subtask->update(['is_completed' => true, 'completed_at' => now()->subDay()]);
+
+    $this->artisan('tasks:reset-recurring')->assertExitCode(0);
+
+    $subtask->refresh();
+    expect($subtask->is_completed)->toBeFalse();
+
+    $net = PointLedgerEntry::where('user_id', $user->id)
+        ->where('source', PointSource::SubtaskCompletion->value)
+        ->sum('amount');
+    expect((int) $net)->toBe(0); // reversed
+
+    // The next occurrence's completion earns again.
+    $subtask->update(['is_completed' => true, 'completed_at' => now()]);
+
+    $positiveAwards = PointLedgerEntry::where('user_id', $user->id)
+        ->where('source', PointSource::SubtaskCompletion->value)
+        ->where('amount', '>', 0)
+        ->count();
+    expect($positiveAwards)->toBe(2);
+});

--- a/tests/Feature/Modules/Points/StoreTest.php
+++ b/tests/Feature/Modules/Points/StoreTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use App\Models\User;
+use App\Modules\Points\Enums\PointSource;
+use App\Modules\Points\Enums\StoreItemSlot;
+use App\Modules\Points\Enums\StoreItemType;
+use App\Modules\Points\Exceptions\InsufficientBalanceException;
+use App\Modules\Points\Models\PointWallet;
+use App\Modules\Points\Models\StoreItem;
+use App\Modules\Points\Models\UserAvatar;
+use App\Modules\Points\Models\UserStoreItem;
+use App\Modules\Points\Services\PointsWalletService;
+use App\Modules\Points\Services\StoreService;
+
+function makeBaseItem(array $overrides = []): StoreItem
+{
+    return StoreItem::create(array_merge([
+        'key' => 'base_'.uniqid(),
+        'name' => 'Fox',
+        'description' => 'A fox',
+        'type' => StoreItemType::AvatarBase->value,
+        'slot' => StoreItemSlot::Base->value,
+        'cost' => 50,
+        'asset' => 'bases/fox',
+        'preview_asset' => 'bases/preview/fox',
+        'is_active' => true,
+        'is_default' => false,
+    ], $overrides));
+}
+
+function fundWallet(User $user, int $amount): void
+{
+    app(PointsWalletService::class)->credit($user->id, $amount, PointSource::AdminAdjust);
+}
+
+it('debits the balance, records inventory, and writes a spend entry on purchase', function () {
+    $user = User::factory()->create();
+    $item = makeBaseItem(['cost' => 50]);
+    fundWallet($user, 100);
+
+    app(StoreService::class)->purchase($user, $item, 'crid-1');
+
+    expect(PointWallet::where('user_id', $user->id)->value('balance'))->toBe(50);
+    $this->assertDatabaseHas('user_store_items', [
+        'user_id' => $user->id,
+        'store_item_id' => $item->id,
+        'acquired_via' => 'purchase',
+    ]);
+    $this->assertDatabaseHas('point_ledger_entries', [
+        'user_id' => $user->id,
+        'source' => PointSource::StorePurchase->value,
+        'amount' => -50,
+    ]);
+});
+
+it('auto-equips a base avatar when the user has none', function () {
+    $user = User::factory()->create();
+    $item = makeBaseItem(['cost' => 50]);
+    fundWallet($user, 100);
+
+    app(StoreService::class)->purchase($user, $item, 'crid-1');
+
+    expect(UserAvatar::where('user_id', $user->id)->value('base_item_id'))->toBe($item->id);
+});
+
+it('rejects a purchase when the balance is insufficient and does not debit', function () {
+    $user = User::factory()->create();
+    $item = makeBaseItem(['cost' => 50]);
+    fundWallet($user, 20);
+
+    expect(fn () => app(StoreService::class)->purchase($user, $item, 'crid-1'))
+        ->toThrow(InsufficientBalanceException::class);
+
+    expect(PointWallet::where('user_id', $user->id)->value('balance'))->toBe(20);
+    expect(UserStoreItem::where('user_id', $user->id)->count())->toBe(0);
+});
+
+it('does not double-charge on a repeated purchase', function () {
+    $user = User::factory()->create();
+    $item = makeBaseItem(['cost' => 50]);
+    fundWallet($user, 100);
+
+    app(StoreService::class)->purchase($user, $item, 'crid-1');
+    app(StoreService::class)->purchase($user, $item, 'crid-1');
+
+    expect(PointWallet::where('user_id', $user->id)->value('balance'))->toBe(50);
+    expect(UserStoreItem::where('user_id', $user->id)->where('store_item_id', $item->id)->count())->toBe(1);
+});
+
+it('equips an owned item', function () {
+    $user = User::factory()->create();
+    $item = makeBaseItem(['cost' => 0]);
+    fundWallet($user, 10);
+    app(StoreService::class)->purchase($user, $item, 'crid-1');
+
+    $second = makeBaseItem(['cost' => 0, 'key' => 'base_second']);
+    fundWallet($user, 10);
+    app(StoreService::class)->purchase($user, $second, 'crid-2');
+
+    app(StoreService::class)->equip($user, $second);
+
+    expect(UserAvatar::where('user_id', $user->id)->value('base_item_id'))->toBe($second->id);
+});
+
+it('forbids equipping an unowned item via the endpoint', function () {
+    $user = User::factory()->create();
+    $item = makeBaseItem(['cost' => 50]);
+
+    $this->actingAs($user)
+        ->post(route('store.equip'), ['store_item_id' => $item->id])
+        ->assertForbidden();
+});
+
+it('renders the store catalog with owned and equipped flags', function () {
+    $user = User::factory()->create();
+    $item = makeBaseItem(['cost' => 50, 'name' => 'Fox']);
+    fundWallet($user, 100);
+    app(StoreService::class)->purchase($user, $item, 'crid-1');
+
+    $version = app(\App\Http\Middleware\HandleInertiaRequests::class)->version(request());
+    $response = $this->actingAs($user)
+        ->withHeaders(['X-Inertia' => 'true', 'X-Inertia-Version' => $version])
+        ->get(route('store.index'));
+
+    $response->assertOk();
+    $page = $response->json();
+
+    expect($page['component'])->toBe('Store/Index');
+    expect($page['props']['balance'])->toBe(50);
+
+    $items = collect($page['props']['items']);
+    $fox = $items->firstWhere('id', $item->id);
+    expect($fox['owned'])->toBeTrue();
+    expect($fox['equipped'])->toBeTrue();
+    expect($fox)->toHaveKeys(['id', 'key', 'name', 'description', 'type', 'slot', 'cost', 'preview_url', 'owned', 'equipped']);
+});

--- a/tests/Feature/Modules/Points/StoreTest.php
+++ b/tests/Feature/Modules/Points/StoreTest.php
@@ -87,6 +87,22 @@ it('does not double-charge on a repeated purchase', function () {
     expect(UserStoreItem::where('user_id', $user->id)->where('store_item_id', $item->id)->count())->toBe(1);
 });
 
+it('rejects reusing a client_request_id for a different item', function () {
+    $user = User::factory()->create();
+    $first = makeBaseItem(['cost' => 50, 'key' => 'base_first']);
+    $second = makeBaseItem(['cost' => 50, 'key' => 'base_second']);
+    fundWallet($user, 100);
+
+    app(StoreService::class)->purchase($user, $first, 'crid-shared');
+
+    // A reused request id must not grant the second item on the first spend.
+    expect(fn () => app(StoreService::class)->purchase($user, $second, 'crid-shared'))
+        ->toThrow(RuntimeException::class);
+
+    expect(UserStoreItem::where('user_id', $user->id)->where('store_item_id', $second->id)->count())->toBe(0);
+    expect(PointWallet::where('user_id', $user->id)->value('balance'))->toBe(50);
+});
+
 it('equips an owned item', function () {
     $user = User::factory()->create();
     $item = makeBaseItem(['cost' => 0]);

--- a/tests/Feature/Modules/Points/StreakTest.php
+++ b/tests/Feature/Modules/Points/StreakTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Models\Task;
+use App\Models\User;
+use App\Modules\Points\Enums\PointSource;
+use App\Modules\Points\Models\PointLedgerEntry;
+use App\Modules\Points\Models\PointWallet;
+use Carbon\Carbon;
+
+function pointsStreakTask(User $user): Task
+{
+    return Task::create([
+        'user_id' => $user->id,
+        'title' => 'Daily task',
+        'status' => 'pending',
+        'position' => 1,
+    ]);
+}
+
+afterEach(fn () => Carbon::setTestNow());
+
+it('awards the streak bonus only once per day', function () {
+    Carbon::setTestNow('2026-08-09 09:00:00');
+    $user = User::factory()->create(['timezone' => 'UTC']);
+
+    pointsStreakTask($user)->update(['status' => 'completed', 'completed_at' => now()]);
+    pointsStreakTask($user)->update(['status' => 'completed', 'completed_at' => now()]);
+
+    $streakEntries = PointLedgerEntry::where('user_id', $user->id)
+        ->where('source', PointSource::DailyStreak->value)
+        ->count();
+
+    expect($streakEntries)->toBe(1);
+    expect(PointWallet::where('user_id', $user->id)->value('current_streak_days'))->toBe(1);
+});
+
+it('increments the streak on consecutive days', function () {
+    $user = User::factory()->create(['timezone' => 'UTC']);
+
+    Carbon::setTestNow('2026-08-09 09:00:00');
+    pointsStreakTask($user)->update(['status' => 'completed', 'completed_at' => now()]);
+
+    Carbon::setTestNow('2026-08-10 09:00:00');
+    pointsStreakTask($user)->update(['status' => 'completed', 'completed_at' => now()]);
+
+    $wallet = PointWallet::where('user_id', $user->id)->first();
+    expect($wallet->current_streak_days)->toBe(2);
+    expect($wallet->longest_streak_days)->toBe(2);
+});
+
+it('resets the streak after a missed day', function () {
+    $user = User::factory()->create(['timezone' => 'UTC']);
+
+    Carbon::setTestNow('2026-08-09 09:00:00');
+    pointsStreakTask($user)->update(['status' => 'completed', 'completed_at' => now()]);
+
+    // Skip 2026-08-10 entirely.
+    Carbon::setTestNow('2026-08-11 09:00:00');
+    pointsStreakTask($user)->update(['status' => 'completed', 'completed_at' => now()]);
+
+    $wallet = PointWallet::where('user_id', $user->id)->first();
+    expect($wallet->current_streak_days)->toBe(1);
+    expect($wallet->longest_streak_days)->toBe(1);
+});

--- a/tests/Feature/Modules/Points/SubtaskEarningTest.php
+++ b/tests/Feature/Modules/Points/SubtaskEarningTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use App\Models\Subtask;
+use App\Models\Task;
+use App\Models\User;
+use App\Modules\Points\Enums\PointSource;
+use App\Modules\Points\Models\PointWallet;
+use App\Services\SubtaskService;
+
+function pointsSubtaskTask(User $user): Task
+{
+    return Task::create([
+        'user_id' => $user->id,
+        'title' => 'Task with subtasks',
+        'status' => 'pending',
+        'position' => 1,
+    ]);
+}
+
+it('awards subtask points when a subtask is completed directly', function () {
+    $user = User::factory()->create();
+    $task = pointsSubtaskTask($user);
+    $subtask = Subtask::create([
+        'task_id' => $task->id,
+        'title' => 'Step one',
+        'is_completed' => false,
+        'position' => 1,
+    ]);
+
+    $subtask->update(['is_completed' => true, 'completed_at' => now()]);
+
+    $this->assertDatabaseHas('point_ledger_entries', [
+        'user_id' => $user->id,
+        'source' => PointSource::SubtaskCompletion->value,
+        'amount' => 2,
+    ]);
+});
+
+it('reverses subtask points when a subtask is un-completed', function () {
+    $user = User::factory()->create();
+    $task = pointsSubtaskTask($user);
+    $subtask = Subtask::create([
+        'task_id' => $task->id,
+        'title' => 'Step one',
+        'is_completed' => false,
+        'position' => 1,
+    ]);
+
+    $subtask->update(['is_completed' => true, 'completed_at' => now()]);
+    $subtask->update(['is_completed' => false, 'completed_at' => null]);
+
+    $net = \App\Modules\Points\Models\PointLedgerEntry::where('user_id', $user->id)
+        ->where('source', PointSource::SubtaskCompletion->value)
+        ->sum('amount');
+
+    expect((int) $net)->toBe(0);
+});
+
+it('awards both subtask and task points when the last subtask auto-completes the task', function () {
+    $user = User::factory()->create();
+    $task = pointsSubtaskTask($user);
+    $subtask = Subtask::create([
+        'task_id' => $task->id,
+        'title' => 'Only step',
+        'is_completed' => false,
+        'position' => 1,
+    ]);
+
+    // Going through the service auto-completes the parent task, firing both
+    // the subtask observer and the task observer.
+    app(SubtaskService::class)->toggleSubtaskCompletion($subtask, $user->id);
+
+    $wallet = PointWallet::where('user_id', $user->id)->first();
+    // subtask (2) + task (10) + first-day streak (5)
+    expect($wallet->balance)->toBe(17);
+
+    $this->assertDatabaseHas('point_ledger_entries', [
+        'user_id' => $user->id,
+        'source' => PointSource::SubtaskCompletion->value,
+    ]);
+    $this->assertDatabaseHas('point_ledger_entries', [
+        'user_id' => $user->id,
+        'source' => PointSource::TaskCompletion->value,
+    ]);
+});

--- a/tests/Feature/Modules/Points/TaskEarningTest.php
+++ b/tests/Feature/Modules/Points/TaskEarningTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use App\Models\Task;
+use App\Models\User;
+use App\Modules\Points\Enums\PointSource;
+use App\Modules\Points\Models\PointWallet;
+use App\Modules\Points\Services\PointsWalletService;
+
+/**
+ * Local task helper (uniquely named — the suite has a pre-existing global
+ * makeTask() collision we must not reintroduce).
+ */
+function pointsEarnTask(User $user, array $overrides = []): Task
+{
+    return Task::create(array_merge([
+        'user_id' => $user->id,
+        'title' => 'Focus task',
+        'status' => 'pending',
+        'position' => 1,
+    ], $overrides));
+}
+
+it('awards config points for completing a task and floors the streak bonus', function () {
+    $user = User::factory()->create();
+    $task = pointsEarnTask($user);
+
+    $task->update(['status' => 'completed', 'completed_at' => now()]);
+
+    $wallet = PointWallet::where('user_id', $user->id)->first();
+    // task_completion (10) + first-day streak bonus (5)
+    expect($wallet->balance)->toBe(15);
+
+    $this->assertDatabaseHas('point_ledger_entries', [
+        'user_id' => $user->id,
+        'source' => PointSource::TaskCompletion->value,
+        'amount' => 10,
+    ]);
+});
+
+it('does not double-award when completed_at changes but stays set', function () {
+    $user = User::factory()->create();
+    $task = pointsEarnTask($user);
+
+    $task->update(['status' => 'completed', 'completed_at' => now()]);
+    // A later re-save that keeps completed_at non-null must not re-award.
+    $task->update(['completed_at' => now()->addMinute()]);
+
+    $taskEntries = \App\Modules\Points\Models\PointLedgerEntry::where('user_id', $user->id)
+        ->where('source', PointSource::TaskCompletion->value)
+        ->count();
+
+    expect($taskEntries)->toBe(1);
+});
+
+it('reverses points when a task is un-completed', function () {
+    $user = User::factory()->create();
+    $task = pointsEarnTask($user);
+
+    $task->update(['status' => 'completed', 'completed_at' => now()]);
+    expect(PointWallet::where('user_id', $user->id)->value('balance'))->toBe(15);
+
+    $task->update(['status' => 'pending', 'completed_at' => null]);
+
+    // The 10 task points are reversed; the streak bonus (5) is not tied to the
+    // task sourceable and remains.
+    expect(PointWallet::where('user_id', $user->id)->value('balance'))->toBe(5);
+});
+
+it('clamps reversals so the balance never goes below zero', function () {
+    $user = User::factory()->create();
+    $task = pointsEarnTask($user);
+
+    $task->update(['status' => 'completed', 'completed_at' => now()]);
+    // Spend everything (simulating a store purchase drain).
+    app(PointsWalletService::class)->debit($user->id, 15, PointSource::StorePurchase);
+    expect(PointWallet::where('user_id', $user->id)->value('balance'))->toBe(0);
+
+    $task->update(['status' => 'pending', 'completed_at' => null]);
+
+    expect(PointWallet::where('user_id', $user->id)->value('balance'))->toBe(0);
+});
+
+it('re-awards a recurring task after it is reset and completed again', function () {
+    $user = User::factory()->create();
+    $task = pointsEarnTask($user);
+
+    $task->update(['status' => 'completed', 'completed_at' => now()]);
+    $task->update(['status' => 'pending', 'completed_at' => null]);   // recurring reset
+    $task->update(['status' => 'completed', 'completed_at' => now()]); // completed again
+
+    $earnEntries = \App\Modules\Points\Models\PointLedgerEntry::where('user_id', $user->id)
+        ->where('source', PointSource::TaskCompletion->value)
+        ->where('amount', '>', 0)
+        ->count();
+
+    // Two positive awards + one clamped/adjust reversal in between.
+    expect($earnEntries)->toBe(2);
+    // Net task contribution is 10 (10 - 10 + 10); plus streak 5 = 15.
+    expect(PointWallet::where('user_id', $user->id)->value('balance'))->toBe(15);
+});

--- a/tests/Feature/Modules/Points/TaskEarningTest.php
+++ b/tests/Feature/Modules/Points/TaskEarningTest.php
@@ -80,6 +80,29 @@ it('clamps reversals so the balance never goes below zero', function () {
     expect(PointWallet::where('user_id', $user->id)->value('balance'))->toBe(0);
 });
 
+it('re-awards a recurring task even after the awarded points were already spent', function () {
+    $user = User::factory()->create();
+    $task = pointsEarnTask($user);
+
+    $task->update(['status' => 'completed', 'completed_at' => now()]); // +10 task +5 streak
+    app(PointsWalletService::class)->debit($user->id, 15, PointSource::StorePurchase); // spend all
+    expect(PointWallet::where('user_id', $user->id)->value('balance'))->toBe(0);
+
+    // Reset reverses but is clamped to 0; the reversal entry still closes the
+    // completion cycle so the next completion can earn again.
+    $task->update(['status' => 'pending', 'completed_at' => null]);
+    $task->update(['status' => 'completed', 'completed_at' => now()->addMinute()]);
+
+    $earnEntries = \App\Modules\Points\Models\PointLedgerEntry::where('user_id', $user->id)
+        ->where('source', PointSource::TaskCompletion->value)
+        ->where('amount', '>', 0)
+        ->count();
+
+    expect($earnEntries)->toBe(2);
+    // Second award lands (10); streak bonus already granted earlier today.
+    expect(PointWallet::where('user_id', $user->id)->value('balance'))->toBe(10);
+});
+
 it('re-awards a recurring task after it is reset and completed again', function () {
     $user = User::factory()->create();
     $task = pointsEarnTask($user);


### PR DESCRIPTION
Adds a gamification reward loop as a self-contained `app/Modules/Points` module: a signed, idempotent points ledger with atomic wallet credit/debit, and config-tunable awards for completing tasks, subtasks, daily streaks, and Pomodoro focus sessions (with new server-side Pomodoro session persistence, since Pomodoro was previously client-only). Points are spent in a new **Store** page to purchase and equip base avatars, with the balance and equipped avatar shared to every page and surfaced in the nav and profile. Avatar art is a curated catalog (pre-generated with OpenArt and committed under `public/images/avatars/`); a layered `Avatar` component renders a token-colored initials fallback until the art lands. New users are seeded a wallet + default avatar via `UserObserver`, and `php artisan points:backfill` covers existing users. The feature is free for everyone (no pro-gating) and covered by 27 Pest feature tests; accessory layering, purchase history, and analytics are deferred to Phase 2 (schema already supports them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)