### PR TITLE
Align Meal Planning UI with the Wevie design system

### DIFF
--- a/app/Modules/MealPlanning/Controllers/MealPlanningPageController.php
+++ b/app/Modules/MealPlanning/Controllers/MealPlanningPageController.php
@@ -16,6 +16,7 @@ use App\Modules\MealPlanning\Resources\PantryItemResource;
 use App\Modules\MealPlanning\Resources\RecipeResource;
 use App\Modules\MealPlanning\Services\HouseholdAccessService;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -26,8 +27,13 @@ class MealPlanningPageController extends Controller
     public function index(Request $request): Response
     {
         $households = Household::with('members')->whereHas('members', fn ($q) => $q->where('user_id', $request->user()->id))->get();
+        $countries = DB::table('countries')->orderBy('name')->get(['code', 'name', 'currency']);
 
-        return Inertia::render('MealPlanning/Index', ['households' => HouseholdResource::collection($households)->resolve()]);
+        return Inertia::render('MealPlanning/Index', [
+            'households' => HouseholdResource::collection($households)->resolve(),
+            'countries' => $countries,
+            'userTimezone' => $request->user()->timezone,
+        ]);
     }
 
     public function planner(Request $request, Household $household): Response

--- a/resources/js/Components/Calendar/CalendarItemMeta.js
+++ b/resources/js/Components/Calendar/CalendarItemMeta.js
@@ -32,7 +32,7 @@ export const SOURCE_META = {
     meal: {
         label: "Meal",
         Icon: Utensils,
-        badgeClass: "bg-wevie-teal/15 text-primary-700 dark:bg-wevie-teal/20 dark:text-primary-300",
+        badgeClass: "bg-wevie-teal/15 text-wevie-teal dark:bg-wevie-teal/20 dark:text-wevie-mint",
         dotClass: "bg-wevie-teal",
     },
 };

--- a/resources/js/Components/MealPlanning/MealPlanningLayout.jsx
+++ b/resources/js/Components/MealPlanning/MealPlanningLayout.jsx
@@ -1,64 +1,101 @@
 import TodoLayout from "@/Layouts/TodoLayout";
 import { Head, Link } from "@inertiajs/react";
+import {
+    ArrowLeft,
+    BookOpen,
+    CalendarDays,
+    NotebookPen,
+    Package,
+    ShoppingCart,
+    SlidersHorizontal,
+    Users,
+    Utensils,
+} from "lucide-react";
 
 const tabs = [
-    ["Planner", "meal-planning.planner"],
-    ["Diary", "meal-planning.diary"],
-    ["Recipes", "meal-planning.recipes"],
-    ["Pantry", "meal-planning.pantry"],
-    ["Grocery", "meal-planning.grocery"],
-    ["Meal calendar", "meal-planning.calendar"],
-    ["Profiles", "meal-planning.members"],
-    ["Preferences", "meal-planning.preferences"],
+    ["Planner", "meal-planning.planner", Utensils],
+    ["Diary", "meal-planning.diary", NotebookPen],
+    ["Recipes", "meal-planning.recipes", BookOpen],
+    ["Pantry", "meal-planning.pantry", Package],
+    ["Grocery", "meal-planning.grocery", ShoppingCart],
+    ["Meal calendar", "meal-planning.calendar", CalendarDays],
+    ["Profiles", "meal-planning.members", Users],
+    ["Preferences", "meal-planning.preferences", SlidersHorizontal],
 ];
 
 export default function MealPlanningLayout({ household, title, children }) {
+    const subtitle = [household.country_code, household.currency, household.timezone]
+        .filter(Boolean)
+        .join(" · ");
+
     return (
-        <TodoLayout>
-            <Head title={`${title} · ${household.name}`} />
-            <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-                <div className="mb-5 flex flex-col gap-3">
-                    <div>
-                        <Link
-                            href={route("meal-planning.index")}
-                            className="text-sm text-primary-600 hover:underline"
-                        >
-                            Households
-                        </Link>
-                        <h1 className="mt-1 text-2xl font-bold text-gray-900 dark:text-white">
-                            {household.name}
-                        </h1>
-                        <p className="text-sm text-gray-500">
-                            {household.country_code} · {household.currency} · {household.timezone}
-                        </p>
-                    </div>
-                    <nav
-                        className="flex gap-2 overflow-x-auto pb-1"
-                        aria-label="Meal planning sections"
+        <TodoLayout
+            header={
+                <div className="flex min-w-0 items-center gap-2 sm:gap-3">
+                    <Link
+                        href={route("meal-planning.index")}
+                        aria-label="All households"
+                        className="inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl border border-light-border/70 bg-light-card text-light-secondary transition-colors hover:bg-light-hover dark:border-dark-border/70 dark:bg-dark-card dark:text-dark-secondary dark:hover:bg-dark-hover"
                     >
-                        {tabs.map(([label, routeName]) => (
+                        <ArrowLeft className="h-4 w-4" />
+                    </Link>
+                    <div className="min-w-0">
+                        <h2 className="truncate text-base font-semibold text-light-primary dark:text-dark-primary sm:text-lg">
+                            {household.name}
+                        </h2>
+                        {subtitle && (
+                            <p className="truncate text-xs text-light-muted dark:text-dark-muted">
+                                {subtitle}
+                            </p>
+                        )}
+                    </div>
+                </div>
+            }
+        >
+            <Head title={`${title} · ${household.name}`} />
+            <div className="space-y-4 sm:space-y-6">
+                <nav
+                    className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1"
+                    aria-label="Meal planning sections"
+                >
+                    {tabs.map(([label, routeName, Icon]) => {
+                        const active = route().current(routeName);
+                        return (
                             <Link
                                 key={routeName}
                                 href={route(routeName, household.id)}
-                                className={`whitespace-nowrap rounded-full px-3 py-1.5 text-sm font-medium ${route().current(routeName) ? "bg-primary-600 text-white" : "bg-white text-gray-700 dark:bg-gray-800 dark:text-gray-200"}`}
+                                aria-current={active ? "page" : undefined}
+                                className={`inline-flex items-center gap-1.5 whitespace-nowrap rounded-full px-3.5 py-1.5 text-sm font-medium transition-colors ${
+                                    active
+                                        ? "bg-gradient-to-r from-wevie-teal to-wevie-mint text-white shadow-soft"
+                                        : "border border-light-border/70 bg-light-card text-light-secondary hover:bg-light-hover dark:border-dark-border/70 dark:bg-dark-card dark:text-dark-secondary dark:hover:bg-dark-hover"
+                                }`}
                             >
+                                <Icon className="h-4 w-4" aria-hidden="true" />
                                 {label}
                             </Link>
-                        ))}
-                    </nav>
-                </div>
+                        );
+                    })}
+                </nav>
                 {children}
             </div>
         </TodoLayout>
     );
 }
 
-export function Panel({ title, children, className = "" }) {
+export function Panel({ title, action, children, className = "" }) {
     return (
-        <section
-            className={`rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800 ${className}`}
-        >
-            <h2 className="mb-3 text-lg font-semibold text-gray-900 dark:text-white">{title}</h2>
+        <section className={`card p-4 sm:p-5 ${className}`}>
+            {(title || action) && (
+                <div className="mb-3 flex items-center justify-between gap-3">
+                    {title && (
+                        <h2 className="text-lg font-semibold text-light-primary dark:text-dark-primary">
+                            {title}
+                        </h2>
+                    )}
+                    {action}
+                </div>
+            )}
             {children}
         </section>
     );

--- a/resources/js/Pages/Admin/MealPlanning/Index.jsx
+++ b/resources/js/Pages/Admin/MealPlanning/Index.jsx
@@ -1,5 +1,7 @@
+import StatCard from "@/Components/Finance/UI/StatCard";
 import TodoLayout from "@/Layouts/TodoLayout";
 import { Head, router } from "@inertiajs/react";
+import { AlertTriangle, BookOpen, Copy, Tags } from "lucide-react";
 
 export default function Index({
     stats = {},
@@ -8,23 +10,39 @@ export default function Index({
     providerRequests = [],
 }) {
     return (
-        <TodoLayout>
+        <TodoLayout
+            header={
+                <h2 className="text-base font-semibold text-light-primary dark:text-dark-primary sm:text-lg">
+                    Meal Planning administration
+                </h2>
+            }
+        >
             <Head title="Meal Planning Administration" />
-            <div className="mx-auto max-w-7xl space-y-6 px-4 py-8">
+            <div className="space-y-6">
                 <div>
-                    <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+                    <h1 className="text-2xl font-bold text-light-primary dark:text-dark-primary">
                         Meal Planning administration
                     </h1>
-                    <p className="text-sm text-gray-500">
+                    <p className="mt-1 text-sm text-light-secondary dark:text-dark-secondary">
                         Normalization review, duplicates, and provider operations.
                     </p>
                 </div>
-                <div className="grid gap-3 sm:grid-cols-3">
-                    <Stat label="Recipes" value={stats.recipes || 0} />
-                    <Stat label="Need review" value={stats.recipes_needing_review || 0} />
-                    <Stat label="Suggested aliases" value={stats.suggested_aliases || 0} />
+                <div className="grid gap-4 sm:grid-cols-3">
+                    <StatCard label="Recipes" value={stats.recipes || 0} icon={BookOpen} />
+                    <StatCard
+                        label="Need review"
+                        value={stats.recipes_needing_review || 0}
+                        icon={AlertTriangle}
+                        iconClassName="bg-warning-500/10 text-warning-600 dark:text-warning-400"
+                    />
+                    <StatCard
+                        label="Suggested aliases"
+                        value={stats.suggested_aliases || 0}
+                        icon={Tags}
+                        iconClassName="bg-secondary-400/10 text-secondary-600 dark:text-secondary-300"
+                    />
                 </div>
-                <Section title="Unmatched ingredient aliases">
+                <Section title="Unmatched ingredient aliases" icon={Tags}>
                     {aliases.map((alias) => (
                         <Row
                             key={alias.id}
@@ -37,7 +55,7 @@ export default function Index({
                         />
                     ))}
                 </Section>
-                <Section title="Potential duplicate recipes">
+                <Section title="Potential duplicate recipes" icon={Copy}>
                     {duplicates.map((candidate) => (
                         <Row
                             key={candidate.id}
@@ -58,7 +76,18 @@ export default function Index({
                         <Row
                             key={request.id}
                             title={`${request.provider} · ${request.operation}`}
-                            detail={`${request.successful ? "successful" : "failed"} · ${request.duration_ms || 0}ms${request.error ? ` · ${request.error}` : ""}`}
+                            badge={
+                                <span
+                                    className={`flex-shrink-0 rounded-full px-2.5 py-1 text-xs font-medium ${
+                                        request.successful
+                                            ? "bg-success-500/10 text-success-600 dark:text-success-400"
+                                            : "bg-error-500/10 text-error-600 dark:text-error-400"
+                                    }`}
+                                >
+                                    {request.successful ? "successful" : "failed"}
+                                </span>
+                            }
+                            detail={`${request.duration_ms || 0}ms${request.error ? ` · ${request.error}` : ""}`}
                         />
                     ))}
                 </Section>
@@ -66,39 +95,48 @@ export default function Index({
         </TodoLayout>
     );
 }
-function Stat({ label, value }) {
+
+function Section({ title, icon: Icon, children }) {
     return (
-        <div className="rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
-            <p className="text-sm text-gray-500">{label}</p>
-            <p className="text-2xl font-bold text-gray-900 dark:text-white">{value}</p>
-        </div>
-    );
-}
-function Section({ title, children }) {
-    return (
-        <section className="rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
-            <h2 className="mb-3 font-semibold text-gray-900 dark:text-white">{title}</h2>
-            <div className="divide-y divide-gray-100 dark:divide-gray-700">
+        <section className="card overflow-hidden">
+            <div className="flex items-center gap-2 border-b border-light-border/70 px-5 py-4 dark:border-dark-border/70">
+                {Icon && (
+                    <Icon
+                        className="h-4 w-4 text-light-muted dark:text-dark-muted"
+                        aria-hidden="true"
+                    />
+                )}
+                <h2 className="font-semibold text-light-primary dark:text-dark-primary">{title}</h2>
+            </div>
+            <div className="divide-y divide-light-border/70 px-5 dark:divide-white/10">
                 {children?.length ? (
                     children
                 ) : (
-                    <p className="py-3 text-sm text-gray-500">Nothing requires attention.</p>
+                    <p className="py-4 text-sm text-light-secondary dark:text-dark-secondary">
+                        Nothing requires attention.
+                    </p>
                 )}
             </div>
         </section>
     );
 }
-function Row({ title, detail, action, actionLabel }) {
+
+function Row({ title, detail, badge, action, actionLabel }) {
     return (
         <div className="flex items-center justify-between gap-4 py-3">
-            <div>
-                <p className="font-medium text-gray-900 dark:text-white">{title}</p>
-                <p className="text-sm text-gray-500">{detail}</p>
+            <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                    <p className="truncate font-medium text-light-primary dark:text-dark-primary">
+                        {title}
+                    </p>
+                    {badge}
+                </div>
+                <p className="text-sm text-light-secondary dark:text-dark-secondary">{detail}</p>
             </div>
             {action && (
                 <button
                     onClick={action}
-                    className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm dark:border-gray-600 dark:text-white"
+                    className="btn-secondary flex-shrink-0 px-3 py-1.5 text-sm"
                 >
                     {actionLabel}
                 </button>

--- a/resources/js/Pages/MealPlanning/Calendar.jsx
+++ b/resources/js/Pages/MealPlanning/Calendar.jsx
@@ -1,4 +1,16 @@
 import MealPlanningLayout, { Panel } from "@/Components/MealPlanning/MealPlanningLayout";
+import { CalendarDays } from "lucide-react";
+
+const formatDay = (day) => {
+    if (day === "Unscheduled") return day;
+    const parsed = new Date(`${day}T00:00:00`);
+    if (Number.isNaN(parsed.getTime())) return day;
+    return parsed.toLocaleDateString(undefined, {
+        weekday: "long",
+        month: "short",
+        day: "numeric",
+    });
+};
 
 export default function Calendar({ household, events = [] }) {
     const grouped = events.reduce((days, event) => {
@@ -10,47 +22,51 @@ export default function Calendar({ household, events = [] }) {
     return (
         <MealPlanningLayout household={household} title="Meal calendar">
             <Panel title="Meal calendar">
-                <p className="mb-4 text-sm text-gray-500">
+                <p className="mb-4 text-sm text-light-secondary dark:text-dark-secondary">
                     Meal, preparation, grocery, batch-cooking, defrosting, and pantry-expiry events
                     stay linked to the plan.
                 </p>
-                <div className="space-y-5">
-                    {Object.entries(grouped).map(([day, dayEvents]) => (
-                        <div key={day}>
-                            <h3 className="mb-2 font-semibold text-gray-900 dark:text-white">
-                                {day}
-                            </h3>
-                            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-                                {dayEvents.map((event) => (
-                                    <article
-                                        key={event.id}
-                                        className="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
-                                    >
-                                        <div className="flex items-center justify-between gap-2">
-                                            <span className="font-medium text-gray-900 dark:text-white">
-                                                {event.title}
-                                            </span>
-                                            <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs uppercase text-gray-600 dark:bg-gray-700 dark:text-gray-200">
-                                                {event.type}
-                                            </span>
-                                        </div>
-                                        <p className="mt-1 text-sm text-gray-500">
-                                            {new Date(event.starts_at).toLocaleTimeString([], {
-                                                hour: "2-digit",
-                                                minute: "2-digit",
-                                            })}{" "}
-                                            · {event.status}
-                                        </p>
-                                    </article>
-                                ))}
+                {events.length > 0 ? (
+                    <div className="space-y-5">
+                        {Object.entries(grouped).map(([day, dayEvents]) => (
+                            <div key={day}>
+                                <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-light-muted dark:text-dark-muted">
+                                    {formatDay(day)}
+                                </h3>
+                                <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                                    {dayEvents.map((event) => (
+                                        <article
+                                            key={event.id}
+                                            className="rounded-xl border border-light-border/70 p-3 dark:border-dark-border/70"
+                                        >
+                                            <div className="flex items-center justify-between gap-2">
+                                                <span className="min-w-0 truncate font-medium text-light-primary dark:text-dark-primary">
+                                                    {event.title}
+                                                </span>
+                                                <span className="flex-shrink-0 rounded-full bg-wevie-teal/10 px-2 py-0.5 text-xs font-medium uppercase text-wevie-teal dark:bg-wevie-teal/20 dark:text-wevie-mint">
+                                                    {event.type}
+                                                </span>
+                                            </div>
+                                            <p className="mt-1 text-sm text-light-secondary dark:text-dark-secondary">
+                                                {new Date(event.starts_at).toLocaleTimeString([], {
+                                                    hour: "2-digit",
+                                                    minute: "2-digit",
+                                                })}{" "}
+                                                · {event.status}
+                                            </p>
+                                        </article>
+                                    ))}
+                                </div>
                             </div>
-                        </div>
-                    ))}
-                </div>
-                {!events.length && (
-                    <p className="text-sm text-gray-500">
-                        Generate a plan to create linked events.
-                    </p>
+                        ))}
+                    </div>
+                ) : (
+                    <div className="py-8 text-center">
+                        <CalendarDays className="mx-auto mb-3 h-10 w-10 text-light-muted dark:text-dark-muted" />
+                        <p className="text-sm text-light-secondary dark:text-dark-secondary">
+                            Generate a plan to create linked meal-calendar events.
+                        </p>
+                    </div>
                 )}
             </Panel>
         </MealPlanningLayout>

--- a/resources/js/Pages/MealPlanning/Diary.jsx
+++ b/resources/js/Pages/MealPlanning/Diary.jsx
@@ -1,7 +1,12 @@
 import MealPlanningLayout, { Panel } from "@/Components/MealPlanning/MealPlanningLayout";
+import InputLabel from "@/Components/InputLabel";
 import { router } from "@inertiajs/react";
 import axios from "axios";
+import { Loader2, NotebookPen, Plus } from "lucide-react";
 import { useState } from "react";
+import { toast } from "react-toastify";
+
+const inputClass = "input-primary w-full border px-3 py-2 text-sm focus:ring-1 focus:outline-none";
 
 export default function Diary({ household, entries = [], date }) {
     const [form, setForm] = useState({
@@ -15,117 +20,162 @@ export default function Diary({ household, entries = [], date }) {
     const submit = async (event) => {
         event.preventDefault();
         setBusy(true);
-        await axios.post(route("meal-planning.api.diary.store", household.id), {
-            household_member_id: form.household_member_id,
-            consumed_at: form.consumed_at,
-            meal_slot: form.meal_slot,
-            status: "modified",
-            items: [
-                {
-                    type: "manual",
-                    name: form.name,
-                    serving_multiplier: 1,
-                    nutrition_snapshot: { calories: Number(form.calories || 0) },
-                    nutrition_source: "manual",
-                    nutrition_confidence: "low",
-                    calculation_version: "manual-v1",
-                },
-            ],
-        });
-        setForm({ ...form, name: "", calories: "" });
-        setBusy(false);
-        router.reload({ only: ["entries"] });
+        try {
+            await axios.post(route("meal-planning.api.diary.store", household.id), {
+                household_member_id: form.household_member_id,
+                consumed_at: form.consumed_at,
+                meal_slot: form.meal_slot,
+                status: "modified",
+                items: [
+                    {
+                        type: "manual",
+                        name: form.name,
+                        serving_multiplier: 1,
+                        nutrition_snapshot: { calories: Number(form.calories || 0) },
+                        nutrition_source: "manual",
+                        nutrition_confidence: "low",
+                        calculation_version: "manual-v1",
+                    },
+                ],
+            });
+            setForm({ ...form, name: "", calories: "" });
+            toast.success("Meal logged.");
+            router.reload({ only: ["entries"] });
+        } catch {
+            toast.error("We couldn’t log that meal just now.");
+        } finally {
+            setBusy(false);
+        }
     };
     return (
         <MealPlanningLayout household={household} title="Meal diary">
-            <div className="grid gap-5 lg:grid-cols-[2fr,1fr]">
+            <div className="grid gap-4 lg:grid-cols-[2fr,1fr] lg:gap-5">
                 <Panel title={`Diary · ${date}`}>
-                    <div className="space-y-3">
-                        {entries.map((entry) => (
-                            <article
-                                key={entry.id}
-                                className="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
-                            >
-                                <div className="flex justify-between gap-3">
-                                    <div>
-                                        <p className="font-medium text-gray-900 dark:text-white">
-                                            {entry.member?.name} ·{" "}
-                                            <span className="capitalize">{entry.meal_slot}</span>
-                                        </p>
-                                        <p className="text-sm text-gray-500">
-                                            {entry.items?.map((item) => item.name).join(", ") ||
-                                                entry.status}
-                                        </p>
+                    {entries.length > 0 ? (
+                        <div className="space-y-3">
+                            {entries.map((entry) => (
+                                <article
+                                    key={entry.id}
+                                    className="rounded-xl border border-light-border/70 p-3 dark:border-dark-border/70"
+                                >
+                                    <div className="flex justify-between gap-3">
+                                        <div className="min-w-0">
+                                            <p className="font-medium text-light-primary dark:text-dark-primary">
+                                                {entry.member?.name} ·{" "}
+                                                <span className="capitalize">
+                                                    {entry.meal_slot}
+                                                </span>
+                                            </p>
+                                            <p className="text-sm text-light-secondary dark:text-dark-secondary">
+                                                {entry.items?.map((item) => item.name).join(", ") ||
+                                                    entry.status}
+                                            </p>
+                                        </div>
+                                        <div className="flex-shrink-0 text-right">
+                                            <p className="font-semibold text-light-primary dark:text-dark-primary">
+                                                {Math.round(entry.actual_nutrition?.calories || 0)}{" "}
+                                                kcal
+                                            </p>
+                                            <p className="text-xs capitalize text-light-muted dark:text-dark-muted">
+                                                {entry.status.replaceAll("_", " ")}
+                                            </p>
+                                        </div>
                                     </div>
-                                    <div className="text-right">
-                                        <p className="font-semibold text-gray-900 dark:text-white">
-                                            {Math.round(entry.actual_nutrition?.calories || 0)} kcal
-                                        </p>
-                                        <p className="text-xs capitalize text-gray-500">
-                                            {entry.status.replaceAll("_", " ")}
-                                        </p>
-                                    </div>
-                                </div>
-                            </article>
-                        ))}
-                        {!entries.length && (
-                            <p className="text-sm text-gray-500">No meals logged for this day.</p>
-                        )}
-                    </div>
+                                </article>
+                            ))}
+                        </div>
+                    ) : (
+                        <div className="py-8 text-center">
+                            <NotebookPen className="mx-auto mb-3 h-10 w-10 text-light-muted dark:text-dark-muted" />
+                            <p className="text-sm text-light-secondary dark:text-dark-secondary">
+                                No meals logged for this day. Add one using the form.
+                            </p>
+                        </div>
+                    )}
                 </Panel>
                 <Panel title="Add diary item">
                     <form onSubmit={submit} className="space-y-3">
-                        <select
-                            value={form.household_member_id}
-                            onChange={(e) =>
-                                setForm({ ...form, household_member_id: e.target.value })
-                            }
-                            className="w-full rounded-lg border-gray-300 dark:bg-gray-900"
-                        >
-                            {household.members?.map((member) => (
-                                <option key={member.id} value={member.id}>
-                                    {member.name}
-                                </option>
-                            ))}
-                        </select>
-                        <div className="grid grid-cols-2 gap-2">
+                        <div>
+                            <InputLabel htmlFor="diary-member" value="Member" />
                             <select
-                                value={form.meal_slot}
-                                onChange={(e) => setForm({ ...form, meal_slot: e.target.value })}
-                                className="rounded-lg border-gray-300 dark:bg-gray-900"
+                                id="diary-member"
+                                value={form.household_member_id}
+                                onChange={(e) =>
+                                    setForm({ ...form, household_member_id: e.target.value })
+                                }
+                                className={`mt-1 ${inputClass}`}
                             >
-                                <option>breakfast</option>
-                                <option>lunch</option>
-                                <option>dinner</option>
-                                <option>snack</option>
+                                {household.members?.map((member) => (
+                                    <option key={member.id} value={member.id}>
+                                        {member.name}
+                                    </option>
+                                ))}
                             </select>
+                        </div>
+                        <div className="grid grid-cols-2 gap-2">
+                            <div>
+                                <InputLabel htmlFor="diary-slot" value="Meal" />
+                                <select
+                                    id="diary-slot"
+                                    value={form.meal_slot}
+                                    onChange={(e) =>
+                                        setForm({ ...form, meal_slot: e.target.value })
+                                    }
+                                    className={`mt-1 ${inputClass} capitalize`}
+                                >
+                                    <option>breakfast</option>
+                                    <option>lunch</option>
+                                    <option>dinner</option>
+                                    <option>snack</option>
+                                </select>
+                            </div>
+                            <div>
+                                <InputLabel htmlFor="diary-time" value="When" />
+                                <input
+                                    id="diary-time"
+                                    type="datetime-local"
+                                    value={form.consumed_at}
+                                    onChange={(e) =>
+                                        setForm({ ...form, consumed_at: e.target.value })
+                                    }
+                                    className={`mt-1 ${inputClass}`}
+                                />
+                            </div>
+                        </div>
+                        <div>
+                            <InputLabel htmlFor="diary-name" value="Food or drink" />
                             <input
-                                type="datetime-local"
-                                value={form.consumed_at}
-                                onChange={(e) => setForm({ ...form, consumed_at: e.target.value })}
-                                className="rounded-lg border-gray-300 dark:bg-gray-900"
+                                id="diary-name"
+                                required
+                                placeholder="e.g. Chicken adobo"
+                                value={form.name}
+                                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                                className={`mt-1 ${inputClass}`}
                             />
                         </div>
-                        <input
-                            required
-                            placeholder="Food or drink"
-                            value={form.name}
-                            onChange={(e) => setForm({ ...form, name: e.target.value })}
-                            className="w-full rounded-lg border-gray-300 dark:bg-gray-900"
-                        />
-                        <input
-                            min="0"
-                            step="0.1"
-                            type="number"
-                            placeholder="Calories (optional)"
-                            value={form.calories}
-                            onChange={(e) => setForm({ ...form, calories: e.target.value })}
-                            className="w-full rounded-lg border-gray-300 dark:bg-gray-900"
-                        />
+                        <div>
+                            <InputLabel htmlFor="diary-cal" value="Calories (optional)" />
+                            <input
+                                id="diary-cal"
+                                min="0"
+                                step="0.1"
+                                type="number"
+                                placeholder="0"
+                                value={form.calories}
+                                onChange={(e) => setForm({ ...form, calories: e.target.value })}
+                                className={`mt-1 ${inputClass}`}
+                            />
+                        </div>
                         <button
+                            type="submit"
                             disabled={busy}
-                            className="w-full rounded-lg bg-primary-600 px-4 py-2 font-medium text-white"
+                            className="btn-primary w-full disabled:opacity-60"
                         >
+                            {busy ? (
+                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            ) : (
+                                <Plus className="mr-2 h-4 w-4" />
+                            )}
                             Log meal
                         </button>
                     </form>

--- a/resources/js/Pages/MealPlanning/GroceryList.jsx
+++ b/resources/js/Pages/MealPlanning/GroceryList.jsx
@@ -1,47 +1,65 @@
 import MealPlanningLayout, { Panel } from "@/Components/MealPlanning/MealPlanningLayout";
+import StatCard from "@/Components/Finance/UI/StatCard";
+import { CircleHelp, Coins, ShoppingCart } from "lucide-react";
 
 export default function GroceryList({ household, shoppingList }) {
     return (
         <MealPlanningLayout household={household} title="Grocery list">
-            <Panel title="Forecast grocery list">
-                {!shoppingList ? (
-                    <p className="text-sm text-gray-500">
-                        Generate a meal plan to build a list from normalized ingredients.
+            {!shoppingList ? (
+                <div className="card p-8 text-center">
+                    <div className="mb-4 text-light-muted dark:text-dark-muted">
+                        <ShoppingCart className="mx-auto h-10 w-10 sm:h-12 sm:w-12" />
+                    </div>
+                    <h3 className="mb-1 text-base font-semibold text-light-primary dark:text-dark-primary sm:text-lg">
+                        No grocery list yet
+                    </h3>
+                    <p className="text-sm text-light-secondary dark:text-dark-secondary">
+                        Generate a meal plan to build a shopping list from normalized ingredients.
                     </p>
-                ) : (
-                    <>
-                        <div className="mb-4 grid gap-3 sm:grid-cols-3">
-                            <Summary
-                                label="Known total"
-                                value={`${household.currency} ${Number(shoppingList.known_cost_total || 0).toFixed(2)}`}
-                            />
-                            <Summary
-                                label="Unknown prices"
-                                value={shoppingList.unknown_price_count || 0}
-                            />
-                            <Summary label="Budget validation" value={shoppingList.budget_status} />
-                        </div>
-                        <div className="divide-y divide-gray-100 dark:divide-gray-700">
+                </div>
+            ) : (
+                <>
+                    <div className="grid gap-4 sm:grid-cols-3">
+                        <StatCard
+                            label="Known total"
+                            value={`${household.currency} ${Number(shoppingList.known_cost_total || 0).toFixed(2)}`}
+                            icon={Coins}
+                        />
+                        <StatCard
+                            label="Unknown prices"
+                            value={shoppingList.unknown_price_count || 0}
+                            icon={CircleHelp}
+                            iconClassName="bg-warning-500/10 text-warning-600 dark:text-warning-400"
+                        />
+                        <StatCard
+                            label="Budget validation"
+                            value={<span className="capitalize">{shoppingList.budget_status}</span>}
+                            icon={ShoppingCart}
+                            iconClassName="bg-secondary-400/10 text-secondary-600 dark:text-secondary-300"
+                        />
+                    </div>
+                    <Panel title="Forecast grocery list">
+                        <div className="divide-y divide-light-border/70 dark:divide-white/10">
                             {(shoppingList.items || []).map((item) => (
                                 <div
                                     key={item.id}
-                                    className="flex items-center justify-between gap-3 py-3"
+                                    className="flex items-center justify-between gap-3 py-3 first:pt-0 last:pb-0"
                                 >
-                                    <div>
-                                        <p className="font-medium text-gray-900 dark:text-white">
+                                    <div className="min-w-0">
+                                        <p className="font-medium text-light-primary dark:text-dark-primary">
                                             {item.ingredient?.canonical_name ||
                                                 `Ingredient #${item.ingredient_id}`}
                                         </p>
-                                        <p className="text-sm text-gray-500">
+                                        <p className="text-sm text-light-secondary dark:text-dark-secondary">
                                             Need {item.required_quantity} {item.unit}; pantry covers{" "}
                                             {item.pantry_quantity}
                                         </p>
                                     </div>
-                                    <div className="text-right">
-                                        <p className="font-medium text-gray-900 dark:text-white">
+                                    <div className="flex-shrink-0 text-right">
+                                        <p className="font-medium text-light-primary dark:text-dark-primary">
                                             Buy {item.purchase_quantity} {item.unit}
                                         </p>
-                                        <p className="text-xs text-gray-500">
+                                        <p className="text-xs text-light-muted dark:text-dark-muted">
                                             {item.estimated_cost == null
                                                 ? "Price unknown"
                                                 : `${household.currency} ${Number(item.estimated_cost).toFixed(2)}`}
@@ -50,18 +68,9 @@ export default function GroceryList({ household, shoppingList }) {
                                 </div>
                             ))}
                         </div>
-                    </>
-                )}
-            </Panel>
+                    </Panel>
+                </>
+            )}
         </MealPlanningLayout>
-    );
-}
-
-function Summary({ label, value }) {
-    return (
-        <div className="rounded-lg bg-gray-50 p-3 dark:bg-gray-900">
-            <p className="text-xs uppercase tracking-wide text-gray-500">{label}</p>
-            <p className="mt-1 font-semibold capitalize text-gray-900 dark:text-white">{value}</p>
-        </div>
     );
 }

--- a/resources/js/Pages/MealPlanning/Index.jsx
+++ b/resources/js/Pages/MealPlanning/Index.jsx
@@ -1,78 +1,227 @@
+import InputError from "@/Components/InputError";
+import InputLabel from "@/Components/InputLabel";
 import TodoLayout from "@/Layouts/TodoLayout";
 import { Head, Link, router } from "@inertiajs/react";
 import axios from "axios";
-import { useState } from "react";
+import { ChevronRight, Loader2, Plus, UtensilsCrossed } from "lucide-react";
+import { useMemo, useState } from "react";
+import { toast } from "react-toastify";
 
-export default function Index({ households = [] }) {
-    const [name, setName] = useState("");
+const inputClass = "input-primary w-full border px-3 py-2 text-sm focus:ring-1 focus:outline-none";
+
+function buildTimezones(preferred) {
+    let zones = [];
+    try {
+        if (typeof Intl.supportedValuesOf === "function") {
+            zones = Intl.supportedValuesOf("timeZone");
+        }
+    } catch {
+        zones = [];
+    }
+    if (!zones.length) {
+        zones = [
+            "UTC",
+            "Asia/Manila",
+            "Asia/Singapore",
+            "Asia/Tokyo",
+            "Australia/Sydney",
+            "Europe/London",
+            "Europe/Berlin",
+            "America/New_York",
+            "America/Chicago",
+            "America/Los_Angeles",
+        ];
+    }
+    if (preferred && !zones.includes(preferred)) {
+        zones = [preferred, ...zones];
+    }
+    return zones;
+}
+
+export default function Index({ households = [], countries = [], userTimezone = null }) {
+    const browserTimezone = useMemo(() => {
+        try {
+            return Intl.DateTimeFormat().resolvedOptions().timeZone;
+        } catch {
+            return null;
+        }
+    }, []);
+    const defaultTimezone = userTimezone || browserTimezone || "Asia/Manila";
+    const timezones = useMemo(() => buildTimezones(defaultTimezone), [defaultTimezone]);
+
+    const defaultCountry = countries.find((c) => c.code === "PH")?.code || countries[0]?.code || "";
+    const currencyFor = (code) => countries.find((c) => c.code === code)?.currency || "";
+
+    const [form, setForm] = useState({
+        name: "",
+        country_code: defaultCountry,
+        currency: currencyFor(defaultCountry) || "PHP",
+        timezone: defaultTimezone,
+    });
     const [processing, setProcessing] = useState(false);
     const [error, setError] = useState("");
+
+    const onCountryChange = (code) => {
+        setForm((prev) => ({
+            ...prev,
+            country_code: code,
+            currency: currencyFor(code) || prev.currency,
+        }));
+    };
+
     const create = async (event) => {
         event.preventDefault();
         setProcessing(true);
         setError("");
         try {
             const { data } = await axios.post(route("meal-planning.api.households.store"), {
-                name,
-                country_code: "PH",
-                timezone: "Asia/Manila",
-                currency: "PHP",
+                name: form.name,
+                country_code: form.country_code || undefined,
+                timezone: form.timezone || undefined,
+                currency: form.currency ? form.currency.toUpperCase() : undefined,
             });
+            toast.success("Household created.");
             router.visit(route("meal-planning.planner", data.data.id));
         } catch (e) {
             setError(e.response?.data?.message || "Unable to create the household.");
             setProcessing(false);
         }
     };
+
     return (
-        <TodoLayout>
+        <TodoLayout
+            header={
+                <h2 className="text-base font-semibold text-light-primary dark:text-dark-primary sm:text-lg">
+                    Meal Planning
+                </h2>
+            }
+        >
             <Head title="Meal Planning" />
-            <div className="mx-auto max-w-6xl px-4 py-8">
-                <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
-                    Household Meal Planning
-                </h1>
-                <p className="mt-1 text-gray-500">
-                    Shared plans, local ingredients, pantry forecasts, and individual meal diaries.
-                </p>
-                <div className="mt-6 grid gap-4 md:grid-cols-2">
-                    {households.map((household) => (
-                        <Link
-                            key={household.id}
-                            href={route("meal-planning.planner", household.id)}
-                            className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm hover:border-primary-500 dark:border-gray-700 dark:bg-gray-800"
-                        >
-                            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-                                {household.name}
-                            </h2>
-                            <p className="mt-1 text-sm text-gray-500">
-                                {household.members?.length || 0} members · {household.country_code}
-                            </p>
-                        </Link>
-                    ))}
+            <div className="space-y-6">
+                <div>
+                    <h1 className="text-2xl font-bold text-light-primary dark:text-dark-primary">
+                        Household meal planning
+                    </h1>
+                    <p className="mt-1 text-sm text-light-secondary dark:text-dark-secondary">
+                        Shared plans, local ingredients, pantry forecasts, and individual meal
+                        diaries.
+                    </p>
                 </div>
-                <form
-                    onSubmit={create}
-                    className="mt-8 max-w-xl rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800"
-                >
-                    <h2 className="font-semibold text-gray-900 dark:text-white">
+
+                {households.length === 0 ? (
+                    <div className="card p-8 text-center">
+                        <div className="mb-4 text-light-muted dark:text-dark-muted">
+                            <UtensilsCrossed className="mx-auto h-10 w-10 sm:h-12 sm:w-12" />
+                        </div>
+                        <h3 className="mb-1 text-base font-semibold text-light-primary dark:text-dark-primary sm:text-lg">
+                            No households yet
+                        </h3>
+                        <p className="text-sm text-light-secondary dark:text-dark-secondary">
+                            Create your first household below to start planning meals together.
+                        </p>
+                    </div>
+                ) : (
+                    <div className="grid gap-4 md:grid-cols-2">
+                        {households.map((household) => (
+                            <Link
+                                key={household.id}
+                                href={route("meal-planning.planner", household.id)}
+                                className="card-hover group flex items-center justify-between gap-3 p-5"
+                            >
+                                <div className="min-w-0">
+                                    <h2 className="truncate text-lg font-semibold text-light-primary dark:text-dark-primary group-hover:text-wevie-teal dark:group-hover:text-wevie-mint">
+                                        {household.name}
+                                    </h2>
+                                    <p className="mt-1 text-sm text-light-secondary dark:text-dark-secondary">
+                                        {household.members?.length || 0} members ·{" "}
+                                        {household.country_code}
+                                    </p>
+                                </div>
+                                <ChevronRight className="h-5 w-5 flex-shrink-0 text-light-muted transition-transform group-hover:translate-x-0.5 dark:text-dark-muted" />
+                            </Link>
+                        ))}
+                    </div>
+                )}
+
+                <form onSubmit={create} className="card max-w-2xl p-5">
+                    <h2 className="text-lg font-semibold text-light-primary dark:text-dark-primary">
                         Create a household
                     </h2>
-                    <div className="mt-3 flex gap-2">
-                        <input
-                            value={name}
-                            onChange={(e) => setName(e.target.value)}
-                            required
-                            placeholder="Household name"
-                            className="min-w-0 flex-1 rounded-lg border-gray-300 dark:bg-gray-900"
-                        />
+                    <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                        <div className="sm:col-span-2">
+                            <InputLabel htmlFor="hh-name" value="Household name" />
+                            <input
+                                id="hh-name"
+                                value={form.name}
+                                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                                required
+                                placeholder="e.g. The Cruz Family"
+                                className={`mt-1 ${inputClass}`}
+                            />
+                        </div>
+                        <div>
+                            <InputLabel htmlFor="hh-country" value="Country" />
+                            <select
+                                id="hh-country"
+                                value={form.country_code}
+                                onChange={(e) => onCountryChange(e.target.value)}
+                                className={`mt-1 ${inputClass}`}
+                            >
+                                {countries.length === 0 && <option value="">—</option>}
+                                {countries.map((country) => (
+                                    <option key={country.code} value={country.code}>
+                                        {country.name}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+                        <div>
+                            <InputLabel htmlFor="hh-currency" value="Currency" />
+                            <input
+                                id="hh-currency"
+                                value={form.currency}
+                                onChange={(e) =>
+                                    setForm({
+                                        ...form,
+                                        currency: e.target.value.toUpperCase().slice(0, 3),
+                                    })
+                                }
+                                maxLength={3}
+                                placeholder="PHP"
+                                className={`mt-1 ${inputClass} uppercase`}
+                            />
+                        </div>
+                        <div className="sm:col-span-2">
+                            <InputLabel htmlFor="hh-timezone" value="Time zone" />
+                            <select
+                                id="hh-timezone"
+                                value={form.timezone}
+                                onChange={(e) => setForm({ ...form, timezone: e.target.value })}
+                                className={`mt-1 ${inputClass}`}
+                            >
+                                {timezones.map((tz) => (
+                                    <option key={tz} value={tz}>
+                                        {tz}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+                    </div>
+                    <InputError message={error} className="mt-3" />
+                    <div className="mt-4">
                         <button
+                            type="submit"
                             disabled={processing}
-                            className="rounded-lg bg-primary-600 px-4 py-2 font-medium text-white"
+                            className="btn-primary disabled:opacity-60"
                         >
-                            Create
+                            {processing ? (
+                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            ) : (
+                                <Plus className="mr-2 h-4 w-4" />
+                            )}
+                            {processing ? "Creating…" : "Create household"}
                         </button>
                     </div>
-                    {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
                 </form>
             </div>
         </TodoLayout>

--- a/resources/js/Pages/MealPlanning/Members.jsx
+++ b/resources/js/Pages/MealPlanning/Members.jsx
@@ -1,6 +1,11 @@
 import MealPlanningLayout, { Panel } from "@/Components/MealPlanning/MealPlanningLayout";
+import InputLabel from "@/Components/InputLabel";
 import { router } from "@inertiajs/react";
+import { Plus, Users } from "lucide-react";
 import { useState } from "react";
+import { toast } from "react-toastify";
+
+const inputClass = "input-primary w-full border px-3 py-2 text-sm focus:ring-1 focus:outline-none";
 
 const empty = {
     name: "",
@@ -20,123 +25,176 @@ export default function Members({ household }) {
     const [form, setForm] = useState(empty);
     const add = async (event) => {
         event.preventDefault();
-        await window.axios.post(route("meal-planning.api.members.store", household.id), {
-            ...form,
-            sex_at_birth: form.sex_at_birth || null,
-            birth_date: form.birth_date || null,
-            height_cm: form.height_cm || null,
-            weight_kg: form.weight_kg || null,
-            allergies: form.allergies
-                .split(",")
-                .map((v) => v.trim())
-                .filter(Boolean),
-            dietary_restrictions: form.dietary_restrictions
-                .split(",")
-                .map((v) => v.trim())
-                .filter(Boolean),
-        });
-        setForm(empty);
-        router.reload();
+        try {
+            await window.axios.post(route("meal-planning.api.members.store", household.id), {
+                ...form,
+                sex_at_birth: form.sex_at_birth || null,
+                birth_date: form.birth_date || null,
+                height_cm: form.height_cm || null,
+                weight_kg: form.weight_kg || null,
+                allergies: form.allergies
+                    .split(",")
+                    .map((v) => v.trim())
+                    .filter(Boolean),
+                dietary_restrictions: form.dietary_restrictions
+                    .split(",")
+                    .map((v) => v.trim())
+                    .filter(Boolean),
+            });
+            setForm(empty);
+            toast.success("Member added.");
+            router.reload();
+        } catch {
+            toast.error("We couldn’t add that member just now.");
+        }
     };
     return (
         <MealPlanningLayout household={household} title="Nutrition Profiles">
             <div className="grid gap-4 lg:grid-cols-2">
                 <Panel title="Household members">
-                    {household.members.map((member) => (
-                        <article
-                            key={member.id}
-                            className="mb-3 rounded-lg bg-gray-50 p-3 dark:bg-gray-900"
-                        >
-                            <div className="flex justify-between">
-                                <div>
-                                    <p className="font-medium text-gray-900 dark:text-white">
-                                        {member.name}
-                                    </p>
-                                    <p className="text-sm capitalize text-gray-500">
-                                        {member.classification} · {member.role}
-                                    </p>
-                                </div>
-                                <span className="text-sm text-gray-500">
-                                    {member.nutrition_targets?.calories
-                                        ? `${member.nutrition_targets.calories} kcal`
-                                        : "Target calculated when complete"}
-                                </span>
-                            </div>
-                            {member.allergies?.length > 0 && (
-                                <p className="mt-2 text-xs text-amber-700">
-                                    Allergies: {member.allergies.join(", ")}
-                                </p>
-                            )}
-                        </article>
-                    ))}
+                    {household.members.length > 0 ? (
+                        <div className="space-y-3">
+                            {household.members.map((member) => (
+                                <article
+                                    key={member.id}
+                                    className="rounded-xl bg-light-hover p-3 dark:bg-dark-hover"
+                                >
+                                    <div className="flex justify-between gap-3">
+                                        <div className="min-w-0">
+                                            <p className="font-medium text-light-primary dark:text-dark-primary">
+                                                {member.name}
+                                            </p>
+                                            <p className="text-sm capitalize text-light-secondary dark:text-dark-secondary">
+                                                {member.classification} · {member.role}
+                                            </p>
+                                        </div>
+                                        <span className="flex-shrink-0 text-right text-sm text-light-secondary dark:text-dark-secondary">
+                                            {member.nutrition_targets?.calories
+                                                ? `${member.nutrition_targets.calories} kcal`
+                                                : "Target calculated when complete"}
+                                        </span>
+                                    </div>
+                                    {member.allergies?.length > 0 && (
+                                        <p className="mt-2 text-xs text-warning-700 dark:text-warning-300">
+                                            Allergies: {member.allergies.join(", ")}
+                                        </p>
+                                    )}
+                                </article>
+                            ))}
+                        </div>
+                    ) : (
+                        <div className="py-8 text-center">
+                            <Users className="mx-auto mb-3 h-10 w-10 text-light-muted dark:text-dark-muted" />
+                            <p className="text-sm text-light-secondary dark:text-dark-secondary">
+                                No members yet. Add household members to tailor nutrition targets.
+                            </p>
+                        </div>
+                    )}
                 </Panel>
                 <Panel title="Add member or dependent">
                     <form onSubmit={add} className="grid gap-3 sm:grid-cols-2">
-                        <input
-                            required
-                            value={form.name}
-                            onChange={(e) => setForm({ ...form, name: e.target.value })}
-                            placeholder="Name"
-                            className="rounded-lg border-gray-300 dark:bg-gray-900"
-                        />
-                        <select
-                            value={form.classification}
-                            onChange={(e) => setForm({ ...form, classification: e.target.value })}
-                            className="rounded-lg border-gray-300 dark:bg-gray-900"
-                        >
-                            <option value="adult">Adult</option>
-                            <option value="child">Child</option>
-                        </select>
-                        <select
-                            value={form.sex_at_birth}
-                            onChange={(e) => setForm({ ...form, sex_at_birth: e.target.value })}
-                            className="rounded-lg border-gray-300 dark:bg-gray-900"
-                        >
-                            <option value="">Sex at birth (optional)</option>
-                            <option value="female">Female</option>
-                            <option value="male">Male</option>
-                        </select>
-                        <input
-                            type="date"
-                            value={form.birth_date}
-                            onChange={(e) => setForm({ ...form, birth_date: e.target.value })}
-                            className="rounded-lg border-gray-300 dark:bg-gray-900"
-                        />
-                        <input
-                            type="number"
-                            step="0.1"
-                            value={form.height_cm}
-                            onChange={(e) => setForm({ ...form, height_cm: e.target.value })}
-                            placeholder="Height (cm)"
-                            className="rounded-lg border-gray-300 dark:bg-gray-900"
-                        />
-                        <input
-                            type="number"
-                            step="0.1"
-                            value={form.weight_kg}
-                            onChange={(e) => setForm({ ...form, weight_kg: e.target.value })}
-                            placeholder="Weight (kg)"
-                            className="rounded-lg border-gray-300 dark:bg-gray-900"
-                        />
-                        <input
-                            value={form.allergies}
-                            onChange={(e) => setForm({ ...form, allergies: e.target.value })}
-                            placeholder="Allergies, comma separated"
-                            className="rounded-lg border-gray-300 dark:bg-gray-900"
-                        />
-                        <input
-                            value={form.dietary_restrictions}
-                            onChange={(e) =>
-                                setForm({ ...form, dietary_restrictions: e.target.value })
-                            }
-                            placeholder="Restrictions, comma separated"
-                            className="rounded-lg border-gray-300 dark:bg-gray-900"
-                        />
-                        <button className="rounded-lg bg-primary-600 px-4 py-2 text-white sm:col-span-2">
-                            Add member
-                        </button>
+                        <div className="sm:col-span-2">
+                            <InputLabel htmlFor="m-name" value="Name" />
+                            <input
+                                id="m-name"
+                                required
+                                value={form.name}
+                                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                                placeholder="Full name"
+                                className={`mt-1 ${inputClass}`}
+                            />
+                        </div>
+                        <div>
+                            <InputLabel htmlFor="m-class" value="Classification" />
+                            <select
+                                id="m-class"
+                                value={form.classification}
+                                onChange={(e) =>
+                                    setForm({ ...form, classification: e.target.value })
+                                }
+                                className={`mt-1 ${inputClass}`}
+                            >
+                                <option value="adult">Adult</option>
+                                <option value="child">Child</option>
+                            </select>
+                        </div>
+                        <div>
+                            <InputLabel htmlFor="m-sex" value="Sex at birth (optional)" />
+                            <select
+                                id="m-sex"
+                                value={form.sex_at_birth}
+                                onChange={(e) => setForm({ ...form, sex_at_birth: e.target.value })}
+                                className={`mt-1 ${inputClass}`}
+                            >
+                                <option value="">Not specified</option>
+                                <option value="female">Female</option>
+                                <option value="male">Male</option>
+                            </select>
+                        </div>
+                        <div>
+                            <InputLabel htmlFor="m-birth" value="Birth date" />
+                            <input
+                                id="m-birth"
+                                type="date"
+                                value={form.birth_date}
+                                onChange={(e) => setForm({ ...form, birth_date: e.target.value })}
+                                className={`mt-1 ${inputClass}`}
+                            />
+                        </div>
+                        <div>
+                            <InputLabel htmlFor="m-height" value="Height (cm)" />
+                            <input
+                                id="m-height"
+                                type="number"
+                                step="0.1"
+                                value={form.height_cm}
+                                onChange={(e) => setForm({ ...form, height_cm: e.target.value })}
+                                placeholder="0"
+                                className={`mt-1 ${inputClass}`}
+                            />
+                        </div>
+                        <div>
+                            <InputLabel htmlFor="m-weight" value="Weight (kg)" />
+                            <input
+                                id="m-weight"
+                                type="number"
+                                step="0.1"
+                                value={form.weight_kg}
+                                onChange={(e) => setForm({ ...form, weight_kg: e.target.value })}
+                                placeholder="0"
+                                className={`mt-1 ${inputClass}`}
+                            />
+                        </div>
+                        <div>
+                            <InputLabel htmlFor="m-allergies" value="Allergies" />
+                            <input
+                                id="m-allergies"
+                                value={form.allergies}
+                                onChange={(e) => setForm({ ...form, allergies: e.target.value })}
+                                placeholder="Comma separated"
+                                className={`mt-1 ${inputClass}`}
+                            />
+                        </div>
+                        <div>
+                            <InputLabel htmlFor="m-restrictions" value="Restrictions" />
+                            <input
+                                id="m-restrictions"
+                                value={form.dietary_restrictions}
+                                onChange={(e) =>
+                                    setForm({ ...form, dietary_restrictions: e.target.value })
+                                }
+                                placeholder="Comma separated"
+                                className={`mt-1 ${inputClass}`}
+                            />
+                        </div>
+                        <div className="sm:col-span-2">
+                            <button type="submit" className="btn-primary w-full">
+                                <Plus className="mr-2 h-4 w-4" />
+                                Add member
+                            </button>
+                        </div>
                     </form>
-                    <p className="mt-3 text-xs text-gray-500">
+                    <p className="mt-3 text-xs text-light-muted dark:text-dark-muted">
                         Automatic targets are estimates. Child profiles never receive an automatic
                         calorie deficit.
                     </p>

--- a/resources/js/Pages/MealPlanning/Pantry.jsx
+++ b/resources/js/Pages/MealPlanning/Pantry.jsx
@@ -1,6 +1,11 @@
 import MealPlanningLayout, { Panel } from "@/Components/MealPlanning/MealPlanningLayout";
+import InputLabel from "@/Components/InputLabel";
 import { router } from "@inertiajs/react";
+import { Package, Plus } from "lucide-react";
 import { useState } from "react";
+import { toast } from "react-toastify";
+
+const inputClass = "input-primary w-full border px-3 py-2 text-sm focus:ring-1 focus:outline-none";
 
 export default function Pantry({ household, pantryItems = [], ingredients = [] }) {
     const [form, setForm] = useState({
@@ -11,79 +16,120 @@ export default function Pantry({ household, pantryItems = [], ingredients = [] }
     });
     const add = async (event) => {
         event.preventDefault();
-        await window.axios.post(route("meal-planning.api.pantry.store", household.id), {
-            ...form,
-            quantity: Number(form.quantity),
-            expires_on: form.expires_on || null,
-        });
-        setForm({ ...form, quantity: "", expires_on: "" });
-        router.reload();
+        try {
+            await window.axios.post(route("meal-planning.api.pantry.store", household.id), {
+                ...form,
+                quantity: Number(form.quantity),
+                expires_on: form.expires_on || null,
+            });
+            setForm({ ...form, quantity: "", expires_on: "" });
+            toast.success("Pantry stock added.");
+            router.reload();
+        } catch {
+            toast.error("We couldn’t add that item just now.");
+        }
     };
     return (
         <MealPlanningLayout household={household} title="Pantry">
             <Panel title="Add pantry stock">
-                <form onSubmit={add} className="grid gap-3 sm:grid-cols-4">
-                    <select
-                        value={form.ingredient_id}
-                        onChange={(e) => setForm({ ...form, ingredient_id: e.target.value })}
-                        className="rounded-lg border-gray-300 dark:bg-gray-900"
-                    >
-                        {ingredients.map((ingredient) => (
-                            <option key={ingredient.id} value={ingredient.id}>
-                                {ingredient.canonical_name}
-                            </option>
-                        ))}
-                    </select>
-                    <input
-                        required
-                        type="number"
-                        step="0.01"
-                        min="0"
-                        value={form.quantity}
-                        onChange={(e) => setForm({ ...form, quantity: e.target.value })}
-                        placeholder="Quantity"
-                        className="rounded-lg border-gray-300 dark:bg-gray-900"
-                    />
-                    <select
-                        value={form.unit}
-                        onChange={(e) => setForm({ ...form, unit: e.target.value })}
-                        className="rounded-lg border-gray-300 dark:bg-gray-900"
-                    >
-                        {["g", "kg", "ml", "l", "tsp", "tbsp", "cup", "piece"].map((unit) => (
-                            <option key={unit}>{unit}</option>
-                        ))}
-                    </select>
-                    <button className="rounded-lg bg-primary-600 px-4 py-2 text-white">Add</button>
-                    <input
-                        type="date"
-                        value={form.expires_on}
-                        onChange={(e) => setForm({ ...form, expires_on: e.target.value })}
-                        className="rounded-lg border-gray-300 dark:bg-gray-900"
-                    />
+                <form onSubmit={add} className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                    <div>
+                        <InputLabel htmlFor="pantry-ingredient" value="Ingredient" />
+                        <select
+                            id="pantry-ingredient"
+                            value={form.ingredient_id}
+                            onChange={(e) => setForm({ ...form, ingredient_id: e.target.value })}
+                            className={`mt-1 ${inputClass}`}
+                        >
+                            {ingredients.map((ingredient) => (
+                                <option key={ingredient.id} value={ingredient.id}>
+                                    {ingredient.canonical_name}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                    <div>
+                        <InputLabel htmlFor="pantry-qty" value="Quantity" />
+                        <input
+                            id="pantry-qty"
+                            required
+                            type="number"
+                            step="0.01"
+                            min="0"
+                            value={form.quantity}
+                            onChange={(e) => setForm({ ...form, quantity: e.target.value })}
+                            placeholder="0"
+                            className={`mt-1 ${inputClass}`}
+                        />
+                    </div>
+                    <div>
+                        <InputLabel htmlFor="pantry-unit" value="Unit" />
+                        <select
+                            id="pantry-unit"
+                            value={form.unit}
+                            onChange={(e) => setForm({ ...form, unit: e.target.value })}
+                            className={`mt-1 ${inputClass}`}
+                        >
+                            {["g", "kg", "ml", "l", "tsp", "tbsp", "cup", "piece"].map((unit) => (
+                                <option key={unit}>{unit}</option>
+                            ))}
+                        </select>
+                    </div>
+                    <div>
+                        <InputLabel htmlFor="pantry-expiry" value="Expires on" />
+                        <input
+                            id="pantry-expiry"
+                            type="date"
+                            value={form.expires_on}
+                            onChange={(e) => setForm({ ...form, expires_on: e.target.value })}
+                            className={`mt-1 ${inputClass}`}
+                        />
+                    </div>
+                    <div className="sm:col-span-2 lg:col-span-4">
+                        <button type="submit" className="btn-primary">
+                            <Plus className="mr-2 h-4 w-4" />
+                            Add stock
+                        </button>
+                    </div>
                 </form>
             </Panel>
-            <Panel title="Current stock" className="mt-4">
-                <div className="divide-y divide-gray-100 dark:divide-gray-700">
-                    {pantryItems.map((item) => (
-                        <div key={item.id} className="flex items-center justify-between py-3">
-                            <div>
-                                <p className="font-medium text-gray-900 dark:text-white">
-                                    {item.ingredient?.canonical_name}
-                                </p>
-                                <p className="text-sm text-gray-500">
-                                    {item.available_quantity} {item.unit} available ·{" "}
-                                    {item.reserved_quantity} reserved
-                                </p>
+            <Panel title="Current stock">
+                {pantryItems.length > 0 ? (
+                    <div className="divide-y divide-light-border/70 dark:divide-white/10">
+                        {pantryItems.map((item) => (
+                            <div
+                                key={item.id}
+                                className="flex items-center justify-between gap-3 py-3 first:pt-0 last:pb-0"
+                            >
+                                <div className="min-w-0">
+                                    <p className="font-medium text-light-primary dark:text-dark-primary">
+                                        {item.ingredient?.canonical_name}
+                                    </p>
+                                    <p className="text-sm text-light-secondary dark:text-dark-secondary">
+                                        {item.available_quantity} {item.unit} available ·{" "}
+                                        {item.reserved_quantity} reserved
+                                    </p>
+                                </div>
+                                <span
+                                    className={`flex-shrink-0 rounded-full px-2.5 py-1 text-xs font-medium ${
+                                        item.expires_on
+                                            ? "bg-warning-500/10 text-warning-700 dark:text-warning-300"
+                                            : "bg-light-hover text-light-muted dark:bg-dark-hover dark:text-dark-muted"
+                                    }`}
+                                >
+                                    {item.expires_on ? `Expires ${item.expires_on}` : "No expiry"}
+                                </span>
                             </div>
-                            <span className="text-sm text-gray-500">
-                                {item.expires_on ? `Expires ${item.expires_on}` : "No expiry"}
-                            </span>
-                        </div>
-                    ))}
-                    {pantryItems.length === 0 && (
-                        <p className="py-6 text-center text-gray-500">No pantry items yet.</p>
-                    )}
-                </div>
+                        ))}
+                    </div>
+                ) : (
+                    <div className="py-8 text-center">
+                        <Package className="mx-auto mb-3 h-10 w-10 text-light-muted dark:text-dark-muted" />
+                        <p className="text-sm text-light-secondary dark:text-dark-secondary">
+                            No pantry items yet. Add stock above to track what you have on hand.
+                        </p>
+                    </div>
+                )}
             </Panel>
         </MealPlanningLayout>
     );

--- a/resources/js/Pages/MealPlanning/Planner.jsx
+++ b/resources/js/Pages/MealPlanning/Planner.jsx
@@ -1,6 +1,11 @@
 import MealPlanningLayout, { Panel } from "@/Components/MealPlanning/MealPlanningLayout";
+import InputLabel from "@/Components/InputLabel";
 import { router } from "@inertiajs/react";
+import { AlertTriangle, CalendarPlus, Loader2, Lock, LockOpen } from "lucide-react";
 import { useState } from "react";
+import { toast } from "react-toastify";
+
+const inputClass = "input-primary block border px-3 py-2 text-sm focus:ring-1 focus:outline-none";
 
 export default function Planner({ household, plan }) {
     const [startDate, setStartDate] = useState(new Date().toISOString().slice(0, 10));
@@ -22,7 +27,10 @@ export default function Planner({ household, plan }) {
                 route("meal-planning.api.plans.generate", [household.id, created.data.data.id]),
                 { idempotency_key: crypto.randomUUID() }
             );
+            toast.success("Meal plan generated.");
             router.reload();
+        } catch {
+            toast.error("We couldn’t generate that plan just now. Please try again.");
         } finally {
             setBusy(false);
         }
@@ -42,52 +50,62 @@ export default function Planner({ household, plan }) {
         <MealPlanningLayout household={household} title="Planner">
             <Panel title="Generate a plan">
                 <div className="flex flex-wrap items-end gap-3">
-                    <label className="text-sm text-gray-600 dark:text-gray-300">
-                        Start date
+                    <div>
+                        <InputLabel htmlFor="plan-start" value="Start date" />
                         <input
+                            id="plan-start"
                             type="date"
                             value={startDate}
                             onChange={(e) => setStartDate(e.target.value)}
-                            className="mt-1 block rounded-lg border-gray-300 dark:bg-gray-900"
+                            className={`mt-1 ${inputClass}`}
                         />
-                    </label>
-                    <label className="text-sm text-gray-600 dark:text-gray-300">
-                        Days
+                    </div>
+                    <div>
+                        <InputLabel htmlFor="plan-days" value="Days" />
                         <input
+                            id="plan-days"
                             type="number"
                             min="1"
                             max="31"
                             value={days}
                             onChange={(e) => setDays(e.target.value)}
-                            className="mt-1 block w-24 rounded-lg border-gray-300 dark:bg-gray-900"
+                            className={`mt-1 w-24 ${inputClass}`}
                         />
-                    </label>
+                    </div>
                     <button
                         onClick={createAndGenerate}
                         disabled={busy}
-                        className="rounded-lg bg-primary-600 px-4 py-2 text-white"
+                        className="btn-primary disabled:opacity-60"
                     >
+                        {busy ? (
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        ) : (
+                            <CalendarPlus className="mr-2 h-4 w-4" />
+                        )}
                         {busy ? "Generating…" : "Generate"}
                     </button>
                 </div>
             </Panel>
-            {plan && (
+            {plan ? (
                 <>
-                    <div className="my-4 flex items-center justify-between">
+                    <div className="flex items-center justify-between gap-3">
                         <div>
-                            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+                            <h2 className="text-xl font-semibold text-light-primary dark:text-dark-primary">
                                 {plan.start_date} · {plan.number_of_days} days
                             </h2>
-                            <p className="text-sm capitalize text-gray-500">
+                            <p className="text-sm capitalize text-light-secondary dark:text-dark-secondary">
                                 {plan.status.replace("_", " ")}
                             </p>
                         </div>
                     </div>
                     {plan.warnings?.length > 0 && (
-                        <div className="mb-4 rounded-lg bg-amber-50 p-3 text-sm text-amber-800">
-                            {plan.warnings.map((warning) => (
-                                <p key={warning}>{warning}</p>
-                            ))}
+                        <div className="flex gap-2 rounded-xl border border-warning-500/30 bg-warning-500/10 p-3 text-sm text-warning-700 dark:text-warning-300">
+                            <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                            <div>
+                                {plan.warnings.map((warning) => (
+                                    <p key={warning}>{warning}</p>
+                                ))}
+                            </div>
                         </div>
                     )}
                     <div className="grid gap-4 lg:grid-cols-2">
@@ -100,50 +118,74 @@ export default function Planner({ household, plan }) {
                                     day: "numeric",
                                 })}
                             >
-                                {items.map((item) => (
-                                    <article
-                                        key={item.id}
-                                        className="mb-3 rounded-lg bg-gray-50 p-3 last:mb-0 dark:bg-gray-900"
-                                    >
-                                        <div className="flex items-start justify-between gap-2">
-                                            <div>
-                                                <p className="text-xs font-semibold uppercase tracking-wide text-primary-600">
-                                                    {item.meal_slot}
-                                                </p>
-                                                <p className="font-medium text-gray-900 dark:text-white">
-                                                    {item.recipe?.name || "Unfilled meal"}
-                                                </p>
-                                                <p className="text-xs text-gray-500">
-                                                    {Math.round(item.nutrition?.calories || 0)} kcal
-                                                    per serving · {item.status}
-                                                </p>
-                                            </div>
-                                            <button
-                                                onClick={() =>
-                                                    updateItem(item, { is_locked: !item.is_locked })
-                                                }
-                                                className="text-xs text-primary-600"
-                                            >
-                                                {item.is_locked ? "Unlock" : "Lock"}
-                                            </button>
-                                        </div>
-                                        <div className="mt-2 flex flex-wrap gap-2">
-                                            {item.portions?.map((portion) => (
-                                                <span
-                                                    key={portion.id}
-                                                    className="rounded-full bg-white px-2 py-1 text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+                                <div className="space-y-3">
+                                    {items.map((item) => (
+                                        <article
+                                            key={item.id}
+                                            className="rounded-xl bg-light-hover p-3 dark:bg-dark-hover"
+                                        >
+                                            <div className="flex items-start justify-between gap-2">
+                                                <div className="min-w-0">
+                                                    <span className="inline-block rounded-full bg-wevie-teal/10 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-wevie-teal dark:bg-wevie-teal/20 dark:text-wevie-mint">
+                                                        {item.meal_slot}
+                                                    </span>
+                                                    <p className="mt-1 font-medium text-light-primary dark:text-dark-primary">
+                                                        {item.recipe?.name || "Unfilled meal"}
+                                                    </p>
+                                                    <p className="text-xs text-light-muted dark:text-dark-muted">
+                                                        {Math.round(item.nutrition?.calories || 0)}{" "}
+                                                        kcal per serving · {item.status}
+                                                    </p>
+                                                </div>
+                                                <button
+                                                    onClick={() =>
+                                                        updateItem(item, {
+                                                            is_locked: !item.is_locked,
+                                                        })
+                                                    }
+                                                    className="inline-flex flex-shrink-0 items-center gap-1 rounded-lg px-2 py-1 text-xs font-medium text-light-secondary transition-colors hover:bg-light-card dark:text-dark-secondary dark:hover:bg-dark-card"
                                                 >
-                                                    {portion.member?.name}:{" "}
-                                                    {portion.serving_multiplier}×
-                                                </span>
-                                            ))}
-                                        </div>
-                                    </article>
-                                ))}
+                                                    {item.is_locked ? (
+                                                        <Lock className="h-3.5 w-3.5" />
+                                                    ) : (
+                                                        <LockOpen className="h-3.5 w-3.5" />
+                                                    )}
+                                                    {item.is_locked ? "Unlock" : "Lock"}
+                                                </button>
+                                            </div>
+                                            {item.portions?.length > 0 && (
+                                                <div className="mt-2 flex flex-wrap gap-2">
+                                                    {item.portions.map((portion) => (
+                                                        <span
+                                                            key={portion.id}
+                                                            className="rounded-full bg-light-card px-2 py-1 text-xs text-light-secondary dark:bg-dark-card dark:text-dark-secondary"
+                                                        >
+                                                            {portion.member?.name}:{" "}
+                                                            {portion.serving_multiplier}×
+                                                        </span>
+                                                    ))}
+                                                </div>
+                                            )}
+                                        </article>
+                                    ))}
+                                </div>
                             </Panel>
                         ))}
                     </div>
                 </>
+            ) : (
+                <div className="card p-8 text-center">
+                    <div className="mb-4 text-light-muted dark:text-dark-muted">
+                        <CalendarPlus className="mx-auto h-10 w-10 sm:h-12 sm:w-12" />
+                    </div>
+                    <h3 className="mb-1 text-base font-semibold text-light-primary dark:text-dark-primary sm:text-lg">
+                        No meal plan yet
+                    </h3>
+                    <p className="text-sm text-light-secondary dark:text-dark-secondary">
+                        Pick a start date and number of days above, then generate a plan tailored to
+                        your household.
+                    </p>
+                </div>
             )}
         </MealPlanningLayout>
     );

--- a/resources/js/Pages/MealPlanning/Preferences.jsx
+++ b/resources/js/Pages/MealPlanning/Preferences.jsx
@@ -1,9 +1,17 @@
 import MealPlanningLayout, { Panel } from "@/Components/MealPlanning/MealPlanningLayout";
+import InputLabel from "@/Components/InputLabel";
+import { Loader2, Save } from "lucide-react";
 import { useState } from "react";
+import { toast } from "react-toastify";
+
+const inputClass =
+    "input-primary mt-1 block w-full border px-3 py-2 text-sm focus:ring-1 focus:outline-none";
+const checkboxClass =
+    "h-4 w-4 rounded border-light-border/70 text-wevie-teal focus:ring-wevie-teal/30 dark:border-dark-border/70 dark:bg-dark-card";
 
 export default function Preferences({ household }) {
     const current = household.settings || {};
-    const [saved, setSaved] = useState(false);
+    const [busy, setBusy] = useState(false);
     const [form, setForm] = useState({
         priority_profile: current.priority_profile || "balanced",
         budget_total: current.budget_total || "",
@@ -14,30 +22,38 @@ export default function Preferences({ household }) {
     });
     const save = async (event) => {
         event.preventDefault();
-        await window.axios.patch(route("meal-planning.api.households.update", household.id), {
-            settings: {
-                ...current,
-                ...form,
-                budget_total: form.budget_total ? Number(form.budget_total) : null,
-                preferred_preparation_minutes: Number(form.preferred_preparation_minutes),
-                equipment: form.equipment
-                    .split(",")
-                    .map((v) => v.trim())
-                    .filter(Boolean),
-            },
-        });
-        setSaved(true);
+        setBusy(true);
+        try {
+            await window.axios.patch(route("meal-planning.api.households.update", household.id), {
+                settings: {
+                    ...current,
+                    ...form,
+                    budget_total: form.budget_total ? Number(form.budget_total) : null,
+                    preferred_preparation_minutes: Number(form.preferred_preparation_minutes),
+                    equipment: form.equipment
+                        .split(",")
+                        .map((v) => v.trim())
+                        .filter(Boolean),
+                },
+            });
+            toast.success("Preferences saved.");
+        } catch {
+            toast.error("We couldn’t save your preferences just now.");
+        } finally {
+            setBusy(false);
+        }
     };
     return (
         <MealPlanningLayout household={household} title="Preferences">
             <Panel title="Planning defaults">
                 <form onSubmit={save} className="grid max-w-2xl gap-4 sm:grid-cols-2">
-                    <label className="text-sm text-gray-600 dark:text-gray-300">
-                        Priority
+                    <div>
+                        <InputLabel htmlFor="pref-priority" value="Priority" />
                         <select
+                            id="pref-priority"
                             value={form.priority_profile}
                             onChange={(e) => setForm({ ...form, priority_profile: e.target.value })}
-                            className="mt-1 block w-full rounded-lg border-gray-300 dark:bg-gray-900"
+                            className={`${inputClass} capitalize`}
                         >
                             {[
                                 "balanced",
@@ -52,62 +68,84 @@ export default function Preferences({ household }) {
                                 </option>
                             ))}
                         </select>
-                    </label>
-                    <label className="text-sm text-gray-600 dark:text-gray-300">
-                        Weekly budget
+                    </div>
+                    <div>
+                        <InputLabel htmlFor="pref-budget" value="Weekly budget" />
                         <input
+                            id="pref-budget"
                             type="number"
                             min="0"
                             value={form.budget_total}
                             onChange={(e) => setForm({ ...form, budget_total: e.target.value })}
-                            className="mt-1 block w-full rounded-lg border-gray-300 dark:bg-gray-900"
+                            placeholder="0"
+                            className={inputClass}
                         />
-                    </label>
-                    <label className="text-sm text-gray-600 dark:text-gray-300">
-                        Preferred preparation minutes
+                    </div>
+                    <div>
+                        <InputLabel htmlFor="pref-prep" value="Preferred preparation minutes" />
                         <input
+                            id="pref-prep"
                             type="number"
                             min="1"
                             value={form.preferred_preparation_minutes}
                             onChange={(e) =>
-                                setForm({ ...form, preferred_preparation_minutes: e.target.value })
+                                setForm({
+                                    ...form,
+                                    preferred_preparation_minutes: e.target.value,
+                                })
                             }
-                            className="mt-1 block w-full rounded-lg border-gray-300 dark:bg-gray-900"
+                            className={inputClass}
                         />
-                    </label>
-                    <label className="text-sm text-gray-600 dark:text-gray-300">
-                        Equipment
+                    </div>
+                    <div>
+                        <InputLabel htmlFor="pref-equipment" value="Equipment" />
                         <input
+                            id="pref-equipment"
                             value={form.equipment}
                             onChange={(e) => setForm({ ...form, equipment: e.target.value })}
                             placeholder="oven, blender"
-                            className="mt-1 block w-full rounded-lg border-gray-300 dark:bg-gray-900"
+                            className={inputClass}
                         />
-                    </label>
-                    <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+                    </div>
+                    <label className="flex items-center gap-2 text-sm text-light-secondary dark:text-dark-secondary">
                         <input
                             type="checkbox"
                             checked={form.allow_specialty_ingredients}
                             onChange={(e) =>
-                                setForm({ ...form, allow_specialty_ingredients: e.target.checked })
+                                setForm({
+                                    ...form,
+                                    allow_specialty_ingredients: e.target.checked,
+                                })
                             }
+                            className={checkboxClass}
                         />
                         Allow specialty ingredients
                     </label>
-                    <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+                    <label className="flex items-center gap-2 text-sm text-light-secondary dark:text-dark-secondary">
                         <input
                             type="checkbox"
                             checked={form.enable_leftovers}
                             onChange={(e) =>
                                 setForm({ ...form, enable_leftovers: e.target.checked })
                             }
+                            className={checkboxClass}
                         />
                         Plan explicit leftovers and reserve the full batch
                     </label>
-                    <button className="rounded-lg bg-primary-600 px-4 py-2 text-white">
-                        Save preferences
-                    </button>
-                    {saved && <p className="text-sm text-green-600">Saved.</p>}
+                    <div className="sm:col-span-2">
+                        <button
+                            type="submit"
+                            disabled={busy}
+                            className="btn-primary disabled:opacity-60"
+                        >
+                            {busy ? (
+                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            ) : (
+                                <Save className="mr-2 h-4 w-4" />
+                            )}
+                            Save preferences
+                        </button>
+                    </div>
                 </form>
             </Panel>
         </MealPlanningLayout>

--- a/resources/js/Pages/MealPlanning/Recipes.jsx
+++ b/resources/js/Pages/MealPlanning/Recipes.jsx
@@ -1,6 +1,11 @@
 import MealPlanningLayout, { Panel } from "@/Components/MealPlanning/MealPlanningLayout";
 import { router } from "@inertiajs/react";
+import { BookOpen, Download, Loader2, Search } from "lucide-react";
 import { useState } from "react";
+import { toast } from "react-toastify";
+
+const inputClass =
+    "input-primary min-w-0 flex-1 border px-3 py-2 text-sm focus:ring-1 focus:outline-none";
 
 export default function Recipes({ household, recipes = [] }) {
     const [query, setQuery] = useState("");
@@ -14,79 +19,115 @@ export default function Recipes({ household, recipes = [] }) {
                 { params: { provider: "themealdb", query } }
             );
             setResults(response.data.data || []);
+        } catch {
+            toast.error("Recipe search failed. Please try again.");
         } finally {
             setBusy(false);
         }
     };
     const importRecipe = async (recipe) => {
-        await window.axios.post(route("meal-planning.api.recipes.import", household.id), {
-            provider: recipe.provider,
-            external_id: recipe.externalId,
-            idempotency_key: crypto.randomUUID(),
-        });
-        window.setTimeout(() => router.reload(), 500);
+        try {
+            await window.axios.post(route("meal-planning.api.recipes.import", household.id), {
+                provider: recipe.provider,
+                external_id: recipe.externalId,
+                idempotency_key: crypto.randomUUID(),
+            });
+            toast.success(`Importing “${recipe.name}”…`);
+            window.setTimeout(() => router.reload(), 500);
+        } catch {
+            toast.error("We couldn’t import that recipe just now.");
+        }
     };
     return (
         <MealPlanningLayout household={household} title="Recipes">
             <Panel title="Find recipe references">
-                <div className="flex gap-2">
+                <form
+                    onSubmit={(e) => {
+                        e.preventDefault();
+                        search();
+                    }}
+                    className="flex gap-2"
+                >
                     <input
                         value={query}
                         onChange={(e) => setQuery(e.target.value)}
                         placeholder="Search TheMealDB"
-                        className="min-w-0 flex-1 rounded-lg border-gray-300 dark:bg-gray-900"
+                        className={inputClass}
                     />
                     <button
-                        onClick={search}
+                        type="submit"
                         disabled={busy}
-                        className="rounded-lg bg-primary-600 px-4 py-2 text-white"
+                        className="btn-primary flex-shrink-0 disabled:opacity-60"
                     >
+                        {busy ? (
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        ) : (
+                            <Search className="mr-2 h-4 w-4" />
+                        )}
                         Search
                     </button>
-                </div>
-                {results.map((recipe) => (
-                    <div
-                        key={`${recipe.provider}-${recipe.externalId}`}
-                        className="mt-3 flex items-center justify-between rounded-lg bg-gray-50 p-3 dark:bg-gray-900"
-                    >
-                        <span>{recipe.name}</span>
-                        <button
-                            onClick={() => importRecipe(recipe)}
-                            className="text-sm text-primary-600"
-                        >
-                            Import normalized copy
-                        </button>
+                </form>
+                {results.length > 0 && (
+                    <div className="mt-3 space-y-2">
+                        {results.map((recipe) => (
+                            <div
+                                key={`${recipe.provider}-${recipe.externalId}`}
+                                className="flex items-center justify-between gap-3 rounded-xl bg-light-hover p-3 dark:bg-dark-hover"
+                            >
+                                <span className="min-w-0 truncate text-sm font-medium text-light-primary dark:text-dark-primary">
+                                    {recipe.name}
+                                </span>
+                                <button
+                                    onClick={() => importRecipe(recipe)}
+                                    className="btn-secondary flex-shrink-0 px-3 py-1.5 text-sm"
+                                >
+                                    <Download className="mr-1.5 h-3.5 w-3.5" />
+                                    Import
+                                </button>
+                            </div>
+                        ))}
                     </div>
-                ))}
+                )}
             </Panel>
-            <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-                {recipes.map((recipe) => (
-                    <article
-                        key={recipe.id}
-                        className="overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
-                    >
-                        {recipe.image_url && (
-                            <img
-                                src={recipe.image_url}
-                                alt=""
-                                className="h-36 w-full object-cover"
-                            />
-                        )}
-                        <div className="p-4">
-                            <h2 className="font-semibold text-gray-900 dark:text-white">
-                                {recipe.name}
-                            </h2>
-                            <p className="mt-1 text-sm text-gray-500">
-                                {recipe.cuisine || "Wevie"} · {recipe.version?.servings || 0}{" "}
-                                servings
-                            </p>
-                            <p className="mt-2 line-clamp-2 text-sm text-gray-600 dark:text-gray-300">
-                                {recipe.description}
-                            </p>
-                        </div>
-                    </article>
-                ))}
-            </div>
+            {recipes.length > 0 ? (
+                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                    {recipes.map((recipe) => (
+                        <article key={recipe.id} className="card overflow-hidden">
+                            {recipe.image_url && (
+                                <img
+                                    src={recipe.image_url}
+                                    alt=""
+                                    className="h-36 w-full object-cover"
+                                />
+                            )}
+                            <div className="p-4">
+                                <h2 className="font-semibold text-light-primary dark:text-dark-primary">
+                                    {recipe.name}
+                                </h2>
+                                <p className="mt-1 text-sm text-wevie-teal dark:text-wevie-mint">
+                                    {recipe.cuisine || "Uncategorized"} ·{" "}
+                                    {recipe.version?.servings || 0} servings
+                                </p>
+                                <p className="mt-2 line-clamp-2 text-sm text-light-secondary dark:text-dark-secondary">
+                                    {recipe.description}
+                                </p>
+                            </div>
+                        </article>
+                    ))}
+                </div>
+            ) : (
+                <div className="card p-8 text-center">
+                    <div className="mb-4 text-light-muted dark:text-dark-muted">
+                        <BookOpen className="mx-auto h-10 w-10 sm:h-12 sm:w-12" />
+                    </div>
+                    <h3 className="mb-1 text-base font-semibold text-light-primary dark:text-dark-primary sm:text-lg">
+                        No recipes yet
+                    </h3>
+                    <p className="text-sm text-light-secondary dark:text-dark-secondary">
+                        Search a provider above and import a normalized copy to build your library.
+                    </p>
+                </div>
+            )}
         </MealPlanningLayout>
     );
 }


### PR DESCRIPTION
Restyles the entire Meal Planning surface — all 9 user-facing pages, the shared layout, and the admin page — onto the Wevie design system: semantic `light-*`/`dark-*` tokens and the `wevie-teal → wevie-mint` brand gradient, the shared `.card`/`.btn-*`/`.input-primary` primitives, full dark mode, lucide icons, real empty states, and toast feedback replacing silent reloads. The household title/back-link now sit in the app's sticky header bar, and the section tabs became an on-brand pill sub-nav. The hardcoded PH/PHP/Asia-Manila household defaults are replaced with country/currency/time-zone pickers (a new `countries` prop on `MealPlanningPageController::index()` is the only backend change). Also fixes a mismatched color family on the calendar `meal` badge; `npm run build`, ESLint, and Prettier all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)